### PR TITLE
📚 docs: Add MCP reinitialization instructions and document new 'startup' property for MCP servers

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -76,6 +76,7 @@ mcpServers:
     ['env', 'Object', '(Optional, `stdio` type only) Environment variables to use when spawning the process.', 'env:\n  NODE_ENV: "production"'],
     ['stderr', 'String or Stream or Number', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Defaults to `"inherit"`.', 'stderr: "inherit"'],
     ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
+    ['startup', 'Boolean', '(Optional) When set to false, this MCP server will not be connected at application startup.', 'startup: false'],
   ]}
 />
 
@@ -247,6 +248,20 @@ mcpServers:
   headers:
     X-Auth-Token: "{{MY_SERVICE_API_KEY}}"
     X-Some-Other-Config: "{{SOME_OTHER_VAR}}"
+  ```
+
+#### `startup`
+
+- **Type:** Boolean (Optional)
+- **Description:** When set to `false`, this MCP server will not be connected at application startup. This is useful for servers that require user input or configuration before connecting, or for cases where you want to control when the server is initialized.
+- **Default Value:** `true`
+- **Example:**
+  ```yaml
+  mcpServers:
+    my-mcp-server:
+      type: streamable-http
+      url: "https://api.example.com/mcp/"
+      startup: false
   ```
 
 ### Notes

--- a/pages/docs/features/mcp.mdx
+++ b/pages/docs/features/mcp.mdx
@@ -215,6 +215,32 @@ Users can configure these credentials:
 - **From Chat Area**: Click the settings icon next to configurable MCP servers in the tool selection dropdown
 - **From MCP Settings Panel**: Access "MCP Settings" in the right panel to manage credentials for all configured servers
 
+
+#### Reinitializing MCP Servers with User Credentials
+
+For MCP servers that require user-specific credentials before they can be used (e.g., `PAT_TOKEN`'s in [GitHub’s official MCP server](https://github.com/github/github-mcp-server)), LibreChat allows users to provide these credentials and then reinitialize the MCP server from within the UI without restarting the whole application:
+
+1. When you select an MCP that uses `customUserVars`, you will be able to **Save** or **Revoke** a `customUserVar`'s value for the selected MCP server from within the MCP Panel. 
+2. After saving a value for a `customUserVar`, click the reinitialize button (an icon with circular arrows next to each server name in the MCP Panel).
+3. LibreChat will attempt to connect to the server using your provided credentials and notify you with a toast whether the reinitialization process has succeeded or failed.
+
+> _Tip: If you know a server will require credentials not available at first startup, you can add `startup: false` to its configuration. This tells LibreChat to not attempt to connect to that server until it is manually reinitialized in the UI._
+
+**Example:**
+```yaml
+mcpServers:
+  github-mcp:
+    type: streamable-http
+    url: "https://api.githubcopilot.com/mcp/"
+    headers:
+      Authorization: "{{PAT_TOKEN}}"
+    customUserVars:
+      PAT_TOKEN:
+        title: "GitHub PAT Token"
+        description: "GitHub Personal Access Token"
+    startup: false
+```
+
 ### OAuth Authentication
 
 LibreChat supports OAuth authentication for MCP servers, following Anthropic's recommendation for secure MCP connections. OAuth provides a standardized, secure way to authenticate without storing long-lived credentials.


### PR DESCRIPTION
- Added `startup` field to MCP server configuration documentation, explaining how users can now control server connection at application startup.
- Added instructions for reinitializing MCP servers with user credentials from within the UI.