### PR TITLE
feat: GOOGLE_WORKSPACE_GROUP  allows to restrict access to a google group 

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/google.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/google.mdx
@@ -89,6 +89,8 @@ DOMAIN_SERVER=https://your-domain.com # use http://localhost:3080 if not using a
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret
 GOOGLE_CALLBACK_URL=/oauth/google/callback
+# optional: you can restrinct login to members of a specific Google Group in your workspace account
+# GOOGLE_WORKSPACE_GROUP=librechatusers@yourdomain.com
 ```
 
 - Save the `.env` file

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -802,6 +802,7 @@ For more information: **[Google Authentication](/docs/configuration/authenticati
     ['GOOGLE_CLIENT_ID', 'string', 'Your Google client ID.','GOOGLE_CLIENT_ID='],
     ['GOOGLE_CLIENT_SECRET', 'string', 'Your Google client secret.','GOOGLE_CLIENT_SECRET='],
     ['GOOGLE_CALLBACK_URL', 'string', 'The callback URL for Google authentication.','GOOGLE_CALLBACK_URL=/oauth/google/callback'],
+    ['GOOGLE_WORKSPACE_GROUP', 'string', 'Restrict access to a single group in your workspace account','GOOGLE_WORKSPACE_GROUP='],
   ]}
 />
 


### PR DESCRIPTION
Explains how to restrict google workspace logins to a specific group of users