### PR TITLE
📘 docs: Update Azure OAuth2 to Clarify Variable Requirement

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
@@ -47,8 +47,9 @@ OPENID_SESSION_SECRET=Any random string
 OPENID_SCOPE=openid profile email #DO NOT CHANGE THIS
 OPENID_CALLBACK_URL=/oauth/openid/callback # this should be the same for everyone
 
-# If you want to restrict access by groups
 OPENID_REQUIRED_ROLE_TOKEN_KIND=id
+
+# If you want to restrict access by groups
 OPENID_REQUIRED_ROLE_PARAMETER_PATH="roles"
 OPENID_REQUIRED_ROLE="Your Group Name"
 ```


### PR DESCRIPTION
…kind is required

`OPENID_REQUIRED_ROLE_TOKEN_KIND` is required and the way the old docs were written, seemed to indicate that it was only necessary if you want to restrict access by groups. I was getting an Internal Server Error after logging in with Open ID if this environment variable was not set. Once I added it, I was able to log in successfully.

Closes #190 