### PR TITLE
RAG API Documentation Update: added explanation for RAG_USE_FULL_CONTEXT variable

### DIFF
--- a/pages/docs/configuration/rag_api.mdx
+++ b/pages/docs/configuration/rag_api.mdx
@@ -160,6 +160,7 @@ Here are some notable configurations:
 - `RAG_PORT`: The port number where the API server will run. Defaults to port 8000.
 - `RAG_HOST`: The hostname or IP address where the API server will run. Defaults to "0.0.0.0"
 - `COLLECTION_NAME`: The name of the collection in the vector store. Default is "testcollection".
+- `RAG_USE_FULL_CONTEXT`: (Optional) Set to "True" to fetch entire context of the file(s) uploaded/referenced into the conversation. Default value is "false" which means it fetches only the top 4 results (top_k=4) of the file based on the user's message.
 - `CHUNK_SIZE`: The size of the chunks for text processing. Default is "1500".
 - `CHUNK_OVERLAP`: The overlap between chunks during text processing. Default is "100".
 - `EMBEDDINGS_PROVIDER`: The embeddings provider to use. Options are "openai", "azure", "huggingface", "huggingfacetei", or "ollama". Default is "openai".


### PR DESCRIPTION
Currently, there isn't documentation that highlights the ability to use full context of the documents uploaded for RAG. This causes new users like myself to run into subpar RAG results in certain scenarios. Adding documentation for the RAG_USE_FULL_CONTEXT parameter/variable to raise awareness of this feature.

Related discussion: https://github.com/danny-avila/LibreChat/discussions/4066