### PR TITLE
📚 docs: Add STT Config Documentation

### DIFF
--- a/components/changelog/content/config_v1.2.8.mdx
+++ b/components/changelog/content/config_v1.2.8.mdx
@@ -88,13 +88,15 @@
 - Improved [Model Specs documentation](/docs/configuration/librechat_yaml/object_structure/model_specs) with parameter support updates:
   - Added support for `disableStreaming`, `thinking`, `thinkingBudget`, `web_search`, and other parameters
 
-- Added OCR and text parsing separation to `fileConfig`:
+- Added OCR, text parsing, and STT separation to `fileConfig`:
   - Added `ocr` configuration to control which file types use OCR processing
   - Added `textParsing` configuration to control which file types use direct text extraction
-  - Separate processing paths for visual documents (OCR) versus text files (native parsing)
-  - OCR takes precedence when files match both patterns
+  - Added `stt` configuration to control which audio file types use Speech-to-Text transcription
+  - Separate processing paths for visual documents (OCR), text files (native parsing), and audio files (STT)
+  - Processing precedence: OCR > STT > text parsing
   - Default OCR support: images (JPEG, GIF, PNG, WebP, HEIC, HEIF), PDFs, Office documents, EPUB files
   - Default text parsing support: all text MIME types and common programming languages
+  - Default STT support: audio formats (MP3, WAV, FLAC, OGG, M4A, WebM, etc.)
   - See [File Config Object Structure](/docs/configuration/librechat_yaml/object_structure/file_config) for details
 
 - Added `fileTokenLimit` parameter support for all endpoints:

--- a/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -152,6 +152,7 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
     ['clientImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
     ['ocr', 'Object', 'Settings for Optical Character Recognition (OCR) file processing.', ''],
     ['textParsing', 'Object', 'Settings for direct text file parsing.', ''],
+    ['stt', 'Object', 'Settings for Speech-to-Text (STT) audio file processing.', ''],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -4,7 +4,7 @@
 
 The `fileConfig` object allows you to configure file handling settings for the application, including size limits and MIME type restrictions. This section provides a detailed breakdown of the `fileConfig` object structure.
 
-There are 6 main fields under `fileConfig`:
+There are 7 main fields under `fileConfig`:
 
   - `endpoints`
   - `serverFileSizeLimit`
@@ -12,6 +12,7 @@ There are 6 main fields under `fileConfig`:
   - `imageGeneration`
   - `ocr`
   - `textParsing`
+  - `stt`
 
 **Notes:**
 
@@ -66,6 +67,9 @@ fileConfig:
   textParsing:
     supportedMimeTypes:
       - "^text/(plain|markdown|csv|json|xml|html|css|javascript|typescript|x-python|x-java|x-csharp|x-php|x-ruby|x-go|x-rust|x-kotlin|x-swift|x-scala|x-perl|x-lua|x-shell|x-sql|x-yaml|x-toml)$"
+  stt:
+    supportedMimeTypes:
+      - "^audio/(mp3|mpeg|mpeg3|wav|wave|x-wav|ogg|vorbis|mp4|x-m4a|flac|x-flac|webm)$"
 ```
 
 ## serverFileSizeLimit
@@ -181,11 +185,39 @@ fileConfig:
       - "^text/(plain|markdown|csv|json|xml|html|css|javascript|typescript|x-python|x-java|x-csharp|x-php|x-ruby|x-go|x-rust|x-kotlin|x-swift|x-scala|x-perl|x-lua|x-shell|x-sql|x-yaml|x-toml)$"
 ```
 
+## stt
+
+<OptionTable
+  options={[
+    ['stt', 'Object', 'Settings for Speech-to-Text (STT) audio file processing.', 'Configures which audio file types are processed using STT for transcription.'],
+  ]}
+/>
+
+**Description:** The `stt` section configures which audio file types should be processed using Speech-to-Text functionality for converting audio to text.
+
+### supportedMimeTypes
+
+<OptionTable
+  options={[
+    ['supportedMimeTypes', 'Array of Strings', 'List of MIME type patterns for audio files that should be transcribed with STT.', 'Uses regular expressions to match audio file types.'],
+  ]}
+/>
+
+**Default:** Common audio formats
+
+```yaml filename="fileConfig / stt / supportedMimeTypes"
+fileConfig:
+  stt:
+    supportedMimeTypes:
+      - "^audio/(mp3|mpeg|mpeg3|wav|wave|x-wav|ogg|vorbis|mp4|x-m4a|flac|x-flac|webm)$"
+```
+
 **Notes:**
 - Files matching `textParsing` patterns are processed with simple text extraction
 - Files matching `ocr` patterns are processed with the provided OCR service
-- If a file matches both patterns, OCR takes precedence
-- Files not matching either pattern will not be processed
+- Files matching `stt` patterns are processed with Speech-to-Text transcription
+- Processing precedence: OCR > STT > text parsing
+- Files not matching any pattern will not be processed
 
 ## endpoints
 


### PR DESCRIPTION
- Added `stt` configuration to `fileConfig` for Speech-to-Text audio file processing, including supported MIME types.
- Updated changelog to reflect the addition of STT alongside existing OCR and text parsing configurations.
Related to [#8893](https://github.com/danny-avila/LibreChat/pull/8893)