### PR TITLE
docs: add privateAssistants config

### DIFF
--- a/pages/docs/configuration/librechat_yaml/example.mdx
+++ b/pages/docs/configuration/librechat_yaml/example.mdx
@@ -272,7 +272,7 @@ This example configuration file sets up LibreChat with detailed options across s
 # https://docs.librechat.ai/install/configuration/custom_config.html
 
 # Configuration version (required)
-version: 1.0.8
+version: 1.0.9
 
 # Cache settings: Set to true to enable caching
 cache: true
@@ -316,6 +316,8 @@ endpoints:
   #   # Should only be one or the other, either `supportedIds` or `excludedIds`
   #   supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
   #   # excludedIds: ["asst_excludedAssistantId"]
+  #   Only show assistants that the user created or that were created externally (e.g. in Assistants playground).
+  #   # privateAssistants: false # Does not work with `supportedIds` or `excludedIds`
   #   # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
   #   retrievalModels: ["gpt-4-turbo-preview"]
   #   # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.

--- a/pages/docs/configuration/librechat_yaml/object_structure/assistants_endpoint.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/assistants_endpoint.mdx
@@ -17,6 +17,8 @@ endpoints:
     # Use either `supportedIds` or `excludedIds` but not both
     supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
     # excludedIds: ["asst_excludedAssistantId"]
+    # `privateAssistants` do not work with `supportedIds` or `excludedIds`
+    # privateAssistants: false
     # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
     # retrievalModels: ["gpt-4-turbo-preview"]
     # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
@@ -104,6 +106,22 @@ supportedIds:
 excludedIds:
   - "asst_excludedAssistantId1"
   - "asst_excludedAssistantId2"
+```
+
+## privateAssistants
+
+**Key:**
+<OptionTable
+  options={[
+    ['privateAssistants', 'Boolean', 'Controls whether assistants are private to the user that created them', 'Does not work with `supportedIds` or `excludedIds` (`supportedIds` and `excludedIds` will be ignored).'],
+  ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml filename="endpoints / assistants / privateAssistants"
+privateAssistants: false
 ```
 
 ## retrievalModels


### PR DESCRIPTION
Docu update for: https://github.com/danny-avila/LibreChat/pull/2831
I got a bit confused with the librechat.yaml version number. Are they supposed to match with the librechat.example.yaml in LibreChat repo?