### PR TITLE
Add example configuration for Requesty.ai in requesty.mdx

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/requesty.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/requesty.mdx
@@ -7,23 +7,20 @@ description: Example configuration for Requesty.ai
 
 > Requesty API key: [requesty.ai/keys](https://app.requesty.ai/manage-api)
 
-**Notes:**
-
-- Use "REQUESTY_KEY" as the environment variable for your API key in your `.env` file.
-
 ```yaml filename="librechat.yaml
-# Requesty Example
-    - name: Requesty
-      apiKey: ${REQUESTY_KEY}
-      baseURL: https://router.requesty.ai/v1
+    # RequestyAI Example
+    - name: 'Requesty'
+      # For `apiKey` and `baseURL`, you can use environment variables that you define.
+      # recommended environment variables:
+      apiKey: '${REQUESTY_API_KEY}'
+      baseURL: 'https://router.requesty.ai/v1'
       models:
-        default:
-          - openai/gpt-4o-mini
+        default: ['openai/gpt-4o']
         fetch: true
       titleConvo: true
-      titleModel: openai/gpt-4o-mini
-      summarize: false
-      summaryModel: openai/gpt-4o-mini
-      modelDisplayLabel: Requesty
+      titleModel: 'openai/gpt-4o'
+      # Recommended: Drop the stop parameter from the request as models use a variety of stop tokens.
+      dropParams: ['stop']
+      modelDisplayLabel: 'Requesty'
       iconURL: https://app.requesty.ai/_next/image?url=%2Ffavicon.ico&w=96&q=75
 ```


### PR DESCRIPTION
Introduce an example configuration for Requesty.ai, including recommended environment variables and an updated icon URL.

https://github.com/danny-avila/LibreChat/pull/6617