### PR TITLE
Add Azure serverless examples

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/azure.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/azure.mdx
@@ -535,15 +535,15 @@ Through the `librechat.yaml` file, you can configure Azure AI Studio serverless 
 
 - You will need to follow the instructions in the compatible model cards to set up **MaaS** ("Models as a Service") access on Azure AI Studio.
 
-    - For reference, here are 2 known compatible model cards:
+    - For reference, here are some known compatible model cards:
 
-    - [Mistral-large](https://aka.ms/aistudio/landing/mistral-large) | [Llama-2-70b-chat](https://aka.ms/aistudio/landing/Llama-2-70b-chat)
+    - [Mistral-large](https://aka.ms/aistudio/landing/mistral-large) | [Llama-2-70b-chat](https://aka.ms/aistudio/landing/Llama-2-70b-chat) | [Phi-3-medium-128k-instruct](https://ai.azure.com/explore/models/Phi-3-medium-128k-instruct/version/1/registry/azureml)
 
 - You can also review [the technical blog for the "Mistral-large" model release](https://techcommunity.microsoft.com/t5/ai-machine-learning-blog/mistral-large-mistral-ai-s-flagship-llm-debuts-on-azure-ai/ba-p/4066996) for more info.
 
 - Then, you will need to add them to your azureOpenAI config in the librechat.yaml file.
 
-- Here are my example configurations for both Mistral-large and LLama-2-70b-chat:
+- Here are example configurations for Mistral-large, LLama-2-70b-chat, and Phi-3-medium-128k-instruct:
 
 ```yaml filename="librechat.yaml"
 endpoints:
@@ -562,6 +562,12 @@ endpoints:
       serverless: true
       models:
         llama-70b-chat: true
+    - group: "phi-3-medium-128k-instruct"
+      apiKey: "${AZURE_PHI3_MEDIUM_API_KEY}" # arbitrary env var name
+      baseURL: "https://Phi-3-medium-128k-instruct-abcde-serverless.eastus2.inference.ai.azure.com/v1/chat/completions"
+      serverless: true
+      models:
+        phi-3-medium-128k-instruct: true
 ```
 
 **Notes**:
@@ -569,5 +575,5 @@ endpoints:
 - Make sure to add the appropriate suffix for your deployment, either "/v1/chat/completions" or "/v1/completions"
 - If using "/v1/completions" (without "chat"), you need to set the `forcePrompt` field to `true` in your [group config.](#group-level-configuration)
 - Compatibility with LibreChat relies on parity with OpenAI API specs, which at the time of writing, are typically **"Pay-as-you-go"** or "Models as a Service" (MaaS) deployments on Azure AI Studio, that are OpenAI-SDK-compatible with either v1/completions or v1/chat/completions endpoint handling.
-- At the moment, only ["Mistral-large"](https://azure.microsoft.com/en-us/blog/microsoft-and-mistral-ai-announce-new-partnership-to-accelerate-ai-innovation-and-introduce-mistral-large-first-on-azure/) and [LLama-2 Chat models](https://techcommunity.microsoft.com/t5/ai-machine-learning-blog/announcing-llama-2-inference-apis-and-hosted-fine-tuning-through/ba-p/3979227) are compatible from the Azure model catalog. You can filter by "Chat completion" under inference tasks to see the full list; however, real time endpoint models have not been tested.
+- All models that offer serverless deployments ("Serverless APIs") are compatible from the Azure model catalog. You can filter by "Serverless API" under Deployment options and "Chat completion" under inference tasks to see the full list; however, real time endpoint models have not been tested.
 - These serverless inference endpoint/models are likely not compatible with OpenAI function calling, which enables the use of Plugins. As they have yet been tested, they are available on the Plugins endpoint, although they are not expected to work.


### PR DESCRIPTION
There are now many more serverless models available in Azure AI Studio. I updated the docs to

- Show how to filter the model catalog to show available models
- Add an additional example model card
- Add a example config for phi-3