### PR TITLE
docs: update model specs docs to clarify label field requirement

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -156,7 +156,7 @@ Unique identifier for the model.
 
 <OptionTable
   options={[
-    ['label', 'String', 'A user-friendly name or label for the model, shown in the header dropdown.', 'No default. Optional.'],
+    ['label', 'String', 'A user-friendly name or label for the model, shown in the header dropdown.', 'No default. Must be specified.'],
   ]}
 />
 


### PR DESCRIPTION
I found that if I use `modelSpecs` config in custom `librechat.yaml`, and I don't provide `label` of a model, I will get error `Invalid custom config file at /app/librechat.yaml`.

Checking at the code, the `label` field isn't optional https://github.com/danny-avila/LibreChat/blob/main/packages/data-provider/src/models.ts#L26

However, the current document states that it is "No default. Optional.".

I assume that the intention is it is required field, not optional field. So I made this PR to correct the document.