### PR TITLE
📝 docs: fix path of General.tsx in development/translation.mdx

### DIFF
--- a/pages/docs/development/translation.mdx
+++ b/pages/docs/development/translation.mdx
@@ -79,7 +79,7 @@ Open `Eng.tsx` and add your language to the language list in the bottom of the d
 
 ### Add your language to the menu
 
-- Navigate to the file `client\src\components\Nav\SettingsTabs\General.tsx`.
+- Navigate to the file `client\src\components\Nav\SettingsTabs\General\General.tsx`.
 - Add your language to the `LangSelector` variable in the following way:
 
   ```ts filename="LangSelector"
@@ -110,8 +110,8 @@ Open `Eng.tsx` and add your language to the language list in the bottom of the d
 If you followed everything you should have **one new file** and **3 modified files**:
 
 ```bash
-  new file:   client/src/localization/languages/**.tsx            <-----new language
-  modified:   client/src/components/Nav/SettingsTabs/General.tsx
+  new file:   client/src/localization/languages/**.tsx                       <-----new language
+  modified:   client/src/components/Nav/SettingsTabs/General/General.tsx
   modified:   client/src/localization/Translation.ts
   modified:   client/src/localization/languages/Eng.tsx
 ```


### PR DESCRIPTION
There's an additional `General` folder missing in the URLs.