### PR TITLE
📚 docs: clarify HELP_AND_FAQ_URL disable option

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -1174,7 +1174,7 @@ See: **[Firebase CDN Configuration](/docs/configuration/cdn/firebase)**
 
 <OptionTable
   options={[
-    ['HELP_AND_FAQ_URL', 'string', 'Help and FAQ URL. If empty or commented, the button is enabled.','HELP_AND_FAQ_URL=https://librechat.ai'],
+    ['HELP_AND_FAQ_URL', 'string', 'Help and FAQ URL. If empty or commented, the button is enabled. To disable the Help and FAQ button, set to "/".','HELP_AND_FAQ_URL=https://librechat.ai'],
   ]}
 />
 


### PR DESCRIPTION
Added documentation to clarify that setting HELP_AND_FAQ_URL to `/` will hide the Help & FAQ menu item in the interface.