### PR TITLE
feat: Add multi-language support for Terms of Service documentation

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/docs/configuration/_meta.ts
+++ b/pages/docs/configuration/_meta.ts
@@ -9,5 +9,6 @@ export default {
   cdn: 'CDN',
   azure: 'Azure OpenAI',
   docker_override: 'Docker Override',
+  tos: 'Terms of Service - i18n',
   mod_system: 'Automated Moderation',
 }

--- a/pages/docs/configuration/tos.mdx
+++ b/pages/docs/configuration/tos.mdx
@@ -1,0 +1,138 @@
+---
+title: Terms of Service - i18n
+description: Terms of Service for LibreChat in multiple languages
+---
+
+# Terms of Service - i18n
+
+## Introduction
+
+LibreChat now supports multi-language functionality for the **Terms of Service**. This guide will help you configure multi-language support for your LibreChat instance, allowing users to view Terms of Service in their preferred language.
+
+### Key Features
+
+* Display Terms of Service in multiple languages.
+* Dynamic language switching based on user preferences.
+* Seamless integration with existing LibreChat functionality.
+
+
+## Prerequisites
+
+* You must have a working instance of LibreChat.
+* The latest version of LibreChat that includes multi-language support.
+* Docker installed (if using a Docker-based setup).
+
+
+## Step 1: Preparing Your Environment
+
+### Updating LibreChat
+
+Make sure your LibreChat instance is up to date. Pull the latest changes from the LibreChat repository:
+
+```bash
+git pull origin main
+```
+
+If using Docker, make sure to update your Docker images:
+
+```bash
+docker-compose pull
+docker-compose up -d
+```
+
+
+## Step 2: Multi-Language Configuration
+
+### 1. Adding Terms of Service Files
+
+The multi-language support requires Markdown files for each language. These files are stored in the `terms` directory.
+
+The following files are currently supported:
+
+* `terms_en.md` (English)
+* `terms_de.md` (German)
+* `terms_fr.md` (French)
+
+To add a new language:
+
+1. Create a new Markdown file in the `terms` directory, named as `terms_<language-code>.md`.
+2. Populate the file with the translated Terms of Service.
+3. **Update the Language Mapping** in `client/src/utils/termsContent.ts`:
+
+* Add an import statement for the new language:
+
+```javascript
+import terms_nl from '../../../terms/terms_nl.md?raw';
+```
+* Add the new language to the `markdownMap` object:
+
+```javascript
+const markdownMap: Record<string, string> = {
+  en: terms_en,
+  de: terms_de,
+  fr: terms_fr,
+  nl: terms_nl // Added Dutch language support
+};
+```
+
+    <Callout type="warning" title="Important" emoji="⚠️">
+        The file name should follow the format: `terms_<language-code>.md`, and the `markdownMap` object must be updated with the new language for it to work.
+    </Callout>
+
+
+### 2. Updating Docker Configuration
+
+Make sure your Docker setup mounts the `terms` directory:
+
+```yaml
+services:
+  client:
+    volumes:
+      - ./terms:/app/terms
+```
+
+Restart the Docker containers to apply the changes:
+
+```bash
+docker-compose up -d
+```
+
+
+## Step 3: Verifying the Setup
+
+After configuring the multi-language support, follow these steps to verify:
+
+1. Access LibreChat from a browser.
+2. Open the **Terms of Service** modal.
+3. Change the language in the UI.
+4. Verify that the Terms of Service content changes accordingly.
+
+
+
+## Troubleshooting
+
+### Terms Not Changing Language
+
+* Ensure that the markdown files are correctly named and placed in the `terms` directory.
+* Verify the language codes match the file names (e.g., `terms_de.md` for German).
+* Make sure the new language is added to the `markdownMap` in `client/src/utils/termsContent.ts`.
+* Restart the Docker containers after making changes.
+
+### Missing Language Support
+
+* Verify that the file exists in the `terms` directory.
+* Ensure that you have imported and added the language in the `markdownMap` object in `termsContent.ts`.
+
+---
+
+## Updating Terms of Service
+
+To update a language's Terms of Service:
+
+1. Edit the corresponding markdown file in the `terms` directory.
+2. Restart the Docker containers:
+
+```bash
+docker-compose up -d
+```
+


### PR DESCRIPTION
This pull request introduces multi-language support for the **Terms of Service** in LibreChat. It includes updates to the configuration metadata and a detailed guide for setting up and managing multi-language Terms of Service. The most significant changes are outlined below.

### Configuration Updates:
* Added a new entry for "Terms of Service - i18n" in the `_meta.ts` configuration file to support the new feature in the documentation.

### Documentation for Multi-Language Terms of Service:
* Created a new `tos.mdx` file that provides a comprehensive guide for configuring and managing multi-language Terms of Service. This includes instructions for preparing the environment, adding language-specific Markdown files, updating Docker configurations, and verifying the setup.