### PR TITLE
Fix RAG API link

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -13,7 +13,7 @@ There are 3 main fields under `fileConfig`:
 **Notes:**
 
 - At the time of writing, the Assistants endpoint [supports filetypes from this list](https://platform.openai.com/docs/assistants/tools/supported-files).
-- OpenAI, Azure OpenAI, Google, and Custom endpoints support files through the [RAG API.](../../features/rag_api.md)
+- OpenAI, Azure OpenAI, Google, and Custom endpoints support files through the [RAG API.](../../rag_api.mdx)
 - Any other endpoints not mentioned, like Plugins, do not support file uploads (yet).
 - The Assistants endpoint has a defined endpoint value of `assistants`. All other endpoints use the defined value `default`
   - For non-assistants endpoints, you can adjust file settings for all of them under `default`


### PR DESCRIPTION
The link to the RAG API page was broken.