### PR TITLE
Update ShuttleAI 🚀

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/shuttleai.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/shuttleai.mdx
@@ -3,9 +3,9 @@ title: ShuttleAI
 description: Example configuration for ShuttleAI
 ---
 
-# [ShuttleAI](https://shuttleai.app/)
+# [ShuttleAI](https://shuttleai.com/)
 
-> ShuttleAI API key: [shuttleai.app/keys](https://shuttleai.app/keys)
+> ShuttleAI API key: [shuttleai.com/keys](https://shuttleai.com/keys)
 
 **Notes:**
 
@@ -14,7 +14,7 @@ description: Example configuration for ShuttleAI
 ```yaml
     - name: "ShuttleAI"
       apiKey: "${SHUTTLEAI_API_KEY}"
-      baseURL: "https://api.shuttleai.app/v1"
+      baseURL: "https://api.shuttleai.com/v1"
       models:
         default: [
           "shuttle-2.5", "shuttle-2.5-mini"


### PR DESCRIPTION
Switched domain from `shuttleai.app` to `shuttleai.com`. (Both work, however `.com` is now encouraged.)