### PR TITLE
docs: instructions for renewing certbot when using nginx

### DIFF
--- a/pages/docs/remote/nginx.mdx
+++ b/pages/docs/remote/nginx.mdx
@@ -111,6 +111,35 @@ cd LibreChat
 sudo docker-compose -f ./deploy-compose.yml up -d
 ```
 
+## Renewing certificates when using nginx
+
+If you set up nginx using the recommended Option A above, use these steps to renew the certificates:
+
+1. Navigate to your application's directory 
+```bash filename="Replace 'LibreChat' with your actual application directory.
+cd LibreChat
+```
+
+2. Stop your running Docker containers
+
+```bash filename="Stop your application"
+sudo docker-compose -f ./deploy-compose.yml down -d
+```
+
+3. renew certificates
+
+```bash 
+sudo certbot renew
+```
+
+4. Restart your application 
+
+```bash filename="Start your application"
+sudo docker-compose -f ./deploy-compose.yml up -d
+```
+
+Note: certbot might restart the host's nginx. You can kill it with `sudo pkill nginx` 
+
 ## Web Application Firewall
 
 Nginx can be configured to act as a web application firewall (WAF) by leveraging the OWASP Core Rule Set (CRS), which provides a robust set of rules to protect against common web application vulnerabilities and attacks. Using OWASP CRS with Nginx can enhance the security of your LibreChat deployment by adding an additional layer of protection.


### PR DESCRIPTION
It's not as straightforward to renew certbot when running nginx. 

Adding instructions to renew certificates.