### PR TITLE
feat: Add balance management configuration to YAML and update token usage documentation

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/_meta.ts
+++ b/pages/docs/configuration/librechat_yaml/object_structure/_meta.ts
@@ -4,6 +4,7 @@ export default {
   interface: 'Interface (UI)',
   model_specs: 'Model Specs',
   registration: 'Registration',
+  balance: 'Balance',
   agents: 'Agents',
   mcp_servers: 'MCP Servers',
   aws_bedrock: 'AWS Bedrock',

--- a/pages/docs/configuration/librechat_yaml/object_structure/balance.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/balance.mdx
@@ -1,0 +1,158 @@
+---
+title: Balance
+description: Configure token credit balances for users in LibreChat
+---
+
+# Balance Object Structure
+
+## Overview
+
+The `balance` object allows administrators to configure how token credit balances are managed for users within LibreChat. Settings include enabling balance tracking, initializing user balances, and configuring automatic token refill behavior.
+
+**Fields under `balance`:**
+
+- `enabled`
+- `startBalance`
+- `autoRefillEnabled`
+- `refillIntervalValue`
+- `refillIntervalUnit`
+- `refillAmount`
+
+**Notes:**
+
+- `balance` configurations apply globally across the application.
+- Defaults are provided but can be customized based on requirements.
+- Conditional logic can dynamically modify these settings based on other configurations.
+
+
+## Example
+
+```yaml filename="balance"
+balance:
+  enabled: false
+  startBalance: 20000
+  autoRefillEnabled: false
+  refillIntervalValue: 30
+  refillIntervalUnit: "days"
+  refillAmount: 10000
+```
+
+
+## enabled
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['enabled', 'Boolean', 'Enables token credit tracking and balance management for users.', 'Set to true to activate balance tracking for token usage.'],
+    ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+
+```yaml filename="balance / enabled"
+balance:
+  enabled: true
+```
+
+
+## startBalance
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['startBalance', 'Integer', 'Specifies the initial number of tokens credited to a user upon registration.', 'Tokens credited to a new user account.'],
+    ]}
+/>
+
+**Default:** `20000`
+
+**Example:**
+
+```yaml filename="balance / startBalance"
+balance:
+  startBalance: 20000
+```
+
+
+## autoRefillEnabled
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['autoRefillEnabled', 'Boolean', 'Determines whether automatic refilling of token credits is enabled.', 'Set to true to enable automatic token refills.'],
+    ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+
+```yaml filename="balance / autoRefillEnabled"
+balance:
+  autoRefillEnabled: true
+```
+
+
+## refillIntervalValue
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['refillIntervalValue', 'Integer', 'Specifies the numerical value for the interval at which token credits are automatically refilled.', 'For example, 30 represents a 30-day interval.'],
+    ]}
+/>
+
+**Default:** `30`
+
+**Example:**
+
+```yaml filename="balance / refillIntervalValue"
+balance:
+  refillIntervalValue: 30
+```
+
+
+## refillIntervalUnit
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['refillIntervalUnit', 'String', 'Specifies the time unit for the refill interval (e.g., "days", "hours").', 'Indicates the unit of time for refillIntervalValue.'],
+    ]}
+/>
+
+**Default:** `"days"`
+
+**Example:**
+
+```yaml filename="balance / refillIntervalUnit"
+balance:
+  refillIntervalUnit: "days"
+```
+
+
+## refillAmount
+
+**Key:**
+
+<OptionTable
+    options={[
+        ['refillAmount', 'Integer', 'Specifies the number of tokens to be added to the user\'s balance during each automatic refill.', 'The amount added to a user’s token credits at each refill interval.'],
+    ]}
+/>
+
+**Default:** `10000`
+
+**Example:**
+
+```yaml filename="balance / refillAmount"
+balance:
+  refillAmount: 10000
+```

--- a/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -19,6 +19,7 @@ These are fields under `interface`:
   - `agents`
   - `customWelcome`
   - `runCode`
+  - `balance`
 
 **Notes:**
 
@@ -52,6 +53,9 @@ interface:
   multiConvo: true
   agents: true
   customWelcome: "Welcome to LibreChat!"
+  balance:
+    enabled: true
+    startBalance: 20000
   runCode: true
 ```
 
@@ -247,8 +251,6 @@ interface:
   agents: true
 ```
 
----
-
 ## customWelcome
 
 **Key:**
@@ -287,3 +289,52 @@ interface:
   runCode: true
 ```
 
+
+
+## balance
+
+The `balance` configuration controls how token credit balances are managed for users. These settings are now specified in your YAML configuration file (e.g., in `librechat.yaml`), replacing the previous environment variable approach. This section outlines each setting available under the `balance` key.
+
+**Example:**
+```yaml filename="interface / balance"
+interface:
+  balance:
+    enabled: true
+    startBalance: 20000
+```
+
+### enabled
+
+**Key:**
+<OptionTable
+    options={[
+        ['enabled', 'Boolean', 'Enables token credit tracking and balance management for users.', 'Set to true to activate balance tracking for token usage.'],
+    ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml filename="interface / balance / enabled"
+interface:
+  balance:
+    enabled: true
+```
+
+### startBalance
+
+**Key:**
+<OptionTable
+    options={[
+        ['startBalance', 'Integer', 'Specifies the initial number of tokens credited to a user upon registration.', 'Tokens credited to a new user account.'],
+    ]}
+/>
+
+**Default:** `0`
+
+**Example:**
+```yaml filename="interface / balance / startBalance"
+interface:
+  balance:
+    startBalance: 20000
+```

--- a/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -19,7 +19,6 @@ These are fields under `interface`:
   - `agents`
   - `customWelcome`
   - `runCode`
-  - `balance`
 
 **Notes:**
 
@@ -53,13 +52,6 @@ interface:
   multiConvo: true
   agents: true
   customWelcome: "Welcome to LibreChat!"
-  balance:
-    enabled: false
-    startBalance: 20000
-    autoRefillEnabled: false
-    refillIntervalValue: 30
-    refillIntervalUnit: "days"
-    refillAmount: 10000
   runCode: true
 ```
 
@@ -291,117 +283,4 @@ Enables/disables the "Run Code" button for Markdown Code Blocks. More info on th
 ```yaml filename="interface / runCode"
 interface:
   runCode: true
-```
-
-
-## balance
-
-The `balance` configuration controls how token credit balances are managed for users. These settings are now specified in your YAML configuration file (e.g., in `librechat.yaml`), replacing the previous environment variable approach. This section outlines each setting available under the `balance` key.
-
-### enabled
-
-**Key:**
-<OptionTable
-    options={[
-        ['enabled', 'Boolean', 'Enables token credit tracking and balance management for users.', 'Set to true to activate balance tracking for token usage.'],
-    ]}
-/>
-
-**Default:** `false`
-
-**Example:**
-```yaml filename="interface / balance / enabled"
-interface:
-  balance:
-    enabled: true
-```
-
-### startBalance
-
-**Key:**
-<OptionTable
-    options={[
-        ['startBalance', 'Integer', 'Specifies the initial number of tokens credited to a user upon registration.', 'Tokens credited to a new user account.'],
-    ]}
-/>
-
-**Default:** `20000`
-
-**Example:**
-```yaml filename="interface / balance / startBalance"
-interface:
-  balance:
-    startBalance: 20000
-```
-
-### autoRefillEnabled
-
-**Key:**
-<OptionTable
-    options={[
-        ['autoRefillEnabled', 'Boolean', 'Determines whether automatic refilling of token credits is enabled.', 'Set to true to enable automatic token refills.'],
-    ]}
-/>
-
-**Default:** `false`
-
-**Example:**
-```yaml filename="interface / balance / autoRefillEnabled"
-interface:
-  balance:
-    autoRefillEnabled: true
-```
-
-### refillIntervalValue
-
-**Key:**
-<OptionTable
-    options={[
-        ['refillIntervalValue', 'Integer', 'Specifies the numerical value for the interval at which token credits are automatically refilled.', 'For example, 30 represents a 30-day interval.'],
-    ]}
-/>
-
-**Default:** `30`
-
-**Example:**
-```yaml filename="interface / balance / refillIntervalValue"
-interface:
-  balance:
-    refillIntervalValue: 30
-```
-
-### refillIntervalUnit
-
-**Key:**
-<OptionTable
-    options={[
-        ['refillIntervalUnit', 'String', 'Specifies the time unit for the refill interval (e.g., "days", "hours").', 'Indicates the unit of time for refillIntervalValue.'],
-    ]}
-/>
-
-**Default:** `days`
-
-**Example:**
-```yaml filename="interface / balance / refillIntervalUnit"
-interface:
-  balance:
-    refillIntervalUnit: 'days'
-```
-
-### refillAmount
-
-**Key:**
-<OptionTable
-    options={[
-        ['refillAmount', 'Integer', 'Specifies the number of tokens to be added to the user\'s balance during each automatic refill.', 'The amount added to a user’s token credits at each refill interval.'],
-    ]}
-/>
-
-**Default:** `10000`
-
-**Example:**
-```yaml filename="interface / balance / refillAmount"
-interface:
-  balance:
-    refillAmount: 10000
 ```

--- a/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -290,18 +290,9 @@ interface:
 ```
 
 
-
 ## balance
 
 The `balance` configuration controls how token credit balances are managed for users. These settings are now specified in your YAML configuration file (e.g., in `librechat.yaml`), replacing the previous environment variable approach. This section outlines each setting available under the `balance` key.
-
-**Example:**
-```yaml filename="interface / balance"
-interface:
-  balance:
-    enabled: true
-    startBalance: 20000
-```
 
 ### enabled
 
@@ -330,11 +321,83 @@ interface:
     ]}
 />
 
-**Default:** `0`
+**Default:** `20000`
 
 **Example:**
 ```yaml filename="interface / balance / startBalance"
 interface:
   balance:
     startBalance: 20000
+```
+
+### autoRefillEnabled
+
+**Key:**
+<OptionTable
+    options={[
+        ['autoRefillEnabled', 'Boolean', 'Determines whether automatic refilling of token credits is enabled.', 'Set to true to enable automatic token refills.'],
+    ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml filename="interface / balance / autoRefillEnabled"
+interface:
+  balance:
+    autoRefillEnabled: true
+```
+
+### refillIntervalValue
+
+**Key:**
+<OptionTable
+    options={[
+        ['refillIntervalValue', 'Integer', 'Specifies the numerical value for the interval at which token credits are automatically refilled.', 'For example, 30 represents a 30-day interval.'],
+    ]}
+/>
+
+**Default:** `30`
+
+**Example:**
+```yaml filename="interface / balance / refillIntervalValue"
+interface:
+  balance:
+    refillIntervalValue: 30
+```
+
+### refillIntervalUnit
+
+**Key:**
+<OptionTable
+    options={[
+        ['refillIntervalUnit', 'String', 'Specifies the time unit for the refill interval (e.g., "days", "hours").', 'Indicates the unit of time for refillIntervalValue.'],
+    ]}
+/>
+
+**Default:** `days`
+
+**Example:**
+```yaml filename="interface / balance / refillIntervalUnit"
+interface:
+  balance:
+    refillIntervalUnit: 'days'
+```
+
+### refillAmount
+
+**Key:**
+<OptionTable
+    options={[
+        ['refillAmount', 'Integer', 'Specifies the number of tokens to be added to the user\'s balance during each automatic refill.', 'The amount added to a user’s token credits at each refill interval.'],
+    ]}
+/>
+
+**Default:** `10000`
+
+**Example:**
+```yaml filename="interface / balance / refillAmount"
+interface:
+  balance:
+    refillAmount: 10000
 ```

--- a/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -54,8 +54,12 @@ interface:
   agents: true
   customWelcome: "Welcome to LibreChat!"
   balance:
-    enabled: true
+    enabled: false
     startBalance: 20000
+    autoRefillEnabled: false
+    refillIntervalValue: 30
+    refillIntervalUnit: "days"
+    refillAmount: 10000
   runCode: true
 ```
 

--- a/pages/docs/configuration/token_usage.mdx
+++ b/pages/docs/configuration/token_usage.mdx
@@ -6,38 +6,31 @@ description: This covers how to track and control your token usage for the OpenA
 
 ## Intro
 
-As of `v6.0.0`, LibreChat accurately tracks token usage for the OpenAI/Plugins endpoints.
-This can be viewed in your database's "Transactions" collection. 
+As of `v0.6.0`, LibreChat accurately tracks token usage for the OpenAI/Plugins endpoints. All token transactions are stored in the "Transactions" collection in your database. In future releases, you’ll be able to toggle viewing how much a conversation costs.
 
-In the future, you will be able to toggle viewing how much a conversation has cost you.
+Currently, you can limit user token usage by enabling user balances. Instead of configuring token credit limits via environment variables, you now set these options in your `librechat.yaml` file under the **balance** section.
 
-Currently, you can limit user token usage by enabling user balances. To enables token credit limiting for the OpenAI/Plugins endpoints, set the following .env variable:
+### New Balance Settings
 
-<OptionTable
-  options={[
-    ['CHECK_BALANCE', 'boolean', 'Enable token credit balances for the OpenAI/Plugins endpoints.','CHECK_BALANCE=false'],
-  ]}
-/>
+The following settings are now managed in your YAML configuration:
 
-And You can also set the number of tokens a user will receive upon registration:
+- **enabled**: Enable token credit balances for the OpenAI/Plugins endpoints.
+- **startBalance**: The number of tokens credited to a user upon registration.
 
-<OptionTable
-  options={[
-    ['START_BALANCE', 'integer', 'If the value is set, tokens will be credited to the user\'s balance after registration.','START_BALANCE=20000']
-  ]}
-/>
+This replaces the old environment variables (`CHECK_BALANCE` and `START_BALANCE`), so you no longer need to manage these settings in your environment.
+
+```yaml filename="librechat.yaml"
+version: 1.2.1
+
+# Balance settings
+balance:
+  enabled: true               # Enable token credit balances for users.
+  startBalance: 20000         # Number of tokens to credit upon registration.
+```
 
 ## Managing Token Balances
 
-You manually add user balance, or you will need to build out a balance-accruing system for users. This may come as a feature to the app whenever an admin dashboard is introduced.
-
-These commands vary depending on your deployment method:
-- **Local Development**:
-Run from the project root directory when running the application locally without Docker
-- **Docker (default setup)**:
-Run from the directory containing your `docker-compose.yml` when using the default Docker setup (typically started with `docker compose up`)
-- **Docker (deployment setup)**:
-Run from the directory containing your `deploy-compose.yml` if you followed the [Ubuntu Docker Guide](/docs/remote/docker_linux)
+You can manually add or set user balances. This is especially useful during development or if you plan to build out a full balance-accruing system in the future (for example, via an admin dashboard).
 
 ### Adding Balances
 
@@ -127,7 +120,7 @@ Token credits value. 1000 credits = $0.001 (1 mill USD)
 
 > "rate": 00, // what's this?
 
-The rate at which tokens are charged as credits. 
+The rate at which tokens are charged as credits.
 
 For example, gpt-3.5-turbo-1106 has a rate of 1 for user prompt (input) and 2 for completion (output)
 
@@ -170,3 +163,18 @@ There will be more customization for this soon from the `librechat.yaml` file.
 ![image](https://github.com/danny-avila/LibreChat/assets/110412045/39a1aa5d-f8fc-43bf-81f2-299e57d944bb)
 
 ![image](https://github.com/danny-avila/LibreChat/assets/110412045/e1b1cc3f-8981-4c7c-a5f8-e7badbc6f675)
+
+## How Auto-Refill Works
+
+When a user’s balance is tracked and **autoRefill** is enabled, the system will automatically add credits to the balance only when the specified time interval has passed since the last refill. This is achieved by comparing the current date with the `lastRefill` date plus the specified interval. For example, if `refillIntervalValue` is set to 30 and `refillIntervalUnit` is `days`, the system will add `refillAmount` tokens to the user’s balance only if 30 days have passed since the last refill.
+
+---
+
+## Additional Notes
+
+- With summarization enabled, API requests are blocked if the cost of the content plus the messages payload exceeds the current balance.
+- The system is lenient with completion tokens, focusing primarily on prompt tokens for balance checks.
+- A buffer is added for titling (approximately 150 tokens) to account for the two-step process.
+- Token credits translate to monetary value (e.g., 1000 credits = $0.001 USD).
+
+For more details and customizations, please refer to the [LibreChat Documentation](https://www.librechat.ai/docs/configuration/librechat_yaml).


### PR DESCRIPTION
This pull request introduces comprehensive changes to the documentation and configuration for managing token credit balances in LibreChat. The primary focus is on adding a new `balance` object structure and updating the token usage documentation to reflect these changes.

### New Balance Object Structure

* [`pages/docs/configuration/librechat_yaml/object_structure/_meta.ts`](diffhunk://#diff-27966d15fc4268b8c5505786a767f8c986c21abd3c9465f554b859c74e205eeeR7): Added `balance` to the list of configuration objects.
* [`pages/docs/configuration/librechat_yaml/object_structure/balance.mdx`](diffhunk://#diff-19705447a3a05a488faf35ada1497be776603c541a43a8d426ec23b6b00cc56dR1-R158): Created a new document detailing the `balance` object, which includes fields like `enabled`, `startBalance`, `autoRefillEnabled`, `refillIntervalValue`, `refillIntervalUnit`, and `refillAmount`.

### Updates to Token Usage Documentation

* [`pages/docs/configuration/token_usage.mdx`](diffhunk://#diff-9e22f4fefeb0bdddba36fbe5eb1fa14ca9b8e41eb6eb05e3041514f8f7d2ee64L9-R33): Updated to reflect the new balance settings, replacing old environment variables with YAML configuration options. Added sections on managing token balances and how auto-refill works. [[1]](diffhunk://#diff-9e22f4fefeb0bdddba36fbe5eb1fa14ca9b8e41eb6eb05e3041514f8f7d2ee64L9-R33) [[2]](diffhunk://#diff-9e22f4fefeb0bdddba36fbe5eb1fa14ca9b8e41eb6eb05e3041514f8f7d2ee64R166-R180)

### Minor Changes

* [`pages/docs/configuration/librechat_yaml/object_structure/interface.mdx`](diffhunk://#diff-baccf5ae1dafaa5bf4377e8685fe3709e814a0b214e9ef69283a83bf43201958L250-L251): Removed unnecessary blank lines to clean up the document. [[1]](diffhunk://#diff-baccf5ae1dafaa5bf4377e8685fe3709e814a0b214e9ef69283a83bf43201958L250-L251) [[2]](diffhunk://#diff-baccf5ae1dafaa5bf4377e8685fe3709e814a0b214e9ef69283a83bf43201958L289)