### PR TITLE
docs: ldap tls config

### DIFF
--- a/pages/docs/configuration/authentication/ldap.mdx
+++ b/pages/docs/configuration/authentication/ldap.mdx
@@ -77,6 +77,9 @@ and configure LibreChat to request login via username:
 **Active Directory over SSL**
 
 To connect via SSL (ldaps://), such as a company using Windows AD, specify the path to the internal CA certificate.
+`LDAP_TLS_REJECT_UNAUTHORIZED` is optional;if not specified Librechat will reject TLS/SSL connections if the LDAP server's certificate cannot be verified.
+set `LDAP_TLS_REJECT_UNAUTHORIZED` to false (not recommended for production environments)
+to allow Librechat to accept TLS/SSL connections even if the LDAP server's certificate cannot be verified,
 
 <OptionTable
   options={[
@@ -85,6 +88,12 @@ To connect via SSL (ldaps://), such as a company using Windows AD, specify the p
       'string',
       'CA certificate path.',
       'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
+    ],
+    [
+      'LDAP_TLS_REJECT_UNAUTHORIZED',
+      'string',
+      'Disable TLS verification',
+      'LDAP_TLS_REJECT_UNAUTHORIZED=true',
     ],
   ]}
 />

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -812,6 +812,12 @@ For more information: **[LDAP/AD Authentication](/docs/configuration/authenticat
       'CA certificate path.',
       'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
     ],
+    [
+      'LDAP_TLS_REJECT_UNAUTHORIZED',
+      'string',
+      'LDAP TLS verification',
+      'LDAP_TLS_REJECT_UNAUTHORIZED=true',
+    ],
   ]}
 />
 


### PR DESCRIPTION
This PR updates the documentation for https://github.com/danny-avila/LibreChat/pull/3247 which allows configuration to disable ldap tls.