### PR TITLE
feat: add COHERE_BASE_URL configuration for custom Cohere endpoints

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -288,6 +288,7 @@ For detailed configuration and customization options, see: [Web Search Configura
     ['FIRECRAWL_API_URL', 'string', 'Custom Firecrawl API URL (optional). Only needed for custom Firecrawl instances.', '# FIRECRAWL_API_URL='],
     ['JINA_API_KEY', 'string', 'API key for Jina reranker service. Get your key from https://jina.ai/api-dashboard/', '# JINA_API_KEY='],
     ['COHERE_API_KEY', 'string', 'API key for Cohere reranker service. Get your key from https://dashboard.cohere.com/welcome/login', '# COHERE_API_KEY='],
+    ['COHERE_BASE_URL', 'string', 'Custom Cohere API base URL (optional). Only needed for custom Cohere endpoints or proxies.', '# COHERE_BASE_URL='],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/web_search.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/web_search.mdx
@@ -28,6 +28,7 @@ webSearch:
   # Reranker Configuration
   jinaApiKey: "${JINA_API_KEY}"
   cohereApiKey: "${COHERE_API_KEY}"
+  cohereApiUrl: "${COHERE_BASE_URL}"
   rerankerType: "jina" # Options: "jina", "cohere"
 
   # General Settings
@@ -294,6 +295,16 @@ webSearch:
 />
 
 **Note:** Get your API key from [Cohere Dashboard](https://dashboard.cohere.com/welcome/login)
+
+### cohereApiUrl
+
+<OptionTable
+  options={[
+    ['cohereApiUrl', 'String', 'Environment variable name for the Cohere API base URL. If not set in .env, users will be prompted to provide it via UI.', '${COHERE_BASE_URL}'],
+  ]}
+/>
+
+**Note:** This is optional and only needed if you're using a custom Cohere endpoint or proxy.
 
 ### rerankerType
 

--- a/pages/docs/features/web_search.mdx
+++ b/pages/docs/features/web_search.mdx
@@ -71,6 +71,7 @@ Each component of the web search feature requires its own API key. Here's how to
 3. Navigate to the API Keys section
 4. Copy your API key
 5. Set it in your environment variables or provide it through the UI
+6. (Optional) Set `COHERE_BASE_URL` if using a custom Cohere endpoint or proxy
 
 ## Components
 


### PR DESCRIPTION
## Summary
- Add `COHERE_BASE_URL` environment variable documentation to support custom Cohere endpoints
- Update web search features documentation with custom endpoint configuration option
- Add `cohereApiUrl` parameter to YAML configuration reference  
- Enables use of custom Cohere endpoints, LiteLLM proxies, or self-hosted Cohere-compatible APIs for reranking

## Changes Made
1. **dotenv.mdx**: Added `COHERE_BASE_URL` environment variable to the Web Search section
2. **web_search.mdx**: Added step 6 to Cohere setup instructions for optional custom endpoint configuration
3. **web_search.mdx (YAML structure)**: Added `cohereApiUrl` parameter with documentation

## Use Cases
- Custom Cohere endpoint deployments
- LiteLLM proxy configurations for Cohere
- Self-hosted Cohere-compatible reranking services
- Corporate firewalls requiring proxy endpoints

## Related
- Implements documentation for: https://github.com/danny-avila/LibreChat/pull/9544

🤖 Generated with [Claude Code](https://claude.ai/code)