### PR TITLE
docs: Add documentation for MCP Streamable HTTP transport

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -337,10 +337,11 @@ see: [Model Specs Object Structure](/docs/configuration/librechat_yaml/object_st
 - **Notes**:
   - Initialization happens at startup, and the app must be restarted for changes to take effect.
   - The `<serverName>` is a unique identifier for each MCP server configuration.
-  - Each MCP server can be configured using one of three connection types:
+  - Each MCP server can be configured using one of four connection types:
     - `stdio`
     - `websocket`
     - `sse`
+    - `streamable-http`
   - The `type` field specifies the connection type to the MCP server.
   - If `type` is omitted, it defaults based on the presence and format of `url` or `command`:
     - If `url` is specified and starts with `http` or `https`, `type` defaults to `sse`.
@@ -382,6 +383,12 @@ mcpServers:
       - -y
       - "mcp-obsidian"
       - /path/to/obsidian/vault
+  streamable-http-example:
+    type: streamable-http
+    url: https://example.com/mcp
+    headers:
+      Authorization: "Bearer ${API_TOKEN}"
+    timeout: 30000
 ```
 
 see: [MCP Servers Object Structure](/docs/configuration/librechat_yaml/object_structure/mcp_servers)

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -34,6 +34,9 @@ mcpServers:
       - -y
       - "mcp-obsidian"
       - /path/to/obsidian/vault
+  streamable-http-server:
+    type: streamable-http
+    url: https://example.com/api/
 ```
 
 ## `<serverName>`
@@ -49,11 +52,11 @@ mcpServers:
 
 <OptionTable
   options={[
-    ['type', 'String', 'Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, or `"sse"`. If omitted, it defaults based on the presence and format of `url` or `command`.', 'type: "stdio"'],
+    ['type', 'String', 'Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, `"streamable-http"`, or `"sse"`. If omitted, it defaults based on the presence and format of `url` or `command`.', 'type: "stdio"'],
     ['command', 'String', '(For `stdio` type) The command or executable to run to start the MCP server.', 'command: "npx"'],
     ['args', 'Array of Strings', '(For `stdio` type) Command line arguments to pass to the `command`.', 'args: ["-y", "@modelcontextprotocol/server-puppeteer"]'],
-    ['url', 'String', '(For `websocket` or `sse` type) The URL to connect to the MCP server.', 'url: "http://localhost:3001/sse"'],
-    ['headers', 'Object', '(Optional, `sse` type only) Custom headers to send with the SSE request. Supports user ID substitution with `{{LIBRECHAT_USER_ID}}` and environment variables with `${ENV_VAR}`.', 'headers:\n  X-User-ID: "{{LIBRECHAT_USER_ID}}"\n  X-API-Key: "${SOME_API_KEY}"'],
+    ['url', 'String', '(For `websocket`, `streamable-http`, or `sse` type) The URL to connect to the MCP server.', 'url: "http://localhost:3001/sse"'],
+    ['headers', 'Object', '(Optional, for `sse` and `streamable-http` types) Custom headers to send with the request. Supports user ID substitution with `{{LIBRECHAT_USER_ID}}` and environment variables with `${ENV_VAR}`.', 'headers:\n  X-User-ID: "{{LIBRECHAT_USER_ID}}"\n  X-API-Key: "${SOME_API_KEY}"'],
     ['iconPath', 'String', '(Optional) Defines the tool\'s display icon shown in the tool selection dialog.', 'iconPath: "/path/to/icon.svg"'],
     ['chatMenu', 'Boolean', '(Optional) When set to `false`, excludes the MCP server from the chatarea dropdown (MCPSelect) for quick and easy access. Defaults to `true`.', 'chatMenu: false'],
     ['timeout', 'Number', '(Optional) Timeout in milliseconds for MCP server requests. Determines how long to wait for a response for tool requests.', 'timeout: 30000'],
@@ -66,7 +69,7 @@ mcpServers:
 #### `type`
 
 - **Type:** String
-- **Description:** Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, or `"sse"`.
+- **Description:** Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, `"streamable-http"`, or `"sse"`.
 - **Default Value:** Determined based on the presence and format of `url` or `command`.
 
 #### `command`
@@ -82,15 +85,16 @@ mcpServers:
 #### `url`
 
 - **Type:** String
-- **Description:** (For `websocket` or `sse` type) The URL to connect to the MCP server.
+- **Description:** (For `websocket`, `streamable-http`, or `sse` type) The URL to connect to the MCP server.
 - **Notes:**
   - For `sse` type, the URL must start with `http://` or `https://`.
+  - For `streamable-http` type, the URL must start with `http://` or `https://`.
   - For `websocket` type, the URL must start with `ws://` or `wss://`.
 
 #### `headers`
 
-- **Type:** Object (Optional, `sse` type only)
-- **Description:** Custom headers to send with the SSE request.
+- **Type:** Object (Optional, for `sse` and `streamable-http` types)
+- **Description:** Custom headers to send with the request.
 - **Special Values:**
   - `{{LIBRECHAT_USER_ID}}`: Will be replaced with the current user's ID, enabling multi-user support.
   - `${ENV_VAR}`: Will be replaced with the value of the environment variable `ENV_VAR`.
@@ -147,6 +151,7 @@ mcpServers:
   - **`stdio`**: Starts an MCP server as a child process and communicates via standard input/output.
   - **`websocket`**: Connects to an external MCP server via WebSocket.
   - **`sse`**: Connects to an external MCP server via Server-Sent Events (SSE).
+  - **`streamable-http`**: Connects to an external MCP server via HTTP with support for streaming responses.
 
 ## Examples
 
@@ -183,6 +188,17 @@ myWebSocketServer:
   url: ws://localhost:8080
 ```
 
+### `streamable-http` MCP Server
+
+```yaml filename="streamable-http MCP Server"
+streamable-http-server:
+  type: streamable-http
+  url: https://example.com/api/
+  headers:
+    X-User-ID: "{{LIBRECHAT_USER_ID}}"
+    X-API-Key: "${SOME_API_KEY}"
+```
+
 ### MCP Server with Custom Icon
 
 ```yaml filename="MCP Server with Icon"
@@ -217,13 +233,14 @@ The `mcpServers` configurations allow LibreChat to dynamically interact with var
   - User connections are monitored for activity and will be disconnected after 15 minutes of inactivity.
 - **Environment Variables:**
   - **In `env` (for `stdio` type):** Useful for setting up specific runtime environments or configurations required by the MCP server process.
-  - **In `headers` (for `sse` type):** Use `${ENV_VAR}` syntax to reference environment variables in header values.
+  - **In `headers` (for `sse` and `streamable-http` types):** Use `${ENV_VAR}` syntax to reference environment variables in header values.
 - **Error Handling (`stderr`):**
   - Configuring `stderr` allows you to manage how error messages from the MCP server process are handled. The default `"inherit"` means that the errors will be printed to the parent process's `stderr`.
 
 ## References
 
 - [Model Context Protocol (MCP) Documentation](https://github.com/modelcontextprotocol)
+- [MCP Transports Specification](https://modelcontextprotocol.io/specification/draft/basic/transports)
 - [Node.js child_process.spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options)
 
 ---

--- a/pages/docs/features/agents.mdx
+++ b/pages/docs/features/agents.mdx
@@ -210,6 +210,13 @@ MCP servers can be configured to use different transport mechanisms:
 - More scalable transport mechanism for multi-user environments
 - Enhanced multi-user support with user-specific connections
 
+**Streamable HTTP Servers**
+- Uses HTTP POST for sending messages and supports streaming responses
+- Operates as an independent process that can handle multiple client connections
+- Supports both basic requests and streaming via Server-Sent Events (SSE)
+- More performant alternative to the legacy HTTP+SSE transport
+- Supports proper multi-user server configurations
+
 **Multi-User Features**
 - User-level and app-level connections with proper establishment and cleanup
 - MCP Servers can distinguish connections by session ID
@@ -226,6 +233,13 @@ mcpServers:
     headers:
       X-User-ID: "{{LIBRECHAT_USER_ID}}"
       X-API-Key: "${SOME_API_KEY}"
+  
+  streamable-http-example:
+    type: streamable-http
+    url: https://example.com/mcp/
+    headers:
+      X-User-ID: "{{LIBRECHAT_USER_ID}}"
+      Authorization: "Bearer ${API_TOKEN}"
 ```
 
 LibreChat is at the forefront of implementing flexible, scalable MCP server integrations to support diverse usage scenarios.


### PR DESCRIPTION
- Added streamable-http to the list of valid connection types
- Added complete configuration examples in the documentation
- Updated type specifications in the YAML configuration schema