### PR TITLE
docs: Add new LLM API Provider(Novita AI) to documentation

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -214,6 +214,7 @@ Uncomment `ENDPOINTS` to customize the available endpoints in LibreChat.
     ['PERPLEXITY_API_KEY', 'string', 'API key for Perplexity.', '# PERPLEXITY_API_KEY='],
     ['SHUTTLEAI_API_KEY', 'string', 'API key for ShuttleAI.', '# SHUTTLEAI_API_KEY='],
     ['TOGETHERAI_API_KEY', 'string', 'API key for TogetherAI.', '# TOGETHERAI_API_KEY='],
+    ['NOVITAAI_API_KEY', 'string', 'API key for NovitaAI.', '# NOVITAAI_API_KEY='],
     ['DEEPSEEK_API_KEY', 'string', 'API key for Deepseek API', '# DEEPSEEK_API_KEY='],
   ]}
 />

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
@@ -3,9 +3,9 @@ title: novita.ai
 description: Example configuration for novita.ai
 ---
 
-# [novita.ai](https://novita.ai/)
+# [novita.ai](https://novita.ai?utm_source=github_librechat&utm_medium=github_readme&utm_campaign=github_link)
 
-> novita.ai API key: [novita.ai/settings/key-management](https://novita.ai/settings/key-management)
+> novita.ai API key: [novita.ai/settings/key-management](https://novita.ai/settings/key-management?utm_source=github_librechat&utm_medium=github_readme&utm_campaign=github_link)
 
 **Notes:**
 

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
@@ -33,9 +33,9 @@ description: Example configuration for novita.ai
         ]
         fetch: false
       titleConvo: true
-      titleModel: "meta-llama/llama-3-8b-instruct"
+      titleModel: "meta-llama/llama-3.3-70b-instruct"
       summarize: false
-      summaryModel: "meta-llama/llama-3-8b-instruct"
+      summaryModel: "meta-llama/llama-3.3-70b-instruct"
       forcePrompt: false
       modelDisplayLabel: "novita.ai"
 ```

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/novitaai.mdx
@@ -1,0 +1,41 @@
+---
+title: novita.ai
+description: Example configuration for novita.ai
+---
+
+# [novita.ai](https://novita.ai/)
+
+> novita.ai API key: [novita.ai/settings/key-management](https://novita.ai/settings/key-management)
+
+**Notes:**
+
+- **Known:** icon provided.
+
+```yaml
+    - name: "novita.ai"
+      apiKey: "${NOVITAAI_API_KEY}"
+      baseURL: "https://api.novita.ai/v3/openai"
+      models:
+        default: [
+          "deepseek/deepseek-r1",
+          "deepseek/deepseek_v3",
+          "meta-llama/llama-3-8b-instruct",
+          "meta-llama/llama-3-70b-instruct",
+          "meta-llama/llama-3.1-8b-instruct",
+          "meta-llama/llama-3.1-70b-instruct",
+          "meta-llama/llama-3.1-405b-instruct",
+          "meta-llama/llama-3.2-1b-instruct",
+          "meta-llama/llama-3.2-3b-instruct",
+          "meta-llama/llama-3.2-11b-vision-instruct",
+          "meta-llama/llama-3.3-70b-instruct",
+          "mistralai/mistral-nemo",
+          "mistralai/mistral-7b-instruct",
+        ]
+        fetch: false
+      titleConvo: true
+      titleModel: "meta-llama/llama-3-8b-instruct"
+      summarize: false
+      summaryModel: "meta-llama/llama-3-8b-instruct"
+      forcePrompt: false
+      modelDisplayLabel: "novita.ai"
+```

--- a/pages/docs/configuration/librechat_yaml/example.mdx
+++ b/pages/docs/configuration/librechat_yaml/example.mdx
@@ -243,6 +243,34 @@ endpoints:
       summaryModel: "togethercomputer/llama-2-7b-chat"
       forcePrompt: false
       modelDisplayLabel: "together.ai"
+
+    # novita.ai
+    - name: "novita.ai"
+      apiKey: "${NOVITAAI_API_KEY}"
+      baseURL: "https://api.novita.ai/v3/openai"
+      models:
+        default: [
+          "deepseek/deepseek-r1",
+          "deepseek/deepseek_v3",
+          "meta-llama/llama-3-8b-instruct",
+          "meta-llama/llama-3-70b-instruct",
+          "meta-llama/llama-3.1-8b-instruct",
+          "meta-llama/llama-3.1-70b-instruct",
+          "meta-llama/llama-3.1-405b-instruct",
+          "meta-llama/llama-3.2-1b-instruct",
+          "meta-llama/llama-3.2-3b-instruct",
+          "meta-llama/llama-3.2-11b-vision-instruct",
+          "meta-llama/llama-3.3-70b-instruct",
+          "mistralai/mistral-nemo",
+          "mistralai/mistral-7b-instruct",
+          ]
+        fetch: false
+      titleConvo: true
+      titleModel: "meta-llama/llama-3-8b-instruct"
+      summarize: false
+      summaryModel: "meta-llama/llama-3-8b-instruct"
+      forcePrompt: false
+      modelDisplayLabel: "novita.ai"
 ```
 
 </Callout>

--- a/pages/docs/configuration/librechat_yaml/example.mdx
+++ b/pages/docs/configuration/librechat_yaml/example.mdx
@@ -266,9 +266,9 @@ endpoints:
           ]
         fetch: false
       titleConvo: true
-      titleModel: "meta-llama/llama-3-8b-instruct"
+      titleModel: "meta-llama/llama-3.3-70b-instruct"
       summarize: false
-      summaryModel: "meta-llama/llama-3-8b-instruct"
+      summaryModel: "meta-llama/llama-3.3-70b-instruct"
       forcePrompt: false
       modelDisplayLabel: "novita.ai"
 ```

--- a/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -119,6 +119,7 @@ iconURL: https://github.com/danny-avila/LibreChat/raw/main/docs/assets/LibreChat
   - "Fireworks"
   - "Perplexity"
   - "together.ai"
+  - "novita.ai"
   - "ollama"
   - "xai"
   - "MLX"

--- a/pages/docs/features/index.mdx
+++ b/pages/docs/features/index.mdx
@@ -67,6 +67,7 @@ import Image from 'next/image'
 - **koboldcpp**: AI-assisted storytelling and content generation tools.
 - **OpenRouter**: API gateway for routing AI model requests.
 - **together.ai**: Collaborative platform for AI model development and deployment.
+- **novita.ai**: An affordable, reliable, and simple inference platform with scalable LLM API.
 - **Perplexity**: AI-driven search engine for contextual answers.
 - **ShuttleAI**: Automated machine learning platform for rapid deployment.
 - **[Learn how to configure Custom endpoints like the ones above](/docs/quick_start/custom_endpoints)**


### PR DESCRIPTION
Added [Novita AI](https://novita.ai?utm_source=github_librechat&utm_medium=github_readme&utm_campaign=github_link) LLM API Provider documentation.

Relevant PR: https://github.com/danny-avila/LibreChat/pull/5115

For any future PR reviews related to Novita AI. We would be glad to help.