### PR TITLE
docs: add clientSideImageResize configuration documentation

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -147,8 +147,61 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
     ['endpoints', 'Record/Object', 'Specifies file handling configurations for individual endpoints, allowing customization per endpoint basis.', ''],
     ['serverFileSizeLimit', 'Number', 'The maximum file size (in MB) that the server will accept. Applies globally across all endpoints unless overridden by endpoint-specific settings.', ''],
     ['avatarSizeLimit', 'Number', 'Maximum size (in MB) for user avatar images.', ''],
+    ['clientSideImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
   ]}
 />
+
+## clientSideImageResize
+
+**Key:**
+<OptionTable
+  options={[
+    ['clientSideImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
+  ]}
+/>
+
+**Subkeys:**
+<OptionTable
+  options={[
+    ['enabled', 'Boolean', 'Enables or disables client-side image resizing functionality. Default: false.', 'enabled: true'],
+    ['maxWidth', 'Number', 'Maximum width in pixels for resized images. Images wider than this will be resized. Default: 1920.', 'maxWidth: 1024'],
+    ['maxHeight', 'Number', 'Maximum height in pixels for resized images. Images taller than this will be resized. Default: 1080.', 'maxHeight: 768'],
+    ['quality', 'Number', 'JPEG compression quality (0.1 to 1.0). Higher values mean better quality but larger file sizes. Default: 0.8.', 'quality: 0.9'],
+    ['compressFormat', 'String', 'Output format for compressed images. Options: "jpeg", "webp". Default: "jpeg".', 'compressFormat: "webp"'],
+  ]}
+/>
+
+**Description:**
+
+The `clientSideImageResize` configuration enables automatic client-side image resizing before upload. This feature helps:
+
+- **Prevent upload failures** due to large image files exceeding server limits
+- **Reduce bandwidth usage** by compressing images before transmission  
+- **Improve upload performance** with smaller file sizes
+- **Maintain image quality** while optimizing file size
+
+When enabled, images that exceed the specified `maxWidth` or `maxHeight` dimensions are automatically resized on the client side before being uploaded to the server. The resizing maintains the original aspect ratio while ensuring the image fits within the specified bounds.
+
+**Example:**
+```yaml filename="clientSideImageResize"
+fileConfig:
+  clientSideImageResize:
+    enabled: true
+    maxWidth: 1920
+    maxHeight: 1080
+    quality: 0.8
+    compressFormat: "jpeg"
+```
+
+**Notes:**
+
+- Only applies to image files (JPEG, PNG, WebP, etc.)
+- Resizing occurs automatically when images exceed the specified dimensions
+- Original aspect ratio is preserved during resizing
+- The feature works with all supported image upload endpoints
+- HEIC/HEIF images are automatically converted to JPEG format before resizing
+- Quality setting only applies to JPEG and WebP formats
+- Setting quality too low (< 0.5) may result in noticeable image degradation
 
 see: [File Config Object Structure](/docs/configuration/librechat_yaml/object_structure/file_config)
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the new `clientSideImageResize` configuration feature in LibreChat. This feature enables automatic client-side image resizing before upload to optimize file handling and prevent upload errors.

## Changes Made

### 📝 Documentation Updates

- **Added `clientSideImageResize` to fileConfig subkeys table** - Listed as a new configuration option under the main `fileConfig` section
- **Dedicated section for `clientSideImageResize`** - Complete documentation with:
  - Key definition and purpose
  - Comprehensive subkeys table documenting all 5 configuration options:
    - `enabled` - Boolean to enable/disable the feature
    - `maxWidth` - Maximum width in pixels (default: 1920)
    - `maxHeight` - Maximum height in pixels (default: 1080)
    - `quality` - JPEG compression quality 0.1-1.0 (default: 0.8)
    - `compressFormat` - Output format "jpeg" or "webp" (default: "jpeg")
  - Detailed description explaining benefits and functionality
  - Complete YAML configuration example
  - Important notes and considerations
