### PR TITLE
docs: add OAuth headers section

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -310,12 +310,19 @@ mcpServers:
 #### `oauth_headers`
 
 - **Type:** Object (Optional)
-- **Description:** Map of header names and values to be used for OAuth requests (e.g., when registering a new client). Each key-value pair represents a header name and its corresponding value. This is useful when OAuth providers require specific headers for client registration or token requests.
+- **Description:** Headers specifically for OAuth-related requests, such as client registration (Dynamic Client Registration/DCR) and token exchange. These headers are sent during the OAuth authentication flow, not during regular MCP server communication.
+- **Common Use Cases:**
+  - Adding authentication to DCR endpoints (e.g., `Authorization: Bearer ${DCR_API_KEY}`)
+  - Including custom provider-specific headers required for OAuth flows
+  - Setting content-type or other headers needed for OAuth token endpoints
+- **Key Differences from `headers`:**
+  - **`headers`**: Used for regular MCP server requests (tool calls, server communication) after authentication is complete
+  - **`oauth_headers`**: Used exclusively during OAuth authentication flows (client registration, token requests)
 - **Example:**
   ```yaml
   oauth_headers:
-    X-Custom-Header-1: "custom_value_1"
-    X-Custom-Header-2: "custom_value_2"
+    Authorization: "Bearer ${DCR_API_KEY}"
+    X-Custom-Header: "custom_value"
   ```
 
 #### `startup`

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -310,7 +310,7 @@ mcpServers:
 #### `oauth_headers`
 
 - **Type:** Object (Optional)
-- **Description:** Headers specifically for OAuth-related requests, such as client registration (Dynamic Client Registration/DCR) and token exchange. These headers are sent during the OAuth authentication flow, not during regular MCP server communication.
+- **Description:** Headers specifically for OAuth flow requests. These headers are **only** used during the OAuth authentication flow (client registration, token exchange, etc.) and **not** during regular MCP server communication
 - **Common Use Cases:**
   - Adding authentication to DCR endpoints (e.g., `Authorization: Bearer ${DCR_API_KEY}`)
   - Including custom provider-specific headers required for OAuth flows

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -90,6 +90,7 @@ mcpServers:
     ['stderr', 'String or Stream or Number', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Defaults to `"inherit"`.', 'stderr: "inherit"'],
     ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
     ['oauth', 'Object', '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.', 'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"'],
+    ['oauth_headers', 'Object', '(Optional) Map of header names and values to be used for OAuth requests (e.g., when registering a new client). Each key-value pair represents a header name and its corresponding value.', 'oauth_headers:\n  X-Custom-Header-1: "custom_value_1"\n  X-Custom-Header-2: "custom_value_2"'],
     ['startup', 'Boolean', '(Optional) When set to false, this MCP server will not be connected at application startup.', 'startup: false'],
   ]}
 />
@@ -306,6 +307,17 @@ mcpServers:
     code_challenge_methods_supported: ["S256", "plain"]
   ```
 
+#### `oauth_headers`
+
+- **Type:** Object (Optional)
+- **Description:** Map of header names and values to be used for OAuth requests (e.g., when registering a new client). Each key-value pair represents a header name and its corresponding value. This is useful when OAuth providers require specific headers for client registration or token requests.
+- **Example:**
+  ```yaml
+  oauth_headers:
+    X-Custom-Header-1: "custom_value_1"
+    X-Custom-Header-2: "custom_value_2"
+  ```
+
 #### `startup`
 
 - **Type:** Boolean (Optional)
@@ -438,6 +450,8 @@ oauth-api-server:
     client_secret: your_client_secret
     redirect_uri: http://localhost:3080/oauth/callback
     scope: "read execute"
+  oauth_headers:
+    X-Custom-Header: "custom_value"
 ```
 
 ### MCP Server with Server Instructions

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -310,7 +310,7 @@ mcpServers:
 #### `oauth_headers`
 
 - **Type:** Object (Optional)
-- **Description:** Headers specifically for OAuth flow requests. These headers are **only** used during the OAuth authentication flow (client registration, token exchange, etc.) and **not** during regular MCP server communication
+- **Description:** Headers specifically for OAuth flow requests. These headers are **only** used during the OAuth authentication flow (client registration, token exchange, etc.) and **not** during regular MCP server communication.
 - **Common Use Cases:**
   - Adding authentication to DCR endpoints (e.g., `Authorization: Bearer ${DCR_API_KEY}`)
   - Including custom provider-specific headers required for OAuth flows


### PR DESCRIPTION
This PR adds a section about `oauth_headers` in the MCP servers config page, introduced in https://github.com/danny-avila/LibreChat/pull/10014.