### PR TITLE
📚 docs: Add documentation for `ENABLE_IMAGE_OUTPUT_GZIP_SCAN` environment variable

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -79,6 +79,7 @@ To securely store credentials, you need a fixed key and IV. You can set them her
     ['STATIC_CACHE_MAX_AGE', 'string', 'Cache-Control max-age in seconds','STATIC_CACHE_MAX_AGE=172800'],
     ['STATIC_CACHE_S_MAX_AGE', 'string', 'Cache-Control s-maxage in seconds for shared caches (CDNs and proxies)','STATIC_CACHE_S_MAX_AGE="86400"'],
     ['DISABLE_COMPRESSION', 'boolean', 'Disables compression for static files.','DISABLE_COMPRESSION=false'],
+    ['ENABLE_IMAGE_OUTPUT_GZIP_SCAN', 'boolean', 'Enables serving gzipped versions of uploaded images if present in the same folder.','ENABLE_IMAGE_OUTPUT_GZIP_SCAN=true'],
   ]}
 />
 
@@ -89,6 +90,7 @@ Sets the [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Heade
 * Uncomment `STATIC_CACHE_MAX_AGE` to change the local `max-age` for static files. By default this is set to 2 days (172800 seconds).
 * Uncomment `STATIC_CACHE_S_MAX_AGE` to set the `s-maxage` for shared caches (CDNs and proxies). By default this is set to 1 day (86400 seconds).
 * Uncomment `DISABLE_COMPRESSION` to disable compression for static files. By default, compression is enabled.
+* Uncomment `ENABLE_IMAGE_OUTPUT_GZIP_SCAN` to enable scanning and serving of gzipped version of images if they have been pre-compressed in the same folder, with the same name and a .gz extension. By default, gzip scan for uploaded images is disabled.
 
 <Callout type="warning" title="Warning">
 - This only affects static files served by the API server and is not applicable to _Firebase_, _NGINX_, or any other configurations.


### PR DESCRIPTION
Documentation for the new environment variable added in
- https://github.com/danny-avila/LibreChat/pull/8307