### PR TITLE
📚 docs: Add MeiliSearch synchronization reset instructions

### DIFF
--- a/pages/docs/configuration/meilisearch.mdx
+++ b/pages/docs/configuration/meilisearch.mdx
@@ -67,3 +67,45 @@ If you're running LibreChat in a node cluster, or multi-node setup, and want to 
         ```sh filename=".env"
         MEILI_NO_SYNC=true
         ```
+
+## 9. Resetting MeiliSearch Synchronization
+
+If you encounter issues where MeiliSearch data has been deleted or corrupted, or if LibreChat believes all data has been synchronized when it hasn't (for example, after upgrading MeiliSearch or deleting its data files), you can use the reset sync script to force a full re-synchronization.
+
+This script resets the synchronization flags in MongoDB, which will trigger LibreChat to re-index all conversations and messages into MeiliSearch on the next startup or sync check.
+
+### Running the Reset Script
+
+```bash filename="To reset MeiliSearch synchronization flags, run:"
+# Local Development
+npm run reset-meili-sync
+
+# Docker (default setup)
+docker-compose exec api npm run reset-meili-sync
+
+# Docker (deployment setup)
+docker exec -it LibreChat-API /bin/sh -c "cd .. && npm run reset-meili-sync"
+```
+
+### What the Script Does
+
+1. Resets the `_meiliIndex` flag to `false` for all messages and conversations in MongoDB
+2. Shows you how many documents were reset and the total number of documents to be synced
+3. Provides advanced options for controlling the sync behavior
+
+### When to Use This Script
+
+- After deleting MeiliSearch data files
+- When upgrading MeiliSearch to a new version that requires reindexing
+- If LibreChat shows conversations as "fully synced" but MeiliSearch is missing data
+- After restoring a MongoDB backup without corresponding MeiliSearch data
+
+### Advanced Sync Options
+
+After running the reset script, you can control the sync behavior with these environment variables:
+
+- `MEILI_SYNC_BATCH_SIZE`: Number of documents to sync per batch (default: 100)
+- `MEILI_SYNC_DELAY_MS`: Delay between sync batches in milliseconds (default: 100ms)
+- `MEILI_SYNC_THRESHOLD`: Minimum number of unsynced documents before triggering a sync (default: 1000)
+
+Note: After resetting the sync flags, you'll need to restart LibreChat for the re-synchronization to begin.


### PR DESCRIPTION
- Introduced a new section on resetting MeiliSearch synchronization, detailing when and how to use the reset sync script.
- Provided commands for local development and Docker setups to reset synchronization flags in MongoDB.
- Explained the script's functionality and advanced sync options for better control over the synchronization process.