### PR TITLE
🦙 docs: ollama.mdx

### DIFF
--- a/pages/docs/configuration/librechat_yaml/ai_endpoints/ollama.mdx
+++ b/pages/docs/configuration/librechat_yaml/ai_endpoints/ollama.mdx
@@ -20,7 +20,7 @@ description: Example configuration for Ollama
     - name: "Ollama"
       apiKey: "ollama"
       # use 'host.docker.internal' instead of localhost if running LibreChat in a docker container
-      baseURL: "http://localhost:11434/v1/chat/completions" 
+      baseURL: "http://localhost:11434/v1/" 
       models:
         default: [
           "llama2",


### PR DESCRIPTION
The baseURL option should not have the /chat/completions part for Ollama models to work with Agents.