### PR TITLE
Omit Privacy and TOS pages from search

### DIFF
--- a/pages/cookie.mdx
+++ b/pages/cookie.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cookie Policy
 note: //TODO Generate new cookie policy once published
+searchable: false
 ---
 
 

--- a/pages/privacy.mdx
+++ b/pages/privacy.mdx
@@ -1,3 +1,6 @@
+---
+searchable: false
+---
 **PRIVACY POLICY**
 
 

--- a/pages/tos.mdx
+++ b/pages/tos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Terms of Services
+searchable: false
 ---
 
 import { TermsOfServices } from '@/components/policies'


### PR DESCRIPTION
I was searching for "update" keyword to look for instructions to update the librechat deployment but found it strange that the privacy policy is the first result.

I think it shouldn't be indexed/searchable to start with, to avoid cluttering search results from the actual docs pages.