### PR TITLE
Update broken link for Serper.dev in documentation

### DIFF
--- a/pages/docs/features/web_search.mdx
+++ b/pages/docs/features/web_search.mdx
@@ -36,7 +36,7 @@ Each component of the web search feature requires its own API key. Here's how to
 ### Search Providers
 
 #### Serper
-1. Visit [Serper.dev](https://serper.dev/api-key)
+1. Visit [Serper.dev](https://serper.dev)
 2. Sign up for an account
 3. Navigate to the API Key section
 4. Copy your API key


### PR DESCRIPTION
Current link: `https://serper.dev/api-key` results in a 404 not found. Updated to `https://serper.dev`