### PR TITLE
docs: MCP OAuth environment variables and requiresOAuth configuration

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -1311,6 +1311,20 @@ LibreChat supports Google Tag Manager for analytics. You will need a Google Tag 
   ]}
 />
 
+### MCP (Model Context Protocol)
+
+Configure Model Context Protocol settings for enhanced server management and OAuth support.
+
+#### MCP Server Configuration
+
+<OptionTable
+  options={[
+    ['MCP_OAUTH_ON_AUTH_ERROR', 'boolean', 'Treat 401/403 responses as OAuth requirement when no oauth metadata found.', 'MCP_OAUTH_ON_AUTH_ERROR=true'],
+    ['MCP_OAUTH_DETECTION_TIMEOUT', 'number', 'Timeout for OAuth detection requests in milliseconds.', 'MCP_OAUTH_DETECTION_TIMEOUT=5000'],
+    ['MCP_CONNECTION_CHECK_TTL', 'number', 'Cache connection status checks for this many milliseconds to avoid expensive verification.', 'MCP_CONNECTION_CHECK_TTL=30000'],
+  ]}
+/>
+
 ### Other
 
 #### Redis

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -11,6 +11,7 @@ mcpServers:
   googlesheets:
     type: sse
     url: https://mcp.composio.dev/googlesheets/some-endpoint
+    requiresOAuth: true
     headers:
       X-User-ID: "{{LIBRECHAT_USER_ID}}"
       X-API-Key: "${SOME_API_KEY}"
@@ -85,6 +86,7 @@ mcpServers:
     ['timeout', 'Number', '(Optional) Timeout in milliseconds for MCP server requests. Determines how long to wait for a response for tool requests.', 'timeout: 30000'],
     ['initTimeout', 'Number', '(Optional) Timeout in milliseconds for MCP server initialization. Determines how long to wait for the server to initialize.', 'initTimeout: 10000'],
     ['env', 'Object', '(Optional, `stdio` type only) Environment variables to use when spawning the process.', 'env:\n  NODE_ENV: "production"'],
+    ['requiresOAuth', 'Boolean', '(Optional, `sse` type only) Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it\'s best to set this value explicitly if you know whether the server requires OAuth or not.', 'requiresOAuth: true'],
     ['stderr', 'String or Stream or Number', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Defaults to `"inherit"`.', 'stderr: "inherit"'],
     ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
     ['oauth', 'Object', '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.', 'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"'],
@@ -220,6 +222,17 @@ mcpServers:
 - **Type:** Number (Optional)
 - **Description:** Timeout in milliseconds for MCP server initialization. Determines how long to wait for the server to initialize.
 - **Default Value:** `10000` (10 seconds)
+
+#### `requiresOAuth`
+
+- **Type:** Boolean (Optional, `sse` type only)
+- **Description:** Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it's best to set this value explicitly if you know whether the server requires OAuth or not.
+- **Default Value:** Auto-detected if not specified
+- **Notes:**
+  - Only applicable to `sse` type MCP servers
+  - Auto-detection occurs during server startup, which may add initialization time
+  - Explicit configuration improves startup performance by skipping detection
+  - Works with MCP OAuth environment variables (`MCP_OAUTH_ON_AUTH_ERROR`, `MCP_OAUTH_DETECTION_TIMEOUT`) for enhanced connection management
 
 #### `stderr`
 
@@ -459,6 +472,30 @@ puppeteer:
       3. Wait for page elements to load before interacting with them
       4. Use specific CSS selectors for reliable element targeting
       5. Check console logs for JavaScript errors when troubleshooting
+```
+
+### OAuth-Enabled MCP Server (Legacy requiresOAuth)
+
+```yaml filename="OAuth-Enabled MCP Server"
+composio-googlesheets:
+  type: sse
+  url: https://mcp.composio.dev/googlesheets/sse-endpoint
+  requiresOAuth: true
+  headers:
+    X-User-ID: "{{LIBRECHAT_USER_ID}}"
+    X-API-Key: "${COMPOSIO_API_KEY}"
+  timeout: 45000
+  initTimeout: 15000
+```
+
+**Related Environment Variables (Optional):**
+```bash
+# OAuth configuration for MCP servers
+MCP_OAUTH_ON_AUTH_ERROR=true
+MCP_OAUTH_DETECTION_TIMEOUT=10000
+
+# API key for the service
+COMPOSIO_API_KEY=your_composio_api_key_here
 ```
 
 ---


### PR DESCRIPTION
- Add MCP_OAUTH_ON_AUTH_ERROR, MCP_OAUTH_DETECTION_TIMEOUT, and MCP_CONNECTION_CHECK_TTL environment variables to dotenv.mdx
- Document requiresOAuth field for MCP server configurations with auto-detection behavior
- Add OAuth-enabled MCP server example with environment variable requirements

Accompanied by: https://github.com/danny-avila/LibreChat/pull/8930