### PR TITLE
fix: Minor typo in stt_tts.mdx

### DIFF
--- a/pages/docs/configuration/stt_tts.mdx
+++ b/pages/docs/configuration/stt_tts.mdx
@@ -128,7 +128,7 @@ The Text-to-Speech (TTS) feature converts written text into spoken words. Variou
 
 - #### Browser-based
 
-No setup required. Ensure the "Text To Speech" switcg in the speech settings tab is enabled and "Browser" is selected in the engine dropdown.
+No setup required. Ensure the "Text To Speech" switch in the speech settings tab is enabled and "Browser" is selected in the engine dropdown.
 
 - #### Piper
 


### PR DESCRIPTION
Hi, while reading about how to configure the [speech settings](https://www.librechat.ai/docs/configuration/stt_tts#openai-compatible), I found a typo that I fixed.

- `switcg` → `switch`