### PR TITLE
Add Portkey Custom Endpoints Docs

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
@@ -35,6 +35,7 @@ description: Example configuration for Portkey AI
         summaryModel: "current_model"
         forcePrompt: false
         modelDisplayLabel: "Portkey:OpenAI"
+        iconURL: https://images.crunchbase.com/image/upload/c_pad,f_auto,q_auto:eco,dpr_1/rjqy7ghvjoiu4cd1xjbf
 ```
 
 
@@ -56,6 +57,7 @@ description: Example configuration for Portkey AI
       summaryModel: "current_model"
       forcePrompt: false
       modelDisplayLabel: "Portkey:Llama"
+      iconURL: https://images.crunchbase.com/image/upload/c_pad,f_auto,q_auto:eco,dpr_1/rjqy7ghvjoiu4cd1xjbf
 ```
 
 ![image](https://raw.githubusercontent.com/siddharthsambharia-portkey/Portkey-Product-Images/refs/heads/main/portkey-librechat.png)

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
@@ -1,0 +1,61 @@
+---
+title: Portkey AI
+description: Example configuration for Portkey AI
+---
+
+# [Portkey Docs](https://docs.portkey.ai/docs/integrations/libraries/librechat)
+
+> Portkey API key: [app.portkey.ai](https://app.portkey.ai/)
+
+
+
+**Notes:**
+- LibreChat requires that the `API key` field is present. We don’t need it for the Portkey integration, we can pass a `dummy` string for it.
+- Portkey integrates with LibreChat, offering observability, 50+ guardrails, caching, and conditional routing with fallbacks and retries for reliable, production-grade deployments.
+- Portkey Supports 250+ Models, you can find the list of providers on [Portkey Docs](https://docs.portkey.ai/docs/integrations/llms)
+- You can use Portkey in two ways—through [Virtual Keys](https://docs.portkey.ai/docs/product/ai-gateway/virtual-keys  ) or [Configs](https://docs.portkey.ai/docs/product/ai-gateway/configs).
+- You can use Model specific parameters like `top_p`, `max Tokens`, etc. in using Portke Config. [Learn more](https://docs.portkey.ai/docs/product/ai-gateway/configs#configs)
+
+
+
+## Using Portkey AI with Virtual Keys
+```yaml filename="librechat.yaml"
+      - name: "Portkey"
+        apikey: "dummy"  
+        baseURL: ${PORTKEY_GATEWAY_URL}
+        headers:
+            x-portkey-api-key: "${PORTKEY_API_KEY}"
+            x-portkey-virtual-key: "PORTKEY_OPENAI_VIRTUAL_KEY"
+        models:
+            default: ["gpt-4o-mini"]
+            fetch: true
+        titleConvo: true
+        titleModel: "current_model"
+        summarize: false
+        summaryModel: "current_model"
+        forcePrompt: false
+        modelDisplayLabel: "Portkey:OpenAI"
+```
+
+
+
+## Using Portkey AI with Configs
+```yaml filename="librechat.yaml"
+    - name: "Portkey"
+      apikey: "dummy"
+      baseURL: ${PORTKEY_GATEWAY_URL}
+      headers:
+        x-portkey-api-key: "${PORTKEY_API_KEY}"
+        x-portkey-config: "pc-libre-xxx"
+      models:
+        default: ["llama-3.2"]
+        fetch: true
+      titleConvo: true
+      titleModel: "current_model"
+      summarize: false
+      summaryModel: "current_model"
+      forcePrompt: false
+      modelDisplayLabel: "Portkey:Llama"
+```
+
+![image](https://raw.githubusercontent.com/siddharthsambharia-portkey/Portkey-Product-Images/refs/heads/main/portkey-librechat.png)


### PR DESCRIPTION
This PR introduces new documentation explaining how to use Portkey's custom endpoints with LibreChat-AI. Key additions include:
- How to update librechat.yaml file to integrate with Portkey

@danny-avila 
