### PR TITLE
docs: Update docker_override.mdx by removing version id

### DIFF
--- a/pages/docs/configuration/docker_override.mdx
+++ b/pages/docs/configuration/docker_override.mdx
@@ -40,8 +40,6 @@ Make your desired changes by uncommenting the relevant sections and customizing 
 If you want to make sure Docker can use your `librechat.yaml` file for [Custom Endpoints & Configuration](/docs/configuration/librechat_yaml), it would look like this:
 
 ```yaml filename="docker-compose.override.yml"
-version: '3.4'
-
 services:
   api:
     volumes:
@@ -51,8 +49,6 @@ services:
 Or, if you want to locally build the image for the `api` service, use the LibreChat config file, and use the older Mongo that doesn't requires AVX support, your `docker-compose.override.yml` might look like this:
 
 ```yaml filename="docker-compose.override.yml"
-version: '3.4'
-
 services:
   api:
     volumes:


### PR DESCRIPTION
Having the version id results with the warning - 
`the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`

The example file also does not have the version so this change matches up the docs to that too. 