### PR TITLE
bugfix: Check file size of conversation being imported against a configured max to prevent large conversations imports from crashing librechat

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -942,6 +942,16 @@ Limits how often users can fork conversations to prevent abuse.
   ]}
 />
 
+#### Conversation import file size limiting
+
+During the conversation import process a user may attempt to upload an extremely large conversation exported conversation.  This can cause librechat to run out of memory.  To prevent this, set a maximum size in bytes for a conversation import using the following environment variable.
+
+<OptionTable
+  options={[
+    ['CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES', 'number', 'Maximum size in bytes that a conversation import can be', 'CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000'],
+  ]}
+/>
+
 ### Balance
 
 The following feature allows for the management of user balances within the system's endpoints. You have the option to add balances manually, or you may choose to implement a system that accumulates balances automatically for users. If a specific initial balance is defined in the configuration, tokens will be credited to the user's balance automatically when they register.


### PR DESCRIPTION
Issue:   https://github.com/danny-avila/LibreChat/issues/10011
