### PR TITLE
docs: add OAuth2 configuration for MCP servers

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -49,6 +49,16 @@ mcpServers:
       MY_SERVICE_API_KEY:
         title: "My Service API Key"
         description: "Enter your personal API key for the service. You can generate one at <a href='https://myservice.example.com/developer/keys' target='_blank'>Service Developer Portal</a>."
+  oauth-example:
+    type: streamable-http
+    url: https://api.example.com/mcp/
+    oauth:
+      authorization_url: https://example.com/oauth/authorize
+      token_url: https://example.com/oauth/token
+      client_id: your_client_id
+      client_secret: your_client_secret
+      redirect_uri: http://localhost:3080/oauth/callback
+      scope: "read execute"
 ```
 
 ## `<serverName>`
@@ -77,6 +87,7 @@ mcpServers:
     ['env', 'Object', '(Optional, `stdio` type only) Environment variables to use when spawning the process.', 'env:\n  NODE_ENV: "production"'],
     ['stderr', 'String or Stream or Number', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Defaults to `"inherit"`.', 'stderr: "inherit"'],
     ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
+    ['oauth', 'Object', '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.', 'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"'],
     ['startup', 'Boolean', '(Optional) When set to false, this MCP server will not be connected at application startup.', 'startup: false'],
   ]}
 />
@@ -251,6 +262,37 @@ mcpServers:
     X-Some-Other-Config: "{{SOME_OTHER_VAR}}"
   ```
 
+#### `oauth`
+
+- **Type:** Object (Optional)
+- **Description:** OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow before the MCP server can be used. If no client id & client secret is provided, Dynamic Client Registration (DCR) will be used.
+- **Required Subkeys:**
+  - `authorization_url`: String - The OAuth authorization endpoint URL
+  - `token_url`: String - The OAuth token endpoint URL  
+  - `client_id`: String - OAuth client identifier
+  - `client_secret`: String - OAuth client secret
+  - `redirect_uri`: String - OAuth redirect URI (eg. `http://localhost:3080/oauth/callback`)
+  - `scope`: String - OAuth scopes (space-separated)
+- **Optional Subkeys:**
+  - `grant_types_supported`: Array of Strings - Supported grant types (defaults to `["authorization_code", "refresh_token"]`)
+  - `token_endpoint_auth_methods_supported`: Array of Strings - Supported token endpoint authentication methods (defaults to `["client_secret_basic", "client_secret_post"]`)
+  - `response_types_supported`: Array of Strings - Supported response types (defaults to `["code"]`)
+  - `code_challenge_methods_supported`: Array of Strings - Supported PKCE code challenge methods (defaults to `["S256", "plain"]`)
+- **Example:**
+  ```yaml
+  oauth:
+    authorization_url: https://api.example.com/oauth/authorize
+    token_url: https://api.example.com/oauth/token
+    client_id: your_client_id
+    client_secret: your_client_secret
+    redirect_uri: http://localhost:3080/oauth/callback
+    scope: "read execute"
+    grant_types_supported: ["authorization_code", "refresh_token"]
+    token_endpoint_auth_methods_supported: ["client_secret_post"]
+    response_types_supported: ["code"]
+    code_challenge_methods_supported: ["S256", "plain"]
+  ```
+
 #### `startup`
 
 - **Type:** Boolean (Optional)
@@ -367,6 +409,21 @@ filesystem:
   chatMenu: false  # Exclude from chatarea dropdown
 ```
 
+### MCP Server with OAuth Authentication
+
+```yaml filename="MCP Server with OAuth"
+oauth-api-server:
+  type: streamable-http
+  url: https://api.example.com/mcp/
+  oauth:
+    authorization_url: https://api.example.com/oauth/authorize
+    token_url: https://api.example.com/oauth/token
+    client_id: your_client_id
+    client_secret: your_client_secret
+    redirect_uri: http://localhost:3080/oauth/callback
+    scope: "read execute"
+```
+
 ### MCP Server with Server Instructions
 
 ```yaml filename="MCP Server with Instructions"
@@ -440,6 +497,9 @@ The `mcpServers` configurations allow LibreChat to dynamically interact with var
   - Custom instructions (string values) take precedence over server-provided instructions
   - Multiple MCP servers can each contribute their own instructions to the agent context
   - Instructions are only included when the corresponding MCP server's tools are actually available to the agent
+- **OAuth Authentication:**
+  - OAuth2 flow is supported for secure authentication with MCP servers
+  - Users will be prompted to authenticate via OAuth before the MCP server can be used
 
 ## References
 


### PR DESCRIPTION
- Add OAuth2 authentication configuration options for MCP servers
- Include required and optional OAuth2 parameters
- Add example configuration with OAuth2 setup
- Document Dynamic Client Registration (DCR) support
- Update examples and additional information sections


related to this PR: https://github.com/danny-avila/LibreChat/pull/8691

I compiled to prod before creating the PR