### PR TITLE
feat: Redis Alt. DNS Lookup for Elasticache support #9263

### DIFF
--- a/pages/docs/configuration/redis.mdx
+++ b/pages/docs/configuration/redis.mdx
@@ -96,6 +96,14 @@ REDIS_URI=rediss://your-redis-host:6380
 # Provide CA certificate for verification
 REDIS_CA=/path/to/your/ca-certificate.pem
 ```
+### TLS with Elasticache
+
+Elasticache may need to use an alternate dnsLookup for TLS connections.  see "Special Note: Aws Elasticache Clusters with TLS" on this webpage: https://www.npmjs.com/package/ioredis
+
+```bash
+# Enable redis alternate dnsLookup
+REDIS_USE_ALTERNATIVE_DNS_LOOKUP=true
+```
 
 ## Advanced Options
 


### PR DESCRIPTION
Added a REDIS_USE_ALTERNATIVE_DNS_LOOKUP environment variable that defaults to false in order to allow users to implement the necessary property to ioredis in order to connect to elasticache

When using TLS for elasticache ioredis is required to set a dnsLookup property otherwise it will not connect. Specifically I am having this issue with elasticache with valkey.

see "Special Note: Aws Elasticache Clusters with TLS" on this webpage: https://www.npmjs.com/package/ioredis
It states the following:

Special Note: Aws Elasticache Clusters with TLS
AWS ElastiCache for Redis (Clustered Mode) supports TLS encryption. If you use this, you may encounter errors with invalid certificates. To resolve this issue, construct the Cluster with the dnsLookup option....