### PR TITLE
🚀 docs: Update Changelog, Artifacts Bundler, Deprecation Warnings, Broken links

### DIFF
--- a/components/changelog/content/v0.7.7.mdx
+++ b/components/changelog/content/v0.7.7.mdx
@@ -16,23 +16,21 @@
 - Support for OAuth in Actions to seamlessly connect with third-party services
 - xAI (Grok) Agent supported with modern interface
 
-### 🧰 Robust Development Features
-- Fully-featured Code Interpreter now supports Rscript alongside existing languages
-- Artifact editing and downloads for improved code workflow
-- Advanced file handling with concurrent operations support
-- Customizable Code API proxy support for flexible deployment scenarios
-
 ### 🔐 Security & Account Management
 - Two-Factor Authentication with backup codes & QR support
 - Apple authentication for streamlined login
 - GitHub Enterprise SSO login
-- Temporary sessions for ephemeral usage (guest mode)
+- Temporary chat sessions for ephemeral usage
+
+### 🧰 Robust Development Features
+- Artifact editing and downloads for improved code workflow
+- Code Interpreter API now supports Rscript alongside existing languages
 
 ### 💻 Enhanced User Experience
 - Quality-of-life messaging enhancements for editing and interaction
 - Conversation settings via URL query parameters for easy sharing
 - Improved accessibility throughout the application
-- Multi-language support with 18 languages including Georgian
+- i18Next Multi-language support with 18 languages
 
 ---
 

--- a/components/changelog/content/v0.7.7.mdx
+++ b/components/changelog/content/v0.7.7.mdx
@@ -1,0 +1,219 @@
+## What's Changed
+
+## [v0.7.7](https://www.librechat.ai/changelog/v0.7.7)
+
+## 🌄 Highlights
+
+### 🌟 New Models & Reasoning Capabilities
+- Claude 3.7 with reasoning and thought streaming support
+- GPT-4.5 support
+- o1-mini & o3-mini with strategic function calling and `reasoning_effort` parameter
+- Anthropic Agents Reasoning for multiple providers, including AWS Bedrock
+
+### 🧠 Enhanced Tools & Agent Framework
+- Expanded agent capabilities with improved UI, artifact management & reasoning visualization
+- New tools: Weather data from OpenWeather, YouTube video analysis, Flux image generation
+- Support for OAuth in Actions to seamlessly connect with third-party services
+- xAI (Grok) Agent supported with modern interface
+
+### 🧰 Robust Development Features
+- Fully-featured Code Interpreter now supports Rscript alongside existing languages
+- Artifact editing and downloads for improved code workflow
+- Advanced file handling with concurrent operations support
+- Customizable Code API proxy support for flexible deployment scenarios
+
+### 🔐 Security & Account Management
+- Two-Factor Authentication with backup codes & QR support
+- Apple authentication for streamlined login
+- GitHub Enterprise SSO login
+- Temporary sessions for ephemeral usage (guest mode)
+
+### 💻 Enhanced User Experience
+- Quality-of-life messaging enhancements for editing and interaction
+- Conversation settings via URL query parameters for easy sharing
+- Improved accessibility throughout the application
+- Multi-language support with 18 languages including Georgian
+
+---
+
+### ✨ New Features
+
+* 👷 feat: Allow Admin to Edit Agent/Assistant Actions by @owengo in https://github.com/danny-avila/LibreChat/pull/4591/
+* 🔨 feat: Use `x-strict` attribute in OpenAPI Actions for Strict Function Definition by @owengo in https://github.com/danny-avila/LibreChat/pull/4639/
+* 🎨 feat: enhance UI & accessibility in file handling components by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5086/
+* 🌱 feat(.env.example): add o1 models by @evrentan in https://github.com/danny-avila/LibreChat/pull/5106/
+* 🎨 feat: enhance Chat Input UI, File Mgmt. UI, Bookmarks a11y by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5112/
+* 🤖 feat: Support Google Agents, fix Various Provider Configurations by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5126/
+* 🔑 feat: Implement TTL Mgmt. for In-Memory Keyv Stores by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5127/
+* ®️ feat: Support Rscript for Code Interpreter & `recursionLimit` for Agents by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5170/
+* 🔗 feat: Convo Settings via URL Query Params & Mention Models by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5184/
+* ✨ feat: Quality-of-Life Chat/Edit-Message Enhancements by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5194/
+* 💾 feat: Production-ready Memory Store for `express-session` by @lkiesow in https://github.com/danny-avila/LibreChat/pull/5212/
+* 📜 feat: Configure JSON Log Truncation Size by @thelinuxkid in https://github.com/danny-avila/LibreChat/pull/5215/
+* 🔗 feat: Enhance Share Functionality, Optimize DataTable & Fix Critical Bugs by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5220/
+* 🌤️ feat: Add OpenWeather Tool for Weather Data Retrieval by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5246/
+* 🏃‍♂️‍➡️ feat: Upgrade Meilisearch to v1.12.3 by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5327/
+* 🖱️ feat: Switch Scroll Button setting by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5332/
+* 🔥 feat: `deepseek-reasoner` Thought Streaming by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5379/
+* 🌟 feat: Enhance User Experience and SEO with Accessibility Updates and robots.txt by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5392/
+* 🌄 feat: Add RouteErrorBoundary for Improved Client Error handling by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5396/
+* 🚀 feat: Artifact Editing & Downloads by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5428/
+* ✨ feat: Add Scripts for listing users and resetting passwords by @jmaddington in https://github.com/danny-avila/LibreChat/pull/5438/
+* 🐳 feat: Deepseek Reasoning UI by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5440/
+* ✨ feat: Add Google Parameters, Ollama/Openrouter Reasoning, & UI Optimizations by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5456/
+* 🍎 feat: Apple auth by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5473/
+* 💬 feat: Temporary Chats by @ohneda in https://github.com/danny-avila/LibreChat/pull/5493/
+* 🚀 feat: o1 Tool Calling & `reasoning_effort` by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5553/
+* 🤖 feat: o3-mini by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5581/
+* 🎥 feat: YouTube Tool by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5582/
+* ☁️ feat: Additional AI Gateway Provider Support; fix: Reasoning Effort for Presets/Agents by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5600/
+* ✨ feat: added Github Enterprise SSO login by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5621/
+* 🛂 feat: OpenID Logout Redirect to `end_session_endpoint` by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5626/
+* 📱 feat: improve mobile viewport behavior with interactive-widget meta by @ssiegel in https://github.com/danny-avila/LibreChat/pull/5675/
+* 🔒 feat: Two-Factor Authentication with Backup Codes & QR support by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5685/
+* ✨ feat: OAuth for Actions by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5693/
+* 🪄 feat: Agent Artifacts by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5804/
+* 🚀 feat: Add Custom Welcome Message in `librechat.yaml` by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5870/
+* 🧠 feat: Reasoning UI for Agents by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5904/
+* 🚀 feat: Support Redis Clusters, Trusted Proxy Setting, And Toggle Meilisearch Indexing by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5963/
+* 🤖 feat: 192x192 Icon for Android PWA by @DavidMaza in https://github.com/danny-avila/LibreChat/pull/5966/
+* 🔼 feat: "Run Code" Button Toggle by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5988/
+* 🚀 feat: Claude 3.7 Support + Reasoning by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6008/
+* 🚀 feat: Add Georgian Language and Update Fallback Languages by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/6022/
+* ✨ feat: Anthropic Agents Prompt Caching & UI Accessibility Enhancements by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6045/
+* 🚀 feat: Agent Cache Tokens & Anthropic Reasoning Support by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6098/
+* 🚀 feat: GPT-4.5, Anthropic Tool Header, and OpenAPI Ref Resolution by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6118/
+* 🐼 feat: Add Flux Image Generation Tool by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6147/
+* 🧠 feat: Bedrock Anthropic Reasoning & Update Endpoint Handling by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6163/
+* 🚀 feat: Enhance Model Handling, Logging & xAI Agent Support by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6182/
+* 🪄 feat: Customize Sandpack `bundlerURL` for Artifacts by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6191/
+* 🕒 feat: Add Configurable MCP Server Timeouts by @iskakaushik in https://github.com/danny-avila/LibreChat/pull/6199/
+* 🚀 feat: Add Code API Proxy Support and Update MCP SDK by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6203/
+
+### 👐 Accessibility
+* ♿ a11y: Improve Accessibility in Endpoints Menu/Navigation by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5123/
+* 🔈 a11y: Accessible name on 'Prev' button in Prompts UI by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5369/
+* ♿️ a11y: Enhance Accessibility in ToolSelectDialog, ThemeSelector and ChatGroupItem by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5395/
+* 🔍 a11y: MultiSearch Clear Input by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5718/
+* 🔇 a11y: Silence Unnecessary Icons for Screen Readers by @kangabell in https://github.com/danny-avila/LibreChat/pull/5726/
+
+### 🌍 Internationalization
+
+* 🌍 i18n: Add Missing "Balance" Localization For All Languages by @TonyMahoney in https://github.com/danny-avila/LibreChat/pull/5594/, Fix "Balance" Localization For Zh&ZhTraditional by @RedwindA in https://github.com/danny-avila/LibreChat/pull/5632/, Fix "Balance" Localization For De by @leondape in https://github.com/danny-avila/LibreChat/pull/5656/, "Balance" Localization For ZhTraditional by @SN-Koarashi in https://github.com/danny-avila/LibreChat/pull/5682/
+* 🌎 i18n: React-i18next & i18next Integration by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5720/
+* 🌍 i18n: Update latest translations in https://github.com/danny-avila/LibreChat/pull/5764/, https://github.com/danny-avila/LibreChat/pull/5765/, https://github.com/danny-avila/LibreChat/pull/5789/, https://github.com/danny-avila/LibreChat/pull/5849/, https://github.com/danny-avila/LibreChat/pull/5855/, https://github.com/danny-avila/LibreChat/pull/5946/, https://github.com/danny-avila/LibreChat/pull/6009/, https://github.com/danny-avila/LibreChat/pull/6132/, https://github.com/danny-avila/LibreChat/pull/6159/
+* 🌏 i18n: fix Traditional Chinese Language Option by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5854/
+* 🐞 i18n: Remove Debug Mode by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5879/
+
+### 🔧 Fixes
+* 🔒 fix: resolve session persistence post password reset by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5077/
+* 🔒 fix: update refresh token handling to use plain token instead of hashed token by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5088/
+* 🐛 fix: Artifacts Type Error, Tool Token Counts, and Agent Chat Import by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5142/
+* 🔧 fix: Fetch PWA Manifest with credentials over CORS by @samvrlewis in https://github.com/danny-avila/LibreChat/pull/5156/
+* 🔧 fix: Handle Concurrent File Mgmt. For Agents by @thingersoft in https://github.com/danny-avila/LibreChat/pull/5159/
+* 🐛 fix: Prevent Default Values in OpenAI/Custom Endpoint Agents by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5180/
+* 🔖 fix: Remove Local State from Bookmark Menu by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5181/
+* 🧵 fix: Prevent Unnecessary Re-renders when Loading Chats by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5189/
+* 🐛 fix: Correct Endpoint/Icon Handling, Update Module Resolutions by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5205/
+* 🐛 fix: Ensure Default ModelSpecs Are Set Correctly by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5218/
+* 🔧 fix: Streamline Builder Links and Enhance UI Consistency by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5229/
+* 🐛 fix: Resolve 'Icon is Not a Function' Error in PresetItems by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5260/
+* 🔧 fix: Maximize Chat Space for Agent Messages by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5330/
+* 🎯 fix: Prevent UI De-sync By Removing Redundant States by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5333/
+* 🐛 fix: use OpenID token signature algo as discovered from the server. by @ragavpr in https://github.com/danny-avila/LibreChat/pull/5348/
+* 🛠️ fix: Optionally add OpenID Sig. Algo. from Server Discovery by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5398/
+* 🪙 fix: Deepseek Pricing & Titling by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5459/
+* 🛡️ fix: enhance email verification process & refactor verifyEmail component by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5485/
+* 🐛 fix: Update deletePromptController to include user role in query by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5488/
+* 🉐 fix: incorrect handling for composing CJK texts in Safari by @oonishi3 in https://github.com/danny-avila/LibreChat/pull/5496/
+* 🤖 fix: GoogleClient Context Handling & GenAI Parameters by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5503/
+* 🗨️ fix: Loading Shared Saved Prompts by @jameslamine in https://github.com/danny-avila/LibreChat/pull/5515/
+* ♻️ fix: Prevent Instructions from Removal when nearing Max Context by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5516/
+* 🔧 fix: handle known OpenAI errors with empty intermediate reply by @jameslamine in https://github.com/danny-avila/LibreChat/pull/5562/
+* 🔧 fix: Add missing `finish_reason` to stream chunks by @jameslamine in https://github.com/danny-avila/LibreChat/pull/5563/
+* 🤖 fix: Azure Agents after Upstream Breaking Change by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5571/
+* 🐛 fix: Handle content generation errors in GoogleClient by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5575/
+* 🛠️ fix: enhance UI/UX and address a11y issues in SetKeyDialog by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5672/
+* 🔧 fix: Wrong import `useGetStartupConfig` by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5692/
+* 🚀 fix: Resolve Google Client Issues, CDN Screenshots, Update Models by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5703/
+* 💬 fix: Temporary Chat PR's broken components and improved UI by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5705/
+* 🧠 fix: Handle Reasoning Chunk Edge Cases by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5800/
+* 🔧 fix: Ariakit Combobox Virtualization by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5851/
+* 🌍 fix: Enhance i18n Support & Optimize Category Handling by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5866/
+* ⚙️ fix: File Config Handling (revisited) by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5881/
+* 🐞 fix: Add Null Checks for BaseURL in Agent Config by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5908/
+* 🐛 fix: RAG Results Sorted By Distance by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5931/
+* 🔒 fix: 2FA Encrypt TOTP Secrets & Improve Docs by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5933/
+* 🔧 fix: Resizable Panel Unmount Error & Code Env. File Re-Upload by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5947/
+* 🔗 fix: Shared Link with Markdown Code Error by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6016/
+
+
+### 🔄 Code Refactoring
+
+* 🐋 refactor: Reduce Dockerfile.multi container size by @alex-torregrosa in https://github.com/danny-avila/LibreChat/pull/5066/
+* 🔄 refactor: Consolidate Tokenizer; Fix Jest Open Handles by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5175/
+* ⚡️ refactor: Optimize Rendering Performance for Icons, Conversations by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5234/
+* ♻️ refactor: Logout UX, Improved State Teardown, & Remove Unused Code by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5292/
+* 📜 refactor: Log Error Messages when OAuth Fails by @ragavpr in https://github.com/danny-avila/LibreChat/pull/5337/
+* 🔧 refactor: Improve Agent Context & Minor Fixes by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5349/
+* 🏄‍♂️ refactor: Optimize Reasoning UI & Token Streaming by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5546/
+* 🔧 refactor: Revamp Model and Tool Filtering Logic by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5637/
+* 🤖 refactor: Prevent Vertex AI from Setting Parameter Defaults by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5653/
+* 🔃 refactor: Parent Message ID Handling on Error, Update Translations, Bump Agents by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5833/
+* ⚙️ refactor: Enhance Logging, Navigation And Error Handling by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5910/
+* 🛠 refactor: Ensure File Deletions, File Naming, and Agent Resource Updates by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5928/
+* 👐 refactor: Agents Accessibility and Gemini Error Handling by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5972/
+* 🔧 refactor: Improve Params Handling, Remove Legacy Items, & Update Configs by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6074/
+* 🖼️ refactor: Enhance Env Extraction & Agent Image Handling by @danny-avila in https://github.com/danny-avila/LibreChat/pull/6131/
+* 🎨 style: Prompt UI Refresh & A11Y Improvements by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5614/
+* ✨ style: Enhance Styling & Accessibility by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5956/
+
+### ⚙️ Other Changes
+
+* 🔧 chore: bump `mongoose` to patch CVE-2025-23061 by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5351/
+* 🔒 chore: bump `katex` package to patch CVE-2025-23207 by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5383/
+* 🔧 chore: Update Deepseek Pricing, Google Safety Settings by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5409/
+* 🔧 chore: bump ```vite``` to patch CVE-2025-24010 by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5495/
+* 🧹 chore: Remove Deprecated BingAI Code & Address Mobile Focus by @danny-avila in https://github.com/danny-avila/LibreChat/pull/5565/
+* 🧹 chore: Migrate to Flat ESLint Config & Update Prettier Settings by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5737/
+* 🧹 chore: Enhance Issue Templates with Emoji Labels by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5754/
+* 🔄 chore: Refactor Locize Workflow for Improved Translation Sync by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5781/
+* 📦 chore: Bump Packages by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5791/
+* 🔄 chore: Enforce 18next Language Keys by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5803/
+* 🛡️ chore: patch `elliptic` to address GHSA-vjh7-7g9h-fjfh by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5848/
+* 🔢 chore: Remove Dollar Sign from Balance Display by @martvaha in https://github.com/danny-avila/LibreChat/pull/5948/
+* 🛜 ci: OpenID Strategy Test Async Handling by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5613/
+* 🤖 ci:  locize-pull-published-sync-pr.yml by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5762/
+* 🤖 ci:  locize-pull-published-sync-pr.yml by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5763/
+* 📜 ci: Consolidate Locize Workflows for Missing Keys & PR Creation by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5769/
+* 🎯 ci: Update ESLint Workflow to target `api/` and `client/` changes by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5771/
+* 🛠️ ci: Add Workflow to Detect Unused i18next Keys in PRs by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5782/
+* 📜 ci: Automate`CHANGELOG.md` by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5838/
+* ⚙️ ci: Trigger Restriction for `Detect Unused NPM Packages` by @rubentalstra in https://github.com/danny-avila/LibreChat/pull/5844/
+* 📘 docs: update readme.md by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5065/
+* 🧾 docs: Update Example `librechat.yaml` by @fcnjd in https://github.com/danny-avila/LibreChat/pull/5165/
+* 📝 docs: Update `librechat.example.yaml` by @fuegovic in https://github.com/danny-avila/LibreChat/pull/5544/
+* 📝 docs: Update Language Request Template & Update README by @berry-13 in https://github.com/danny-avila/LibreChat/pull/5766/
+
+## New Contributors
+* @fcnjd made their first contribution in https://github.com/danny-avila/LibreChat/pull/5165
+* @lkiesow made their first contribution in https://github.com/danny-avila/LibreChat/pull/5212
+* @ragavpr made their first contribution in https://github.com/danny-avila/LibreChat/pull/5337
+* @oonishi3 made their first contribution in https://github.com/danny-avila/LibreChat/pull/5496
+* @evrentan made their first contribution in https://github.com/danny-avila/LibreChat/pull/5106
+* @jameslamine made their first contribution in https://github.com/danny-avila/LibreChat/pull/5515
+* @jmaddington made their first contribution in https://github.com/danny-avila/LibreChat/pull/5438
+* @owengo made their first contribution in https://github.com/danny-avila/LibreChat/pull/4591
+* @samvrlewis made their first contribution in https://github.com/danny-avila/LibreChat/pull/5156
+* @TonyMahoney made their first contribution in https://github.com/danny-avila/LibreChat/pull/5594
+* @RedwindA made their first contribution in https://github.com/danny-avila/LibreChat/pull/5632
+* @leondape made their first contribution in https://github.com/danny-avila/LibreChat/pull/5656
+* @SN-Koarashi made their first contribution in https://github.com/danny-avila/LibreChat/pull/5682
+* @ssiegel made their first contribution in https://github.com/danny-avila/LibreChat/pull/5675
+* @kangabell made their first contribution in https://github.com/danny-avila/LibreChat/pull/5726
+* @github-actions made their first contribution in https://github.com/danny-avila/LibreChat/pull/5764
+* @martvaha made their first contribution in https://github.com/danny-avila/LibreChat/pull/5948
+* @DavidMaza made their first contribution in https://github.com/danny-avila/LibreChat/pull/5966
+* @iskakaushik made their first contribution in https://github.com/danny-avila/LibreChat/pull/6199
+
+**Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.7.6...v0.7.7

--- a/pages/changelog/v0.7.7.mdx
+++ b/pages/changelog/v0.7.7.mdx
@@ -1,0 +1,15 @@
+---
+date: 2025/03/07
+title: 🚀 LibreChat v0.7.7
+description: The v0.7.7 release of LibreChat
+ogImage: /images/changelog/v0.7.7.gif
+---
+
+import { ChangelogHeader } from '@/components/changelog/ChangelogHeader'
+import Content from '@/components/changelog/content/v0.7.7.mdx'
+
+<ChangelogHeader />
+
+---
+
+<Content />

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -246,9 +246,11 @@ see: [Anthropic Endpoint](./ai_setup.md#anthropic)
     ['ANTHROPIC_API_KEY', 'string', 'Anthropic API key or "user_provided" to allow users to provide their own API key.', 'Defaults to an empty string.'],
     ['ANTHROPIC_MODELS', 'string', 'Comma-separated list of Anthropic models to use.', '# ANTHROPIC_MODELS=claude-3-opus-20240229,claude-3-sonnet-20240229,claude-3-haiku-20240307,claude-2.1,claude-2,claude-1.2,claude-1,claude-1-100k,claude-instant-1,claude-instant-1-100k'],
     ['ANTHROPIC_REVERSE_PROXY', 'string', 'Reverse proxy for Anthropic.', '# ANTHROPIC_REVERSE_PROXY='],
-    ['ANTHROPIC_TITLE_MODEL', 'string', 'Model to use for titling with Anthropic.', '# ANTHROPIC_TITLE_MODEL=claude-3-haiku-20240307'],
+    ['ANTHROPIC_TITLE_MODEL', 'string', 'DEPRECATED: Model to use for titling with Anthropic.', '# ANTHROPIC_TITLE_MODEL=claude-3-haiku-20240307'],
   ]}
 />
+
+- `ANTHROPIC_TITLE_MODEL` is now deprecated and will be removed in future versions. Use the [`titleModel` Endpoint Setting](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings#titlemodel) instead in the `librechat.yaml` config instead.
 
 > **Note:** Must be compatible with the Anthropic Endpoint. Also, Claude 2 and Claude 3 models perform best at this task, with `claude-3-haiku` models being the cheapest.
 
@@ -274,7 +276,7 @@ Follow these instructions to setup the [Google Endpoint](/docs/configuration/pre
     ['GOOGLE_REVERSE_PROXY', 'string', 'Google reverse proxy URL.', 'GOOGLE_REVERSE_PROXY='],
     ['GOOGLE_MODELS', 'string', 'Available Gemini API Google models, separated by commas.', 'GOOGLE_MODELS=gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision'],
     ['GOOGLE_MODELS', 'string', 'Available Vertex AI Google models, separated by commas.', 'GOOGLE_MODELS=gemini-1.5-pro-preview-0409,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bison,codechat-bison-32k,text-bison,text-bison-32k,text-unicorn,code-gecko,code-bison,code-bison-32k'],
-    ['GOOGLE_TITLE_MODEL', 'string', 'The model used for titling with Google.', 'GOOGLE_TITLE_MODEL=gemini-pro'],
+    ['GOOGLE_TITLE_MODEL', 'string', 'DEPRECATED: The model used for titling with Google.', 'GOOGLE_TITLE_MODEL=gemini-pro'],
     ['GOOGLE_LOC', 'string', 'Specifies the Google Cloud location for processing API requests', 'GOOGLE_LOC=us-central1'],
     ['GOOGLE_EXCLUDE_SAFETY_SETTINGS', 'string', 'Completely omit the safety settings that are included by default, which will use provider defaults', 'GOOGLE_EXCLUDE_SAFETY_SETTINGS=true'],
     ['GOOGLE_SAFETY_SEXUALLY_EXPLICIT', 'string', 'Safety setting for sexually explicit content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', 'GOOGLE_SAFETY_SEXUALLY_EXPLICIT=BLOCK_ONLY_HIGH'],
@@ -285,6 +287,8 @@ Follow these instructions to setup the [Google Endpoint](/docs/configuration/pre
 />
 
 Customize the available models, separated by commas, **without spaces**. The first will be default. Leave it blank or commented out to use internal settings.
+
+- `GOOGLE_TITLE_MODEL` is now deprecated and will be removed in future versions. Use the [`titleModel` Endpoint Setting](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings#titlemodel) instead in the `librechat.yaml` config instead.
 
 **Note:** For the Vertex AI `GOOGLE_SAFETY` variables, you do not have access to the `BLOCK_NONE` setting by default. To use this restricted `HarmBlockThreshold` setting, you will need to either:
 - (a) Get access through an allowlist via your Google account team
@@ -300,14 +304,17 @@ See: [OpenAI Setup](/docs/configuration/pre_configured_ai/openai)
     ['OPENAI_API_KEY', 'string', 'Your OpenAI API key. Leave blank to disable this endpoint or set to "user_provided" to allow users to provide their own API key from the WebUI.', 'OPENAI_API_KEY=user_provided'],
     ['OPENAI_MODELS', 'string', 'Customize the available models, separated by commas, without spaces. The first will be default. Leave commented out to use internal settings.', '# OPENAI_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k'],
     ['DEBUG_OPENAI', 'boolean', 'Enable debug mode for the OpenAI endpoint.', 'DEBUG_OPENAI=false'],
-    ['OPENAI_TITLE_MODEL', 'string', 'The model used for OpenAI titling.', '# OPENAI_TITLE_MODEL=gpt-3.5-turbo'],
     ['OPENAI_SUMMARIZE', 'boolean', 'Enable message summarization. False by default', '# OPENAI_SUMMARIZE=true'],
     ['OPENAI_SUMMARY_MODEL', 'string', 'The model used for OpenAI summarization.', '# OPENAI_SUMMARY_MODEL=gpt-3.5-turbo'],
     ['OPENAI_FORCE_PROMPT', 'boolean', 'Force the API to be called with a prompt payload instead of a messages payload.', '# OPENAI_FORCE_PROMPT=false'],
-    ['OPENAI_REVERSE_PROXY', 'string', 'Reverse proxy settings for OpenAI.', '# OPENAI_REVERSE_PROXY='],
     ['OPENAI_ORGANIZATION', 'string', 'Specify which organization to use for each API request to OpenAI. Optional', '# OPENAI_ORGANIZATION='],
+    ['OPENAI_REVERSE_PROXY', 'string', 'DEPRECATED: Reverse proxy settings for OpenAI.', '# OPENAI_REVERSE_PROXY='],
+    ['OPENAI_TITLE_MODEL', 'string', 'DEPRECATED: The model used for OpenAI titling.', '# OPENAI_TITLE_MODEL=gpt-3.5-turbo'],
   ]}
 />
+
+- `OPENAI_TITLE_MODEL` is now deprecated and will be removed in future versions. Use the [`titleModel` Endpoint Setting](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings#titlemodel) instead in the `librechat.yaml` config instead.
+- `OPENAI_REVERSE_PROXY` is now deprecated and will be removed in future versions. Use a [custom endpoint](/docs/quick_start/custom_endpoints) instead.
 
 ### Assistants
 

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -56,6 +56,22 @@ Refer to [Express.js - trust proxy](https://expressjs.com/en/guide/behind-proxie
   ]}
 />
 
+### Credentials Configuration
+
+To securely store credentials, you need a fixed key and IV. You can set them here for prod and dev environments.
+
+<OptionTable
+  options={[
+    ['CREDS_KEY', 'string', '32-byte key (64 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_KEY=f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0'],
+    ['CREDS_IV', 'string', '16-byte IV (32 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb'],
+  ]}
+/>
+
+<Callout type="warning" title="Warning">
+**Warning:** If you don't set `CREDS_KEY` and `CREDS_IV`, the app will crash on startup.
+- You can use this [Key Generator](/toolkit/creds_generator) to generate them quickly.
+</Callout>
+
 ### Static File Handling
 
 <OptionTable
@@ -331,14 +347,15 @@ See: [Assistants Setup](/docs/configuration/pre_configured_ai/assistants)
 Note: You can customize the available models, separated by commas, without spaces. The first will be default. Leave it blank or commented out to use internal settings.
 
 ### Plugins
+
+**Note:** Plugins are now deprecated. Use [Agents](/docs/features/agents) instead.
+
 Here are some useful resources about plugins:
 
 * [Introduction](/docs/features/plugins)
 * [Make Your Own](/docs/development/tools_and_plugins)
 
-#### General Configuration
-
-### Environment Variables
+#### Environment Variables
 
 <OptionTable
   options={[
@@ -358,22 +375,6 @@ Here are some useful resources about plugins:
 
 <Callout type="note" title="Note">
 **Note:** Make sure the `gptPlugins` endpoint is set in the [`ENDPOINTS`](#endpoints) environment variable if it was configured before.
-</Callout>
-
-### Credentials Configuration
-
-To securely store credentials, you need a fixed key and IV. You can set them here for prod and dev environments.
-
-<OptionTable
-  options={[
-    ['CREDS_KEY', 'string', '32-byte key (64 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_KEY=f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0'],
-    ['CREDS_IV', 'string', '16-byte IV (32 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb'],
-  ]}
-/>
-
-<Callout type="warning" title="Warning">
-**Warning:** If you don't set `CREDS_KEY` and `CREDS_IV`, the app will crash on startup.
-- You can use this [Key Generator](/toolkit/creds_generator) to generate them quickly.
 </Callout>
 
 #### Azure AI Search
@@ -562,7 +563,7 @@ Get API key here: **https://api.traversaal.ai/dashboard**
   ]}
 />
 
-#### WolframAlpha
+### WolframAlpha
 
 See detailed instructions here: **[Wolfram Alpha](/docs/configuration/tools/wolfram)**
 
@@ -574,7 +575,7 @@ See detailed instructions here: **[Wolfram Alpha](/docs/configuration/tools/wolf
   ]}
 />
 
-#### Zapier
+### Zapier
 
 **Description:** - You need a Zapier account. Get your API key from here: **[Zapier](https://nla.zapier.com/credentials/)**
 - Create allowed actions - Follow step 3 in this getting start guide from Zapier

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -590,6 +590,20 @@ See detailed instructions here: **[Wolfram Alpha](/docs/configuration/tools/wolf
   ]}
 />
 
+## Artifacts
+
+Artifacts leverage the CodeSandbox library for secure rendering of HTML/JS code. By default, the public CDN hosted by CodeSandbox is used.
+
+Fortunately, for those with internal network requirements, you can [self-host the bundler](https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler) that compiles the frontend code and specify a custom bundler URL for Sandpack.
+
+For more info, including pre-made container images for self-hosting with metric requests removed, see: https://github.com/LibreChat-AI/codesandbox-client
+
+<OptionTable
+  options={[
+    ['SANDPACK_BUNDLER_URL', 'string', 'Specifies a custom bundler URL for Sandpack, used by Artifacts','SANDPACK_BUNDLER_URL=your-bundler-url'],
+  ]}
+/>
+
 ## Search (Meilisearch)
 
 Enables search in messages and conversations:

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/fireworks.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/fireworks.mdx
@@ -10,7 +10,7 @@ description: Example configuration for Fireworks
 **Notes:**
 
 - **Known:** icon provided, fetching list of models is recommended.
-- - API may be strict for some models, and may not allow fields like `user`, in which case, you should use [`dropParams`.](./custom_config.md#dropparams)
+- - API may be strict for some models, and may not allow fields like `user`, in which case, you should use [`dropParams`.](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#dropparams)
 
 ```yaml filename="librechat.yaml"
     - name: "Fireworks"

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/openrouter.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/openrouter.mdx
@@ -11,7 +11,7 @@ description: Example configuration for Openrouter
 
 - **Known:** icon provided, fetching list of models is recommended as API token rates and pricing used for token credit balances when models are fetched.
 
-- `stop` is no longer included as a default parameter, so there is no longer a need to include it in [`dropParams`](./custom_config.md#dropparams), unless you would like to completely prevent users from configuring this field.
+- `stop` is no longer included as a default parameter, so there is no longer a need to include it in [`dropParams`](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#dropparams), unless you would like to completely prevent users from configuring this field.
 
 - **Known issue:** you should not use `OPENROUTER_API_KEY` as it will then override the `openAI` endpoint to use OpenRouter as well.
 

--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/perplexity.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/perplexity.mdx
@@ -11,7 +11,7 @@ description: Example configuration for Perplexity
 
 - **Known:** icon provided.
 - **Known issue:** fetching list of models is not supported.
-- API may be strict for some models, and may not allow fields like `stop` and `frequency_penalty` may cause an error when set to 0, in which case, you should use [`dropParams`.](./custom_config.md#dropparams)
+- API may be strict for some models, and may not allow fields like `stop` and `frequency_penalty` may cause an error when set to 0, in which case, you should use [`dropParams`.](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#dropparams)
 - The example includes a model list, which was last updated on 3 July 2024, for your convenience.
 
 ```yaml

--- a/pages/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings.mdx
@@ -50,4 +50,4 @@ endpoints:
 - [Anthropic](/docs/configuration/pre_configured_ai/anthropic)
 - [Google](/docs/configuration/pre_configured_ai/google)
 - [Azure OpenAI](/docs/configuration/librechat_yaml/object_structure/azure_openai)
-- [Assistants](/docs/configuration/librechat_yaml/object_structure/assistants)
+- [Assistants](/docs/configuration/librechat_yaml/object_structure/assistants_endpoint)

--- a/pages/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings.mdx
@@ -8,12 +8,19 @@ This page describes the shared configuration settings for all endpoints. The set
 endpoints:
   openAI:
     streamRate: 25
+    titleModel: "gpt-4o-mini"
   anthropic:
     streamRate: 25
+    titleModel: "claude-3-5-haiku-20241022"
+  bedrock:
+    streamRate: 25
+    titleModel: "us.amazon.nova-lite-v1:0"
   google:
     streamRate: 1
+    titleModel: "gemini-2.0-flash-lite"
   azureOpenAI:
     streamRate: 20
+    titleModel: "gpt-4o-mini"
   assistants:
     streamRate: 30
   azureAssistants:
@@ -36,6 +43,20 @@ endpoints:
 
 > Allows for streaming data at the fastest rate possible while allowing the system to wait for the next tick
 
+## titleModel
+
+**Key:**
+<OptionTable
+  options={[
+    ['titleModel', 'String', 'Specifies the model to use for titles.', 'Defaults to system default for the current endpoint if omitted. May cause issues if the system default model is not available. You can also dynamically use the current conversation model by setting it to "current_model".'],
+  ]}
+/>
+
+**Default:** System default for the current endpoint
+**Notes:** It isn't yet possible to set a `titleModel` for the `all` key. This setting must be set individually for each endpoint.
+
+---
+
 **Notes:**
 - The `all` setting would override all individual endpoint values, making those specific settings unnecessary if used.
 - The value can be customized for each endpoint or set globally using the `all` key.
@@ -48,6 +69,7 @@ endpoints:
 - [Custom Endpoints](/docs/configuration/librechat_yaml/object_structure/custom_endpoint)
 - [OpenAI](/docs/configuration/pre_configured_ai/openai)
 - [Anthropic](/docs/configuration/pre_configured_ai/anthropic)
+- [Bedrock](/docs/configuration/pre_configured_ai/bedrock)
 - [Google](/docs/configuration/pre_configured_ai/google)
 - [Azure OpenAI](/docs/configuration/librechat_yaml/object_structure/azure_openai)
 - [Assistants](/docs/configuration/librechat_yaml/object_structure/assistants_endpoint)

--- a/pages/docs/features/artifacts.mdx
+++ b/pages/docs/features/artifacts.mdx
@@ -28,6 +28,42 @@ Experience the future of UI/UX design and development with LibreChat's generativ
 
 You may need to need to update your web server's Content-Security-Policy to include `frame-src 'self' https://*.codesandbox.io` in order to load generated HTML apps in the Artifacts panel. This is a dependency of the [sandpack](https://sandpack.codesandbox.io/) library.
 
+## Self-Hosting the Sandpack Bundler
+
+Artifacts in LibreChat use CodeSandbox's Sandpack library to securely render HTML/JS code. By default, LibreChat connects to CodeSandbox's public CDN, which may also transmit telemetry for its usage.
+
+For enhanced privacy, security compliance, or isolated network environments, you can [self-host the bundler.](https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler)
+
+### Why Self-Host the Sandpack Bundler?
+
+[Self-hosting the bundler](https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler) provides several advantages:
+
+- **Privacy & Security**: Keep code execution within your own infrastructure
+- **Reliability**: Remove dependency on external services
+- **Performance**: Reduce latency by hosting the bundler in your network
+- **Compliance**: Meet organizational data handling requirements
+- **Control**: Configure and customize to your specific needs
+
+### Configuration
+
+Once you have a self-hosted bundler set up, simply configure LibreChat to use it by setting the environment variable:
+
+```bash
+# `.env` file
+SANDPACK_BUNDLER_URL=http://your-bundler-url
+```
+
+### General Considerations
+
+Self-hosting the bundler introduces some additional overhead:
+
+- **CORS Configuration**: You'll need to manage cross-origin resource sharing policies
+- **Security Management**: You become responsible for the security of the bundler service
+- **Maintenance**: Updates and patches will need to be applied manually
+- **Resource Requirements**: Additional server resources will be needed to host the bundler
+
+For detailed instructions on setting up and maintaining your self-hosted bundler, refer to the [forked CodeSandbox repository](https://github.com/LibreChat-AI/codesandbox-client) tailored for LibreChat deployment, including the removal of telemetry from Sandpack.
+
 ---
 
 AI News 2024: The Original and BEST Open-Source AI Chat Platform, LibreChat Releases Code Artifacts! This Generative UI Tool Can Generate React, HTML & Diagrams Instantly from a Single Prompt in Your Browser with Any LLM, OpenAI, Anthropic, LLAMA, Mistral, DeepSeek Coder & More Thanks to OLLAMA Integration.

--- a/pages/docs/remote/index.mdx
+++ b/pages/docs/remote/index.mdx
@@ -51,7 +51,7 @@ The minimum requirements for running LibreChat:
 
 ## Cloud Vendor Integration and Configuration
 
-The integration level with cloud vendors varies: from platforms enabling single-click LibreChat deployments like [Railway](/docs/remote/railway), through platforms leveraging Infrastructure as Code tools such as Azure with Terraform, to more traditional VM setups requiring manual configuration, exemplified by [DigitalOcean](digitalocean.md), Linode, and Hetzner.
+The integration level with cloud vendors varies: from platforms enabling single-click LibreChat deployments like [Railway](/docs/remote/railway), through platforms leveraging Infrastructure as Code tools such as Azure with Terraform, to more traditional VM setups requiring manual configuration, exemplified by [DigitalOcean](/docs/remote/digitalocean), Linode, and Hetzner.
 
 ## Essential Security Considerations
 


### PR DESCRIPTION
## Summary

I updated LibreChat’s documentation to match the v0.7.7 release while refining configuration details, deprecation notices, and self-hosting options for enhanced privacy and security.

- Updated the changelog content for v0.7.7 to highlight new models, features, and contributor changes.
- Added self-hosting instructions for the Sandpack bundler, including configuration examples and related security considerations.
- Revised the credentials configuration section in the dotenv docs to clearly explain key and IV requirements with warning callouts.
- Marked deprecated title model settings for Anthropic, Google, and OpenAI endpoints and updated documentation to suggest the new titleModel setting.
- Fixed several broken /docs links and adjusted header ordering to ensure smoother navigation and consistency.
    - closes #251
    - closes #226
    - closes #195

## Testing:
- Verified that all documentation pages render correctly locally.
- Confirmed that updated links and configuration examples direct to the proper pages.
- Ran documentation build tests and reviewed configuration examples for accuracy.

## Checklist:
- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my changes
- [x] I have made pertinent documentation updates
- [x] Local documentation tests pass with my changes