### PR TITLE
docs: Document AWS_ENDPOINT_URL for S3 configuration

### DIFF
--- a/pages/docs/configuration/cdn/s3.mdx
+++ b/pages/docs/configuration/cdn/s3.mdx
@@ -91,12 +91,14 @@ AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_REGION=your_selected_region
 AWS_BUCKET_NAME=your_bucket_name
+AWS_ENDPOINT_URL=your_endpoint_url
 ```
 
 - **AWS_ACCESS_KEY_ID:** Your IAM user's access key.
 - **AWS_SECRET_ACCESS_KEY:** Your IAM user's secret key.
 - **AWS_REGION:** The AWS region where your S3 bucket is located.
 - **AWS_BUCKET_NAME:** The name of the S3 bucket you created.
+- **AWS_ENDPOINT_URL:** (Optional) The custom AWS endpoint URL
 
 If you are using **IRSA** on Kubernetes, you do **not** need to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your environment. The AWS SDK will automatically obtain temporary credentials via the service account assigned to your pod. Ensure that `AWS_REGION` and `AWS_BUCKET_NAME` are still provided.
 


### PR DESCRIPTION
This commit updates the documentation related to S3 storage configuration to include the `AWS_ENDPOINT_URL` environment variable. This variable was introduced in PR [#6431](https://github.com/danny-avila/LibreChat/pull/6431) to allow users to specify a custom endpoint URL for S3 connections, but the documentation is not update.

The changes include:
- Adding a description for `AWS_ENDPOINT_URL`, clarifying its purpose and indicating that it's optional.