### PR TITLE
Feat/cloudflare turnstile

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/_meta.ts
+++ b/pages/docs/configuration/librechat_yaml/object_structure/_meta.ts
@@ -2,6 +2,7 @@ export default {
   config: 'Root Settings',
   file_config: 'File Config',
   interface: 'Interface (UI)',
+  turnstile: 'Cloudflare Turnstile',
   model_specs: 'Model Specs',
   registration: 'Registration',
   agents: 'Agents',

--- a/pages/docs/configuration/librechat_yaml/object_structure/turnstile.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/turnstile.mdx
@@ -1,3 +1,5 @@
+# Cloudflare Turnstile Configuration
+
 ## Example
 
 ```yaml filename="turnstile"

--- a/pages/docs/configuration/librechat_yaml/object_structure/turnstile.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/turnstile.mdx
@@ -1,0 +1,65 @@
+## Example
+
+```yaml filename="turnstile"
+turnstile:
+  siteKey: "your-site-key-here"
+  options:
+    language: "auto"    # "auto" or an ISO 639-1 language code (e.g., en)
+    size: "normal"      # Options: "normal", "compact", "flexible", or "invisible"
+```
+
+## turnstile
+
+**Key:**
+<OptionTable
+  options={[
+    ['turnstile', 'Object', 'Cloudflare Turnstile configuration that integrates a CAPTCHA alternative to protect your application from automated abuse.'],
+  ]}
+/>
+
+### Fields
+
+<OptionTable
+  options={[
+    ['siteKey', 'String', 'Your unique Cloudflare Turnstile site key. Register your domain with Cloudflare and obtain this key.', 'your-site-key-here'],
+    ['options', 'Object', 'An object to customize additional settings for the Turnstile widget.'],
+  ]}
+/>
+
+#### siteKey
+
+- **Type:** `String`
+- **Description:** Your unique Cloudflare Turnstile site key. Make sure you have registered your domain with Cloudflare and obtained this key from the [Cloudflare Turnstile Get Started](https://developers.cloudflare.com/turnstile/get-started/) guide.
+- **Example:**
+```yaml
+turnstile:
+  siteKey: "your-site-key-here"
+```
+
+#### options
+
+- **Type:** `Object`
+- **Description:** An object to configure additional settings for the Turnstile widget.
+
+**Subkeys:**
+<OptionTable
+  options={[
+    ['language', 'String', 'Specifies the language for the Turnstile widget. Use `auto` to automatically detect the user\'s language, or provide an ISO 639-1 language code (e.g., `en`).', 'auto'],
+    ['size', 'String', 'Determines the widget\'s display size. Valid options include `normal`, `compact`, `flexible`, or `invisible`.', 'normal'],
+    ]}
+/>
+
+```yaml
+turnstile:
+  options:
+    language: "auto"
+    size: "normal"
+```
+
+### Notes
+
+- **Optional Integration:** The `turnstile` configuration block is optional. If you choose not to use Cloudflare Turnstile, you may omit this block entirely.
+- **Dashboard Consistency:** Ensure that the values you configure here match your settings in the Cloudflare dashboard.
+- **User Experience:** Customize the `options` subkeys as needed to tailor the widget's behavior and appearance to your application’s requirements.
+
+---


### PR DESCRIPTION
This pull request introduces Cloudflare Turnstile configuration to the documentation. The most important changes include adding a new section for Turnstile in the configuration documentation and updating the meta information to include Turnstile.

Documentation updates:

* [`pages/docs/configuration/librechat_yaml/object_structure/turnstile.mdx`](diffhunk://#diff-e1855082fca57eaf27128f054414e91c506a373174bf01a26a73def9f16d1e02R1-R67): Added a detailed configuration guide for Cloudflare Turnstile, including example YAML configuration and descriptions of the `siteKey` and `options` fields.

Meta information update:

* [`pages/docs/configuration/librechat_yaml/object_structure/_meta.ts`](diffhunk://#diff-27966d15fc4268b8c5505786a767f8c986c21abd3c9465f554b859c74e205eeeR5): Added 'Cloudflare Turnstile' to the meta configuration categories.