### PR TITLE
feat: Allow other LDAP field besides "mail" to map to email address

### DIFF
--- a/pages/docs/configuration/authentication/ldap.mdx
+++ b/pages/docs/configuration/authentication/ldap.mdx
@@ -48,6 +48,12 @@ You can specify a mapping between the attributes of Librechat users and those of
       'LDAP_USERNAME=givenName',
     ],
     [
+      'LDAP_EMAIL',
+      'string',
+      'By default, it uses mail.',
+      'LDAP_EMAIL=userPrincipalName',
+    ],
+    [
       'LDAP_FULL_NAME',
       'string',
       'By default, it uses a combination of givenName and surname.',


### PR DESCRIPTION
See https://github.com/danny-avila/LibreChat/pull/4127