### PR TITLE
📝 docs: remove duplicated heading `DALL-E:` in configuration/dotenv.mdx 

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -377,8 +377,6 @@ Remember to replace placeholder text with actual prompts or instructions and pro
 
 Here's the updated layout for the DALL-E configuration options:
 
-#### DALL-E:
-
 **API Keys:**
 <OptionTable
   options={[


### PR DESCRIPTION
There are currently two `#### DALL-E:`, much the second one should be `#### DALL-E (Azure):` I believe.