### PR TITLE
Update perplexity.mdx

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/perplexity.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/perplexity.mdx
@@ -20,13 +20,12 @@ description: Example configuration for Perplexity
       baseURL: "https://api.perplexity.ai/"
       models:
         default: [
-          "llama-3-sonar-small-32k-chat",
-          "llama-3-sonar-small-32k-online",
-          "llama-3-sonar-large-32k-chat",
-          "llama-3-sonar-large-32k-online",
-          "mixtral-8x7b-instruct",
-          "llama-3-8b-instruct",
-          "llama-3-70b-instruct"
+          "sonar-deep-research",
+          "sonar-reasoning-pro",
+          "sonar-reasoning",
+          "sonar-pro",
+          "sonar",
+          "r1-1776"
           ]
         fetch: false # fetching list of models is not supported
       titleConvo: true


### PR DESCRIPTION
Updated models that work in March 2025. Reference: https://docs.perplexity.ai/guides/model-cards 