### PR TITLE
📚 docs: Finalize fileTokenLimit documentation

### DIFF
--- a/components/changelog/content/config_v1.2.8.mdx
+++ b/components/changelog/content/config_v1.2.8.mdx
@@ -100,6 +100,6 @@
   - See [File Config Object Structure](/docs/configuration/librechat_yaml/object_structure/file_config) for details
 
 - Added `fileTokenLimit` parameter support for all endpoints:
-  - Allows setting maximum token limits for file processing to control costs and resource usage
-  - Available as URL query parameter and in endpoint configuration panels
-  - Schema validation included but enforcement logic reserved for future implementation
+  - Allows setting default and on-the-fly maximum token limits for file processing to control costs and resource usage
+  - Available as URL query parameter and in endpoint configuration panels, or can be configured in `fileConfig` field of `librechat.yaml`
+  - Runtime behavior: text from attached files is truncated to this limit just before prompt construction (default: 100000)

--- a/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -153,6 +153,7 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
     ['ocr', 'Object', 'Settings for Optical Character Recognition (OCR) file processing.', ''],
     ['textParsing', 'Object', 'Settings for direct text file parsing.', ''],
     ['stt', 'Object', 'Settings for Speech-to-Text (STT) audio file processing.', ''],
+    ['fileTokenLimit', 'Number', 'Maximum number of tokens from text files to include in prompts before truncation.', 'fileTokenLimit: 100000'],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -54,6 +54,7 @@ fileConfig:
         - "image/.*"
   serverFileSizeLimit: 1000
   avatarSizeLimit: 2
+  fileTokenLimit: 100000
   imageGeneration:
     percentage: 100
     px: 1024
@@ -125,6 +126,23 @@ fileConfig:
   imageGeneration:
     percentage: 100
     px: 1024
+```
+
+## fileTokenLimit
+
+<OptionTable
+  options={[
+    ['fileTokenLimit', 'Number', 'Maximum number of tokens from text files to include in prompts before truncation.', 'fileTokenLimit: 100000'],
+  ]}
+/>
+
+**Description:** When attaching text content, LibreChat truncates the text at runtime to the configured token limit just before prompt construction.
+
+**Default:** `100000`
+
+```yaml filename="fileConfig / fileTokenLimit"
+fileConfig:
+  fileTokenLimit: 100000
 ```
 
 ## ocr

--- a/pages/docs/features/url_query.mdx
+++ b/pages/docs/features/url_query.mdx
@@ -155,6 +155,7 @@ LibreChat supports a wide range of parameters for fine-tuning your conversation 
 - `spec`: Select a specific LibreChat [Model Spec](/docs/configuration/librechat_yaml/object_structure/model_specs) by name.
   - Note: other parameters will not take effect, only those defined by the model spec.
 - `fileTokenLimit`: Set maximum token limit for file processing to control costs and resource usage.
+  - Note: Request value overrides YAML default.
 
 ### Model Parameters
 Different endpoints support various parameters:


### PR DESCRIPTION
- Adds documentation for fileTokenLimit configurable default field and updates docs from previous scaffolded version

Related to [#8911](https://github.com/danny-avila/LibreChat/pull/8911)