### PR TITLE
docs: Corrected example for TRUST_PROXY

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -52,7 +52,7 @@ Refer to [Express.js - trust proxy](https://expressjs.com/en/guide/behind-proxie
 
 <OptionTable
   options={[
-    ['TRUST_PROXY', 'number', 'Specifies the number of hops.', 'HOST=1'],
+    ['TRUST_PROXY', 'number', 'Specifies the number of hops.', 'TRUST_PROXY=1'],
   ]}
 />
 


### PR DESCRIPTION
The example for TRUST_PROXY was using HOST, apparently an older version?