### PR TITLE
feat: Add support for LDAP StartTLS and update documentation for LDAP settings

### DIFF
--- a/pages/docs/configuration/authentication/ldap.mdx
+++ b/pages/docs/configuration/authentication/ldap.mdx
@@ -31,7 +31,7 @@ You can use a Lightweight Directory Access Protocol (LDAP) authentication server
 
 **Field Mappings**
 
-You can specify a mapping between the attributes of Librechat users and those of LDAP users. Use these settings if the default mappings do not work properly.
+You can specify a mapping between the attributes of LibreChat users and those of LDAP users. Use these settings if the default mappings do not work properly.
 
 <OptionTable
   options={[
@@ -83,7 +83,7 @@ and configure LibreChat to request login via username:
 **Active Directory over SSL**
 
 To connect via SSL (ldaps://), such as a company using Windows AD, specify the path to the internal CA certificate.
-`LDAP_TLS_REJECT_UNAUTHORIZED` is optional;if not specified Librechat will reject TLS/SSL connections if the LDAP server's certificate cannot be verified.
+`LDAP_TLS_REJECT_UNAUTHORIZED` is optional;if not specified LibreChat will reject TLS/SSL connections if the LDAP server's certificate cannot be verified.
 set `LDAP_TLS_REJECT_UNAUTHORIZED` to false (not recommended for production environments)
 to allow Librechat to accept TLS/SSL connections even if the LDAP server's certificate cannot be verified,
 
@@ -102,4 +102,19 @@ to allow Librechat to accept TLS/SSL connections even if the LDAP server's certi
       'LDAP_TLS_REJECT_UNAUTHORIZED=true',
     ],
   ]}
+/>
+
+**LDAP StartTLS**
+
+Enabling LDAP StartTLS allows LibreChat to upgrade an insecure connection to a secure TLS connection. This is useful if you want to secure the connection without switching to ldaps://.
+
+<OptionTable
+    options={[
+        [
+            'LDAP_STARTTLS',
+            'string',
+            'Enable LDAP StartTLS for upgrading the connection to TLS. Set to true to enable this feature.',
+            'LDAP_STARTTLS=true',
+        ],
+    ]}
 />

--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -901,30 +901,36 @@ For more information:
 For more information: **[LDAP/AD Authentication](/docs/configuration/authentication/ldap)**
 
 <OptionTable
-  options={[
-    ['LDAP_URL', 'string', 'LDAP server URL.', 'LDAP_URL=ldap://localhost:389'],
-    ['LDAP_BIND_DN', 'string', 'Bind DN', 'LDAP_BIND_DN=cn=root'],
-    ['LDAP_BIND_CREDENTIALS', 'string', 'Password for bindDN', 'LDAP_BIND_CREDENTIALS=password'],
-    [
-      'LDAP_USER_SEARCH_BASE',
-      'string',
-      'LDAP user search base',
-      'LDAP_USER_SEARCH_BASE=o=users,o=example.com',
-    ],
-    ['LDAP_SEARCH_FILTER', 'string', 'LDAP search filter', 'LDAP_SEARCH_FILTER=mail={{username}}'],
-    [
-      'LDAP_CA_CERT_PATH',
-      'string',
-      'CA certificate path.',
-      'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
-    ],
-    [
-      'LDAP_TLS_REJECT_UNAUTHORIZED',
-      'string',
-      'LDAP TLS verification',
-      'LDAP_TLS_REJECT_UNAUTHORIZED=true',
-    ],
-  ]}
+    options={[
+        ['LDAP_URL', 'string', 'LDAP server URL.', 'LDAP_URL=ldap://localhost:389'],
+        ['LDAP_BIND_DN', 'string', 'Bind DN', 'LDAP_BIND_DN=cn=root'],
+        ['LDAP_BIND_CREDENTIALS', 'string', 'Password for bindDN', 'LDAP_BIND_CREDENTIALS=password'],
+        [
+            'LDAP_USER_SEARCH_BASE',
+            'string',
+            'LDAP user search base',
+            'LDAP_USER_SEARCH_BASE=o=users,o=example.com',
+        ],
+        ['LDAP_SEARCH_FILTER', 'string', 'LDAP search filter', 'LDAP_SEARCH_FILTER=mail={{username}}'],
+        [
+            'LDAP_CA_CERT_PATH',
+            'string',
+            'CA certificate path.',
+            'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
+        ],
+        [
+            'LDAP_TLS_REJECT_UNAUTHORIZED',
+            'string',
+            'LDAP TLS verification',
+            'LDAP_TLS_REJECT_UNAUTHORIZED=true',
+        ],
+        [
+            'LDAP_STARTTLS',
+            'string',
+            'Enable LDAP StartTLS for upgrading the connection to TLS. Set to true to enable this feature.',
+            'LDAP_STARTTLS=true',
+        ],
+    ]}
 />
 
 ### Password Reset


### PR DESCRIPTION
PR: https://github.com/danny-avila/LibreChat/pull/6438

This pull request includes updates to the LDAP authentication documentation in the `pages/docs/configuration` directory. The changes include corrections to the spelling of "LibreChat" and the addition of a new feature for LDAP StartTLS.

Documentation updates:

* [`pages/docs/configuration/authentication/ldap.mdx`](diffhunk://#diff-0c02dc7f7c676aa75fcf818bfe579a288a941abf8e4b671a39af50e202a82730L34-R34): Corrected the spelling of "LibreChat" in multiple instances. [[1]](diffhunk://#diff-0c02dc7f7c676aa75fcf818bfe579a288a941abf8e4b671a39af50e202a82730L34-R34) [[2]](diffhunk://#diff-0c02dc7f7c676aa75fcf818bfe579a288a941abf8e4b671a39af50e202a82730L86-R86)
* [`pages/docs/configuration/authentication/ldap.mdx`](diffhunk://#diff-0c02dc7f7c676aa75fcf818bfe579a288a941abf8e4b671a39af50e202a82730R106-R120): Added a new section to describe the LDAP StartTLS feature, including an `OptionTable` entry for `LDAP_STARTTLS`.
* [`pages/docs/configuration/dotenv.mdx`](diffhunk://#diff-2e31cabe621742d50b7d79191845b45a018e68fd88696282d09bb62dcc355a12R927-R932): Added an `OptionTable` entry for `LDAP_STARTTLS` to enable upgrading the connection to TLS.