### PR TITLE
👁️ docs: update OCR documentation configuration to include azure_mist…

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/ocr.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/ocr.mdx
@@ -14,11 +14,11 @@ There are 4 main fields under `ocr`:
 **Notes:**
 
 - If using the Mistral OCR API, you don't need to edit your `librechat.yaml` file.
-    - You only need the following environment variables to get started: `OCR_API_KEY` and `OCR_BASEURL`.
+- You only need the following environment variables to get started: `OCR_API_KEY` and `OCR_BASEURL`.
 - OCR functionality allows the application to extract text from images, which can then be processed by AI models.
 - The default strategy is `mistral_ocr`, which uses Mistral's OCR capabilities.
-- You can also configure a custom OCR service by setting the strategy to `custom_ocr`.
-- If using the default Mistral OCR, you may optionally specify a specific Mistral model to use.
+- Alternatively, set the strategy to `azure_mistral_ocr` to use an Azure-hosted Mistral model, or to `custom_ocr` to use a custom OCR service.
+- If using the default Mistral OCR or Azure-hosted Mistral OCR, you may optionally specify a specific Mistral model to use.
 - Environment variable parsing is supported for `apiKey`, `baseURL`, and `mistralModel` parameters.
 - A `user_provided` strategy option is planned for future releases but is not yet implemented.
 
@@ -38,6 +38,16 @@ ocr:
   apiKey: "your-custom-ocr-api-key"
   baseURL: "https://your-custom-ocr-service.com/api"
   strategy: "custom_ocr"
+```
+
+Example with azure mistral OCR:
+
+```yaml filename="ocr with azure mistral OCR"
+ocr:
+  mistralModel: "mistral-ocr-2503"  # Specify the Azure Mistral model, mistral-ocr-2503 is an example"
+  apiKey: "${OCR_API_KEY}"        # Optional: Defaults to OCR_API_KEY env variable
+  baseURL: "https://your-azure-mistral-ocr-endpoint.com/v1"  # Optional: Defaults to OCR_BASEURL env variable, or Mistral's API if no variable set
+  strategy: "azure_mistral_ocr"
 ```
 
 ## mistralModel
@@ -83,7 +93,7 @@ ocr:
 
 <OptionTable
   options={[
-    ['strategy', 'String', 'The OCR strategy to use.', 'Determines which OCR service to use. Options are "mistral_ocr" or "custom_ocr". Defaults to "mistral_ocr".'],
+    ['strategy', 'String', 'The OCR strategy to use.', 'Determines which OCR service to use. Options are "mistral_ocr", "custom_ocr" or "azure_mistral_ocr". Defaults to "mistral_ocr".'],
   ]}
 />
 
@@ -95,4 +105,5 @@ ocr:
 **Available Strategies:**
 
 - `mistral_ocr`: Uses Mistral's OCR capabilities.
+- `azure_mistral_ocr`: Uses an Azure-hosted Mistral model for OCR.
 - `custom_ocr`: Uses a custom OCR service specified by the baseURL.


### PR DESCRIPTION
## Update documentation to support Azure Mistral OCR strategy
This pull request updates the documentation to reflect the added azure_mistral_ocr strategy from PR https://github.com/danny-avila/LibreChat/pull/7743, introduced to support Mistral OCR endpoints hosted on Azure.