### PR TITLE
docs: clarify where agent admin controls are located, instruct on how to add admins

### DIFF
--- a/pages/docs/features/agents.mdx
+++ b/pages/docs/features/agents.mdx
@@ -251,12 +251,21 @@ Files uploaded as "File Context" are processed using OCR to extract text, which 
 
 ### Administrator Controls
 
-Administrators have access to global permission settings:
+Administrators have access to global permission settings within the agent builder UI:
 
 - Enable/disable agent sharing across all users
 - Control agent usage permissions
 - Manage agent creation rights
 - Configure platform-wide settings
+
+The first account created for your instance is an administrator. If you need to add an additional administrator, you may [access MongoDB](/docs/configuration/mongodb/mongodb_auth) and update the user's profile:
+
+```
+db.users.updateOne(
+  { email: 'USER_EMAIL_ADDRESS' },
+  { $set: { role: 'ADMIN' } }
+)
+```
 
 The use of agents for all users can also be disabled via config, [more info](/docs/configuration/librechat_yaml/object_structure/interface).
 


### PR DESCRIPTION
I found myself hunting for information on how to share agents, which lead me to realize I had been operating with an inactive administrator account since initial installation. Since this is the first time many users will need admin rights within the LibreChat web UI, it would be useful to instruct them on how to make it work and add additional admins, as well as specifically where the controls are located.