### PR TITLE
Allow username for LDAP login

### DIFF
--- a/pages/docs/configuration/authentication/ldap.mdx
+++ b/pages/docs/configuration/authentication/ldap.mdx
@@ -56,6 +56,24 @@ You can specify a mapping between the attributes of Librechat users and those of
   ]}
 />
 
+**Username or Email**
+
+By default, LibreChat uses an email address and password for authentication.
+This may sometimes cause problem with LDAP and you may want to use a username instead.
+Set the `LDAP_SEARCH_FILTER` to filter for the username instead (e.g. `LDAP_SEARCH_FILTER=uid={{username}}`
+and configure LibreChat to request login via username:
+
+<OptionTable
+  options={[
+    [
+      'LDAP_LOGIN_USES_USERNAME',
+      'string',
+      'Use username instead of email.',
+      'LDAP_LOGIN_USES_USERNAME=true',
+    ],
+  ]}
+/>
+
 **Active Directory over SSL**
 
 To connect via SSL (ldaps://), such as a company using Windows AD, specify the path to the internal CA certificate.


### PR DESCRIPTION
This patch corresponds to #3268 which allows for LDAP login via username instead of email address.