### PR TITLE
docs: add Authentik documentation

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentik
-description: Learn how to configure LibreChat to use Keycloak for user authentication.
+description: Learn how to configure LibreChat to use Authentik for user authentication.
 ---
 
 # Authentik

--- a/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
@@ -1,0 +1,53 @@
+---
+title: Authentik
+description: Learn how to configure LibreChat to use Keycloak for user authentication.
+---
+
+# Authentik
+
+1. **Access Authentik Admin Interface:**
+- Open the Authentik Admin Interface in your browser. Can be found at a URL such as: `https://authentik.example.com/if/admin/#/administration/overview`.
+> We will use `https://authentik.example.com` as an example URL. Replace this with the URL of your Authentik instance.
+
+2. **Create a new Application and Provider using the wizard:**
+- Click on the Applications tab in the left sidebar and click on Applications again.
+- At the top of the page you should see a button that says `Create with Wizard`. Click on it.
+> Note: You can also create an application and provider manually just be sure to link them afterwards.
+- You can name the application whatever you want. For this example, we will name it `LibreChat` and click next.
+- Choose the `OAuth2/OIDC` provider and click next.
+- Choose your authentication and authorization flows.
+- Scroll down and take note of the `Client ID` and `Client Secret`. You will need these later.
+- Under Advanced protocol settings change Subject mode to `Based on the User's Email`.
+- Click Submit.
+- Add the new application you created to an Outpost.
+> Note: You should also apply any policies for access control that you want to apply to LibreChat at this point.
+
+3. **Gather Information for .env:**
+- You will need the following information from Authentik:
+  - `Client ID`
+  - `Client Secret`
+  - `OpenID Configuration URL`
+  > All of these can be found by clicking on the provider you just created.
+
+3. **Configure LibreChat:**
+- Open the `.env` file and add the following variables:
+```bash filename=".env"
+  OPENID_ISSUER=https://authentik.example.com/application/o/librechat/.well-known/openid-configuration
+  OPENID_CLIENT_ID=[YourClientID]
+  OPENID_CLIENT_SECRET=[YourClientSecret]
+  OPENID_SESSION_SECRET=[JustGenerateARandomSessionSecret]
+  OPENID_CALLBACK_URL=/oauth/openid/callback
+  OPENID_SCOPE=openid profile email
+  # Optional customization below
+  OPENID_BUTTON_LABEL=Login with Authentik
+  OPENID_IMAGE_URL=https://cdn.jsdelivr.net/gh/selfhst/icons/png/authentik.png
+```
+> Note: Make sure nothing is wrapped in quotes in your .env and you have allowed social login.
+
+4. **Check Configuration:**
+- Restart LibreChat to apply the changes.
+- Open an Icognito window and navigate to your LibreChat instance.
+- Underneath the form login there should be a new button that says `Login with Authentik`.
+- You should be redirected to Authentik to login.
+- After logging in you should be redirected back to LibreChat and be logged in.
+    - If you are not redirected back to LibreChat, check Authentik logs for any errors.

--- a/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
@@ -32,15 +32,15 @@ description: Learn how to configure LibreChat to use Authentik for user authenti
 3. **Configure LibreChat:**
 - Open the `.env` file and add the following variables:
 ```bash filename=".env"
-  OPENID_ISSUER=https://authentik.example.com/application/o/librechat/.well-known/openid-configuration
-  OPENID_CLIENT_ID=[YourClientID]
-  OPENID_CLIENT_SECRET=[YourClientSecret]
-  OPENID_SESSION_SECRET=[JustGenerateARandomSessionSecret]
-  OPENID_CALLBACK_URL=/oauth/openid/callback
-  OPENID_SCOPE=openid profile email
-  # Optional customization below
-  OPENID_BUTTON_LABEL=Login with Authentik
-  OPENID_IMAGE_URL=https://cdn.jsdelivr.net/gh/selfhst/icons/png/authentik.png
+OPENID_ISSUER=https://authentik.example.com/application/o/librechat/.well-known/openid-configuration
+OPENID_CLIENT_ID=[YourClientID]
+OPENID_CLIENT_SECRET=[YourClientSecret]
+OPENID_SESSION_SECRET=[JustGenerateARandomSessionSecret]
+OPENID_CALLBACK_URL=/oauth/openid/callback
+OPENID_SCOPE=openid profile email
+# Optional customization below
+OPENID_BUTTON_LABEL=Login with Authentik
+OPENID_IMAGE_URL=https://cdn.jsdelivr.net/gh/selfhst/icons/png/authentik.png
 ```
 > Note: Make sure nothing is wrapped in quotes in your .env and you have allowed social login.
 


### PR DESCRIPTION
Added initial [Authentik](https://github.com/goauthentik/authentik) documentation. 

Currently "guides" are scattered across Discord and issues. Followed the Keycloak guide and adapted it for Authentik. Can probably be improved by adding images and tidying up the formatting and verbosity.