### PR TITLE
📚 docs: update Azure OpenAI documentation for new domain format support

### DIFF
--- a/pages/docs/configuration/azure.mdx
+++ b/pages/docs/configuration/azure.mdx
@@ -163,7 +163,7 @@ options={[
 Azure OpenAI Instance:
 <OptionTable
 options={[
-['instanceName', 'string', 'Name of the Azure OpenAI instance. This field can also support environment variable references.', 'instanceName: ${AZURE_OPENAI_INSTANCE}'],
+['instanceName', 'string', 'Name of the Azure OpenAI instance. This field can also support environment variable references. **Supports both domain formats**: `.openai.azure.com` (legacy) and `.cognitiveservices.azure.com` (new). You can specify either the full domain (e.g., `my-instance.cognitiveservices.azure.com`) or just the instance name (e.g., `my-instance`) for backward compatibility with the legacy `.openai.azure.com` format.', 'instanceName: ${AZURE_OPENAI_INSTANCE}'],
 ]}
 />
 
@@ -403,6 +403,14 @@ The base URL for Azure OpenAI API requests can be dynamically configured. This i
 
 LibreChat will use the baseURL field for your Azure model grouping, which can include placeholders for the Azure OpenAI API instance and deployment names.
 
+<Callout type="info" title="Azure Endpoint Domain Format Support">
+Azure OpenAI now supports both endpoint domain formats:
+- **New format**: `.cognitiveservices.azure.com`
+- **Legacy format**: `.openai.azure.com`
+
+When using `instanceName` without a full domain, the legacy `.openai.azure.com` format is applied by default. If you provide a full domain (e.g., `my-instance.cognitiveservices.azure.com`), it will be used as-is. This applies to both `instanceName` fields and `baseURL` configurations.
+</Callout>
+
 In the configuration, the base URL can be customized like so:
 
 ```yaml filename="librechat.yaml"
@@ -413,8 +421,11 @@ endpoints:
       - group: "group-with-custom-base-url"
       baseURL: "https://example.azure-api.net/${INSTANCE_NAME}/${DEPLOYMENT_NAME}"
 
-# OR
+# Legacy format (.openai.azure.com)
       baseURL: "https://${INSTANCE_NAME}.openai.azure.com/openai/deployments/${DEPLOYMENT_NAME}"
+
+# New format (.cognitiveservices.azure.com)
+      baseURL: "https://${INSTANCE_NAME}.cognitiveservices.azure.com/openai/deployments/${DEPLOYMENT_NAME}"
 
 # Cloudflare example
       baseURL: "https://gateway.ai.cloudflare.com/v1/ACCOUNT_TAG/GATEWAY/azure-openai/${INSTANCE_NAME}/${DEPLOYMENT_NAME}"
@@ -515,8 +526,8 @@ Here's the updated layout for the DALL-E configuration options:
 **Base URLs:**
 <OptionTable
   options={[
-    ['DALLE3_BASEURL', 'string', 'The base URL for DALL-E 3 API endpoints.','# DALLE3_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.openai.azure.com/openai/deployments/<DALLE3_DEPLOYMENT_NAME>/'],
-    ['DALLE2_BASEURL', 'string', 'The base URL for DALL-E 2 API endpoints.','# DALLE2_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.openai.azure.com/openai/deployments/<DALLE2_DEPLOYMENT_NAME>/'],
+    ['DALLE3_BASEURL', 'string', 'The base URL for DALL-E 3 API endpoints. Supports both `.openai.azure.com` (legacy) and `.cognitiveservices.azure.com` (new) domain formats.','# DALLE3_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.openai.azure.com/openai/deployments/<DALLE3_DEPLOYMENT_NAME>/\n# OR\n# DALLE3_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.cognitiveservices.azure.com/openai/deployments/<DALLE3_DEPLOYMENT_NAME>/'],
+    ['DALLE2_BASEURL', 'string', 'The base URL for DALL-E 2 API endpoints. Supports both `.openai.azure.com` (legacy) and `.cognitiveservices.azure.com` (new) domain formats.','# DALLE2_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.openai.azure.com/openai/deployments/<DALLE2_DEPLOYMENT_NAME>/\n# OR\n# DALLE2_BASEURL=https://<AZURE_OPENAI_API_INSTANCE_NAME>.cognitiveservices.azure.com/openai/deployments/<DALLE2_DEPLOYMENT_NAME>/'],
   ]}
 />
 

--- a/pages/docs/configuration/librechat_yaml/object_structure/azure_openai.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/azure_openai.mdx
@@ -115,7 +115,7 @@ apiKey: "${WESTUS_API_KEY}"
 **Key:**
 <OptionTable
   options={[
-    ['instanceName', 'String', 'Name of the Azure instance.', 'It\'s recommended to use a custom env. variable reference for this field, i.e. `${YOUR_VARIABLE}`'],
+    ['instanceName', 'String', 'Name of the Azure instance. **Supports both domain formats**: `.openai.azure.com` (legacy) and `.cognitiveservices.azure.com` (new). You can specify either the full domain (e.g., `my-instance.cognitiveservices.azure.com`) or just the instance name (e.g., `my-instance`) for backward compatibility with the legacy `.openai.azure.com` format.', 'It\'s recommended to use a custom env. variable reference for this field, i.e. `${YOUR_VARIABLE}`'],
   ]}
 />
 
@@ -123,7 +123,10 @@ apiKey: "${WESTUS_API_KEY}"
 
 **Example:**
 ```yaml filename="endpoints / azureOpenAI / groups / {group_item} / instanceName"
+# Using just the instance name (legacy format applied)
 instanceName: "my-westus"
+# OR using the full domain (new format)
+instanceName: "my-westus.cognitiveservices.azure.com"
 ```
 
 

--- a/pages/docs/configuration/stt_tts.mdx
+++ b/pages/docs/configuration/stt_tts.mdx
@@ -93,6 +93,14 @@ speech:
       apiVersion: 'apiVersion'
 ```
 
+<Callout type="info" title="Azure Endpoint Domain Support">
+The `instanceName` field supports both Azure OpenAI domain formats:
+- **New format**: `.cognitiveservices.azure.com` (e.g., `my-instance.cognitiveservices.azure.com`)
+- **Legacy format**: `.openai.azure.com` (e.g., `my-instance.openai.azure.com`)
+
+You can specify either the full domain or just the instance name. If you provide a full domain including `.azure.com`, it will be used as-is. Otherwise, the legacy `.openai.azure.com` format will be applied for backward compatibility.
+</Callout>
+
 - #### OpenAI compatible
 
 Refer to the OpenAI Whisper section, adjusting the `url` and `model` as needed.
@@ -188,6 +196,14 @@ speech:
       model: 'tts-1'
       voices: ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer']
 ```
+
+<Callout type="info" title="Azure Endpoint Domain Support">
+The `instanceName` field supports both Azure OpenAI domain formats:
+- **New format**: `.cognitiveservices.azure.com` (e.g., `my-instance.cognitiveservices.azure.com`)
+- **Legacy format**: `.openai.azure.com` (e.g., `my-instance.openai.azure.com`)
+
+You can specify either the full domain or just the instance name. If you provide a full domain including `.azure.com`, it will be used as-is. Otherwise, the legacy `.openai.azure.com` format will be applied for backward compatibility.
+</Callout>
 
 - #### ElevenLabs
 


### PR DESCRIPTION
Updated documentation to reflect changes from LibreChat PR https://github.com/danny-avila/LibreChat/pull/10355, which fixed Azure OpenAI Speech-to-Text 400 Bad Request errors by adding support for the new `.cognitiveservices.azure.com` domain format alongside the legacy `.openai.azure.com` format.

Changes:
- Added domain format support callouts in STT/TTS configuration documentation
- Updated Azure OpenAI configuration guide with new endpoint format examples
- Enhanced instanceName field descriptions across all Azure configuration docs
- Updated DALL-E baseURL documentation to show both domain formats
- Added examples demonstrating both legacy and new domain usage