### PR TITLE
docs: Add OIDC Group Synchronization documentation for Keycloak

### DIFF
--- a/pages/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
+++ b/pages/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
@@ -119,7 +119,65 @@ OPENID_GROUPS_TOKEN_KIND=access  # or 'id'
 
 # Source identifier for synced groups (optional)
 OPENID_GROUP_SOURCE=keycloak  # default: 'oidc'
+
+# Exclude specific roles/groups from sync (optional)
+# Comma-separated list: exact names or regex patterns (prefix with 'regex:')
+OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,offline_access,regex:^view-.*
 ```
+
+### Filtering Roles/Groups (Exclusion Pattern)
+
+<Callout type="tip" title="Filter System Roles">
+Use `OPENID_GROUPS_EXCLUDE_PATTERN` to prevent system roles, default roles, and authentication-only roles from being synced as groups.
+</Callout>
+
+The exclusion pattern supports two types of matching:
+
+**1. Exact Match (case-insensitive):**
+```bash
+OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,view-profile
+```
+Excludes roles with exact names: `default-roles-mediawan`, `manage-account`, `view-profile`
+
+**2. Regex Pattern (prefix with `regex:`):**
+```bash
+OPENID_GROUPS_EXCLUDE_PATTERN=regex:^default-.*,regex:^manage-.*
+```
+- `regex:^default-.*` - Excludes anything starting with "default-" 
+- `regex:^manage-.*` - Excludes anything starting with "manage-"
+
+**3. Mixed (recommended):**
+```bash
+OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,offline_access,uma_authorization,regex:^manage-.*,regex:^view-.*
+```
+
+**Common Keycloak exclusions:**
+```bash
+# Exclude all system/default roles and account management
+OPENID_GROUPS_EXCLUDE_PATTERN=offline_access,uma_authorization,regex:^default-.*,regex:^manage-.*,regex:^view-.*
+```
+
+**Why exclude roles?**
+- **System roles** (`offline_access`, `uma_authorization`) - Not relevant for resource permissions
+- **Default realm roles** (`default-roles-*`) - Assigned to everyone, not useful for group-based access
+- **Account management roles** (`manage-account`, `view-profile`) - Authentication-related, not business groups
+- **OPENID_REQUIRED_ROLE** - If you use a role for login authorization, you might not want it as a group
+
+**Example scenario:**
+
+Your Keycloak realm has roles:
+- `admin` ✅ (business role, sync as group)
+- `developers` ✅ (team role, sync as group)
+- `default-roles-mediawan` ❌ (everyone has this, exclude)
+- `manage-account` ❌ (system role, exclude)
+- `offline_access` ❌ (OAuth scope, exclude)
+
+Configuration:
+```bash
+OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,offline_access
+```
+
+Result: Only `admin` and `developers` are synced as groups.
 
 ### How It Works
 


### PR DESCRIPTION
Add comprehensive documentation for the new OIDC group sync feature:
- Overview and prerequisites
- Configuration examples for realm roles, client roles, and groups
- Step-by-step setup instructions
- Troubleshooting guide with common claim paths
- Usage examples for permissions
- Limitations and best practices

Covers integration with LibreChat's granular permissions system for agents, prompts, files, and conversations.

Related to LibreChat PR and issue https://github.com/danny-avila/LibreChat/issues/10006