### PR TITLE
📂 docs: outdated link for openai assistants tools support file types

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -12,7 +12,7 @@ There are 3 main fields under `fileConfig`:
 
 **Notes:**
 
-- At the time of writing, the Assistants endpoint [supports filetypes from this list](https://platform.openai.com/docs/assistants/tools/supported-files).
+- At the time of writing, the Assistants endpoint [supports filetypes from this list](https://platform.openai.com/docs/assistants/tools/file-search#supported-files).
 - OpenAI, Azure OpenAI, Google, and Custom endpoints support files through the [RAG API.](../../rag_api.mdx)
 - Any other endpoints not mentioned, like Plugins, do not support file uploads (yet).
 - The Assistants endpoint has a defined endpoint value of `assistants`. All other endpoints use the defined value `default`


### PR DESCRIPTION
Fix the outdated link for openai assistants tools support file types