### PR TITLE
📚 docs: Add OCR, textParsing, and fileTokenLimit configuration documentation

### DIFF
--- a/components/changelog/content/config_v1.2.8.mdx
+++ b/components/changelog/content/config_v1.2.8.mdx
@@ -87,3 +87,17 @@
 
 - Improved [Model Specs documentation](/docs/configuration/librechat_yaml/object_structure/model_specs) with parameter support updates:
   - Added support for `disableStreaming`, `thinking`, `thinkingBudget`, `web_search`, and other parameters
+
+- Added OCR and text parsing separation to `fileConfig`:
+  - Added `ocr` configuration to control which file types use OCR processing
+  - Added `textParsing` configuration to control which file types use direct text extraction
+  - Separate processing paths for visual documents (OCR) versus text files (native parsing)
+  - OCR takes precedence when files match both patterns
+  - Default OCR support: images (JPEG, GIF, PNG, WebP, HEIC, HEIF), PDFs, Office documents, EPUB files
+  - Default text parsing support: all text MIME types and common programming languages
+  - See [File Config Object Structure](/docs/configuration/librechat_yaml/object_structure/file_config) for details
+
+- Added `fileTokenLimit` parameter support for all endpoints:
+  - Allows setting maximum token limits for file processing to control costs and resource usage
+  - Available as URL query parameter and in endpoint configuration panels
+  - Schema validation included but enforcement logic reserved for future implementation

--- a/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -150,6 +150,8 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
     ['serverFileSizeLimit', 'Number', 'The maximum file size (in MB) that the server will accept. Applies globally across all endpoints unless overridden by endpoint-specific settings.', ''],
     ['avatarSizeLimit', 'Number', 'Maximum size (in MB) for user avatar images.', ''],
     ['clientImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
+    ['ocr', 'Object', 'Settings for Optical Character Recognition (OCR) file processing.', ''],
+    ['textParsing', 'Object', 'Settings for direct text file parsing.', ''],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -4,12 +4,14 @@
 
 The `fileConfig` object allows you to configure file handling settings for the application, including size limits and MIME type restrictions. This section provides a detailed breakdown of the `fileConfig` object structure.
 
-There are 4 main fields under `fileConfig`:
+There are 6 main fields under `fileConfig`:
 
   - `endpoints`
   - `serverFileSizeLimit`
   - `avatarSizeLimit`
   - `imageGeneration`
+  - `ocr`
+  - `textParsing`
 
 **Notes:**
 
@@ -54,6 +56,16 @@ fileConfig:
   imageGeneration:
     percentage: 100
     px: 1024
+  ocr:
+    supportedMimeTypes:
+      - "^image/(jpeg|gif|png|webp|heic|heif)$"
+      - "^application/pdf$"
+      - "^application/vnd\\.openxmlformats-officedocument\\.(wordprocessingml\\.document|presentationml\\.presentation|spreadsheetml\\.sheet)$"
+      - "^application/vnd\\.ms-(word|powerpoint|excel)$"
+      - "^application/epub\\+zip$"
+  textParsing:
+    supportedMimeTypes:
+      - "^text/(plain|markdown|csv|json|xml|html|css|javascript|typescript|x-python|x-java|x-csharp|x-php|x-ruby|x-go|x-rust|x-kotlin|x-swift|x-scala|x-perl|x-lua|x-shell|x-sql|x-yaml|x-toml)$"
 ```
 
 ## serverFileSizeLimit
@@ -110,6 +122,70 @@ fileConfig:
     percentage: 100
     px: 1024
 ```
+
+## ocr
+
+<OptionTable
+  options={[
+    ['ocr', 'Object', 'Settings for Optical Character Recognition (OCR) file processing.', 'Configures which file types are processed using OCR.'],
+  ]}
+/>
+
+**Description:** The `ocr` section configures which file types should be processed using OCR functionality for extracting text from visual documents.
+
+### supportedMimeTypes
+
+<OptionTable
+  options={[
+    ['supportedMimeTypes', 'Array of Strings', 'List of MIME type patterns for files that should be processed with OCR.', 'Uses regular expressions to match file types.'],
+  ]}
+/>
+
+**Default:** Images, PDFs, and Office documents
+
+```yaml filename="fileConfig / ocr / supportedMimeTypes"
+fileConfig:
+  ocr:
+    supportedMimeTypes:
+      - "^image/(jpeg|gif|png|webp|heic|heif)$"
+      - "^application/pdf$"
+      - "^application/vnd\\.openxmlformats-officedocument\\.(wordprocessingml\\.document|presentationml\\.presentation|spreadsheetml\\.sheet)$"
+      - "^application/vnd\\.ms-(word|powerpoint|excel)$"
+      - "^application/epub\\+zip$"
+```
+
+## textParsing
+
+<OptionTable
+  options={[
+    ['textParsing', 'Object', 'Settings for direct text file parsing without OCR.', 'Configures which file types are processed as plain text files for direct content extraction.'],
+  ]}
+/>
+
+**Description:** The `textParsing` section configures which file types should be processed using direct text extraction.
+
+### supportedMimeTypes
+
+<OptionTable
+  options={[
+    ['supportedMimeTypes', 'Array of Strings', 'List of MIME type patterns for files that should be parsed as plain text.', 'Uses regular expressions to match file types.'],
+  ]}
+/>
+
+**Default:** All text files and common programming languages
+
+```yaml filename="fileConfig / textParsing / supportedMimeTypes"
+fileConfig:
+  textParsing:
+    supportedMimeTypes:
+      - "^text/(plain|markdown|csv|json|xml|html|css|javascript|typescript|x-python|x-java|x-csharp|x-php|x-ruby|x-go|x-rust|x-kotlin|x-swift|x-scala|x-perl|x-lua|x-shell|x-sql|x-yaml|x-toml)$"
+```
+
+**Notes:**
+- Files matching `textParsing` patterns are processed with simple text extraction
+- Files matching `ocr` patterns are processed with the provided OCR service
+- If a file matches both patterns, OCR takes precedence
+- Files not matching either pattern will not be processed
 
 ## endpoints
 

--- a/pages/docs/features/url_query.mdx
+++ b/pages/docs/features/url_query.mdx
@@ -154,6 +154,7 @@ LibreChat supports a wide range of parameters for fine-tuning your conversation 
   - OpenAI, Custom Endpoints, which are OpenAI-like, and Azure OpenAI, for which this defaults to 'auto'
 - `spec`: Select a specific LibreChat [Model Spec](/docs/configuration/librechat_yaml/object_structure/model_specs) by name.
   - Note: other parameters will not take effect, only those defined by the model spec.
+- `fileTokenLimit`: Set maximum token limit for file processing to control costs and resource usage.
 
 ### Model Parameters
 Different endpoints support various parameters:


### PR DESCRIPTION
- Added support for `ocr` and `textParsing` configurations in `fileConfig`, allowing users to specify file types for OCR processing and direct text extraction.
- Introduced `fileTokenLimit` parameter for all endpoints to manage maximum token limits for file processing.