### PR TITLE
Update nginx.mdx

### DIFF
--- a/pages/docs/remote/nginx.mdx
+++ b/pages/docs/remote/nginx.mdx
@@ -46,7 +46,20 @@ Nginx acts as a reverse proxy, forwarding client requests to your LibreChat appl
 
 The `deploy-compose.yml` file includes an Nginx container and uses the `client/nginx.conf` file for Nginx configuration. However, since `sudo certbot --nginx` extracts the certificate to the host configuration, you need to duplicate the certificate to the Docker containers.
 
-1. Update `client/nginx.conf` with your domain and certificate paths.
+1. Update `client/nginx.conf` with your domain and certificate paths. They are in `/etc/letsencrypt/live/<your-domain>/` directory on your host.
+
+```nginx
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    # ...
+    ssl_certificate     /etc/letsencrypt/live/<your-domain>/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/<your-domain>/privkey.pem;
+    # ...
+    server_name <your-domain>;
+    # ...
+```
+
 2. Update `deploy-compose.yml` in the `client` section to mount the certificate files from the host:
 
 ```yaml
@@ -62,7 +75,8 @@ client:
 
 3. Stop any running instance: `npm run stop:deployed`
 4. Commit the changes to a new Git branch.
-5. Rebase the deployed instance: `npm run rebase:deployed`
+5. Stop nginx on your host, which could be started by `sudo certbot --nginx` command.
+6. Rebase the deployed instance: `npm run rebase:deployed`
 
 ### Option B: Host-based Deployment without Docker
 


### PR DESCRIPTION
The document about using nginx + certbot is confusing.
I updated how to configure nginx in container with correct key path created by certbot.
Also, I need to stop the host nginx, after certbot started it on port 80/443. Otherwise the nginx container will not start.