### PR TITLE
📚 docs: Update Preset Fields and Query Params

### DIFF
--- a/components/changelog/content/config_v1.2.8.mdx
+++ b/components/changelog/content/config_v1.2.8.mdx
@@ -23,3 +23,4 @@
 - Added user placeholder variables support to Custom Endpoint Headers:
   - Users can now use `{{LIBRECHAT_USER_ID}}`, `{{LIBRECHAT_USER_EMAIL}}`, and other user field placeholders in custom endpoint headers
   - See: [Custom Endpoint Object Structure - Headers](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#headers) for details
+- Improved [Model Specs documentation](/docs/configuration/librechat_yaml/object_structure/model_specs) with parameter support updates (disableStreaming, thinking, thinkingBudget, web_search, etc...)

--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -360,7 +360,7 @@ preset:
   ]}
 />
 
-**Default:** `false`
+**Default:** `true`
 
 **Example:**
 ```yaml filename="modelSpecs / list / {spec_item} / preset / resendFiles"
@@ -382,6 +382,8 @@ preset:
     ['imageDetail', 'Enum (eImageDetailSchema)', 'Specifies the level of detail required in image analysis tasks, applicable to models with vision capabilities (OpenAI spec).', ''],
   ]}
 />
+
+**Default:** `"auto"`
 
 **Example:**
 ```yaml filename="modelSpecs / list / {spec_item} / preset / imageDetail"
@@ -710,10 +712,166 @@ preset:
   ]}
 />
 
+**Default:** `true`
+
 **Example:**
 ```yaml
 preset:
   promptCache: true
+```
+
+---
+
+#### reasoning_effort
+
+**Accepted Values:**
+- None
+- Low
+- Medium
+- High
+
+> **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
+
+<OptionTable
+  options={[
+    ['reasoning_effort', 'String', 'Controls the reasoning effort level for the model.', ''],
+  ]}
+/>
+
+**Default:** `"None"`
+
+**Example:**
+```yaml
+preset:
+  reasoning_effort: "low"
+```
+
+---
+
+#### reasoning_summary
+
+**Accepted Values:**
+- None
+- Auto
+- Concise
+- Detailed
+
+> **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
+
+<OptionTable
+  options={[
+    ['reasoning_summary', 'String', 'Sets reasoning summary preferences for the model.', ''],
+  ]}
+/>
+
+**Default:** `"None"`
+
+**Example:**
+```yaml
+preset:
+  reasoning_summary: "detailed"
+```
+
+---
+
+#### useResponsesApi
+
+> **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
+
+<OptionTable
+  options={[
+    ['useResponsesApi', 'Boolean', 'Enables or disables the responses API for the model.', ''],
+  ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml
+preset:
+  useResponsesApi: true
+```
+
+---
+
+#### web_search
+
+> **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like), `google`, `anthropic`
+
+<OptionTable
+  options={[
+    ['web_search', 'Boolean', 'Enables or disables web search functionality for the model.', ''],
+  ]}
+/>
+
+**Default:** `false`
+
+**Note:** For Google endpoints, this parameter appears as `Grounding with Google Search` in the actual panel but controls `web_search` in the implementation.
+
+**Example:**
+```yaml
+preset:
+  web_search: true
+```
+
+---
+
+#### disableStreaming
+
+> **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
+
+<OptionTable
+  options={[
+    ['disableStreaming', 'Boolean', 'Disables streaming responses from the model.', ''],
+  ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml
+preset:
+  disableStreaming: true
+```
+
+---
+
+#### thinkingBudget
+
+> **Supported by:** `google`, `anthropic`, `bedrock` (Anthropic models)
+
+<OptionTable
+  options={[
+    ['thinkingBudget', 'Number or String', 'Controls the number of thinking tokens the model can use for internal reasoning. Larger budgets can improve response quality for complex problems.', ''],
+  ]}
+/>
+
+**Default:** `"Auto (-1)"` (Google), `2000` (Anthropic, Bedrock (Anthropic models))
+
+**Example:**
+```yaml
+preset:
+  thinkingBudget: "2000"
+```
+
+---
+
+#### thinking
+
+> **Supported by:** `google`, `anthropic`, `bedrock` (Anthropic models)
+
+<OptionTable
+  options={[
+    ['thinking', 'Boolean', 'Indicates whether the model should spend time thinking before generating a response.', ''],
+  ]}
+/>
+
+**Default:** `true`
+
+**Example:**
+```yaml
+preset:
+  thinking: true
 ```
 
 ---

--- a/pages/docs/features/url_query.mdx
+++ b/pages/docs/features/url_query.mdx
@@ -160,14 +160,14 @@ Different endpoints support various parameters:
 
 **OpenAI, Custom, Azure OpenAI:**
 ```bash
-# Note: these should be valid numbers according to the provider's API
+# Note: these should be valid values according to the provider's API
 temperature, presence_penalty, frequency_penalty, stop, top_p, max_tokens,
 reasoning_effort, reasoning_summary, useResponsesApi, web_search, disableStreaming
 ```
 
 **Google, Anthropic:**
 ```bash
-# Note: these should be valid numbers according to the provider's API
+# Note: these should be valid values according to the provider's API
 topP, topK, maxOutputTokens, thinking, thinkingBudget, web_search
 ```
 

--- a/pages/docs/features/url_query.mdx
+++ b/pages/docs/features/url_query.mdx
@@ -161,13 +161,14 @@ Different endpoints support various parameters:
 **OpenAI, Custom, Azure OpenAI:**
 ```bash
 # Note: these should be valid numbers according to the provider's API
-temperature, presence_penalty, frequency_penalty, stop, top_p, max_tokens
+temperature, presence_penalty, frequency_penalty, stop, top_p, max_tokens,
+reasoning_effort, reasoning_summary, useResponsesApi, web_search, disableStreaming
 ```
 
 **Google, Anthropic:**
 ```bash
 # Note: these should be valid numbers according to the provider's API
-topP, topK, maxOutputTokens
+topP, topK, maxOutputTokens, thinking, thinkingBudget, web_search
 ```
 
 **Anthropic Specific:**


### PR DESCRIPTION
This pull request updates the documentation for newly added fields / toggles in the Parameters Panel.

### Documentation Enhancements:

* Improved the [Model Specs documentation](/docs/configuration/librechat_yaml/object_structure/model_specs) to include updates on parameter support, such as `disableStreaming`, `thinking`, `thinkingBudget`, `web_search`, and others.

### Updates to `preset` Parameters:

* Updated default values for existing parameters in `preset`:
  - Changed the default for `resendFiles` from `false` to `true`.
  - Added a default value of `"auto"` for `imageDetail`.
  - Set the default for `thinking` to `true`.

* Added new parameters to the `preset` configuration:
  - [`reasoning_effort`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Controls the reasoning effort level for the model, with accepted values like `None`, `Low`, `Medium`, and `High`.
  - [`reasoning_summary`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Sets reasoning summary preferences, such as `None`, `Auto`, `Concise`, and `Detailed`.
  - [`useResponsesApi`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Enables or disables the responses API for the model.
  - [`web_search`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Enables or disables web search functionality, with specific notes for Google endpoints.
  - [`disableStreaming`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Disables streaming responses from the model.
  - [`thinkingBudget`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Controls the number of thinking tokens for internal reasoning, with provider-specific defaults.
  - [`thinking`](diffhunk://#diff-b685020308b775b3c8a09bf011506c8d40b6d3f04337ad4bdf008456459780caR725-R878): Indicates whether the model should spend time thinking before generating a response.

### Parameter Support in URL Query:

* Expanded the list of supported parameters for different endpoints in `url_query.mdx`:
  - Added `reasoning_effort`, `reasoning_summary`, `useResponsesApi`, `web_search`, and `disableStreaming` for OpenAI, Custom, and Azure OpenAI endpoints.
  - Added `thinking` and `thinkingBudget` for Google and Anthropic endpoints.