### PR TITLE
Add helm oci image to docs

### DIFF
--- a/pages/docs/local/helm_chart.mdx
+++ b/pages/docs/local/helm_chart.mdx
@@ -42,15 +42,24 @@ kind: Secret
 3. Apply the Secret to the Cluster:
 
 ## Install Helm Chart
-In the root directory, run: 
 
-`helm install <deployment-name> helmchart`
+To install the helm chart run: 
+
+`helm install <deployment-name> oci://ghcr.io/danny-avila/librechat-chart/librechat`
+
+<details>
+  <summary>Development version</summary>
+
+In the repo's root directory, run: 
+
+`helm install <deployment-name> ./helm/librechat`
+</details>
 
 Similar to other Helm charts, there exists a [values file](https://github.com/danny-avila/LibreChat/blob/main/helm/librechat/values.yaml) that outlines the default settings and indicates which configuration options can be modified.
 
 Create a `values.yaml` file populated with the values you want to modify from the default.
 
-Install the Helm chart: `helm install librechat helmchart --values <values-override-filel>`
+Install the Helm chart: `helm install librechat oci://ghcr.io/danny-avila/librechat-chart/librechat --values <values-override-filel>`
 
 ## Uninstall the Helm Chart
 


### PR DESCRIPTION
Updating the docs to use the new helm chart OCI image published by the changes in the [main repo](https://github.com/danny-avila/LibreChat/pull/7256). 