### PR TITLE
Docs: Fixed a few typos in agents.mdx

### DIFF
--- a/pages/docs/features/agents.mdx
+++ b/pages/docs/features/agents.mdx
@@ -179,7 +179,7 @@ With the Actions capability, you can dynamically create tools from [OpenAPI spec
   - [More info](/docs/configuration/librechat_yaml/object_structure/agents#capabilities)
 - Individual domains can be whitelisted for agent actions:
   - [More info](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains)
-- Note that you can add add the 'x-strict': true flag at operation-level in the OpenAPI spec for actions.
+- Note that you can add the 'x-strict': true flag at operation-level in the OpenAPI spec for actions.
 If using an OpenAI model supporting it, this will automatically generate function calls with 'strict' mode enabled.
   - Strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported for details.
 
@@ -322,7 +322,7 @@ LibreChat allows admins to configure the use of agents via the [`librechat.yaml`
 When chatting with agents, you can:
 - Use "Upload as Text" to include full document content in conversations (text parsing by default, enhanced by OCR)
 - Use "Upload for File Search" for semantic search over documents (requires RAG API)
-- Add files to agent's "File Context" to included a file's full content as part of the agent's system instructions
+- Add files to agent's "File Context" to include a file's full content as part of the agent's system instructions
 
 ## Migration Required (v0.8.0-rc3+)
 
@@ -420,7 +420,7 @@ Furthermore, the update introduces a new paradigm for LibreChat, as its underlyi
 
 To highlight one notable optimization, an AI generation of roughly 1000 tokens will transfer about 1 MB of data using traditional endpoints (at the time of writing, any endpoint option besides Agents and AWS Bedrock).
 
-Using an agent, the same generation will transfer about about 52 kb of data, a 95% reduction in data transfer, which is that much less of a load on the server and the user's device.
+Using an agent, the same generation will transfer about 52 kb of data, a 95% reduction in data transfer, which is that much less of a load on the server and the user's device.
 
 ---
 


### PR DESCRIPTION
Hi, I fixed some typos in the [agents page](https://www.librechat.ai/docs/features/agents).

- `add add` → `add`
- `about about` → `about`
- `to included a file's` → `to include a file's`