### PR TITLE
Update portkey.mdx

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/portkey.mdx
@@ -21,7 +21,7 @@ description: Example configuration for Portkey AI
 ## Using Portkey AI with Virtual Keys
 ```yaml filename="librechat.yaml"
       - name: "Portkey"
-        apikey: "dummy"  
+        apiKey: "dummy"  
         baseURL: ${PORTKEY_GATEWAY_URL}
         headers:
             x-portkey-api-key: "${PORTKEY_API_KEY}"


### PR DESCRIPTION
Without this, `api/server/services/Config/loadConfigModels.js` fails as follows:
<img width="1960" alt="Screenshot 2024-11-15 at 10 54 48 AM" src="https://github.com/user-attachments/assets/9074d369-6543-40ff-980a-2cb27a87a209">


Due to this line failing: https://github.com/danny-avila/LibreChat/blob/493e64e6dbe0c362a51415486806ae8483cd653e/api/server/services/Config/loadConfigModels.js#L68