### PR TITLE
Update ShuttleAI default models

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/shuttleai.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/shuttleai.mdx
@@ -17,16 +17,16 @@ description: Example configuration for ShuttleAI
       baseURL: "https://api.shuttleai.app/v1"
       models:
         default: [
-          "shuttle-2-turbo", "shuttle-turbo"
+          "shuttle-2.5", "shuttle-2.5-mini"
           ]
         fetch: true
       titleConvo: true
-      titleModel: "shuttle-2-turbo"
+      titleModel: "shuttle-2.5-mini"
       summarize: false
-      summaryModel: "shuttle-2-turbo"
+      summaryModel: "shuttle-2.5-mini"
       forcePrompt: false
       modelDisplayLabel: "ShuttleAI"
-      dropParams: ["user"]
+      dropParams: ["user", "stop"]
 ```
 
 ![image](https://github.com/danny-avila/LibreChat/assets/32828263/a694e6d0-5663-4c89-92b5-887742dca876)


### PR DESCRIPTION
Pretty straight-forward - just updating outdated models to its latest versions.