### PR TITLE
 docs: update Bedrock authentication with AWS profile support

### DIFF
--- a/pages/docs/configuration/pre_configured_ai/bedrock.mdx
+++ b/pages/docs/configuration/pre_configured_ai/bedrock.mdx
@@ -6,31 +6,91 @@ You’ll also need to turn on model access for your account, which you can do by
 
 ## Authentication
 
-- You will need to set the following environment variables:
+LibreChat supports three methods for AWS Bedrock authentication, listed in order of recommendation:
+
+### Option 1: AWS Profile
+
+Using AWS profiles to handle credentials.
+
+1. **Configure your AWS profile** in `~/.aws/credentials` or `~/.aws/config`:
+
+```bash filename="~/.aws/config"
+[profile your-profile-name]
+region = us-west-2
+```
+
+```bash filename="~/.aws/credentials"
+[your-profile-name]
+aws_access_key_id = YOUR_ACCESS_KEY
+aws_secret_access_key = YOUR_SECRET_KEY
+aws_session_token = YOUR_SESSION_TOKEN
+```
+
+2. **Set environment variables** in your `.env` file:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-west-2
+BEDROCK_AWS_PROFILE=your-profile-name
+```
+
+**Optional: Enable Auto-Refresh**
+
+For automatic credential refresh using external commands (e.g., company-specific credential tools), configure `credential_process` in `~/.aws/config`:
+
+```bash filename="~/.aws/config"
+[profile your-profile-name]
+region = us-west-2
+credential_process = your-command-to-fetch-credentials --format json
+```
+
+The command must output credentials in this JSON format:
+```json
+{
+  "Version": 1,
+  "AccessKeyId": "...",
+  "SecretAccessKey": "...",
+  "SessionToken": "...",
+  "Expiration": "2025-10-31T23:59:59Z"
+}
+```
+
+**Resources:**
+- [AWS CLI Configuration Files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+- [Sourcing Credentials with External Process](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html)
+
+### Option 2: AWS Credential Provider Chain (Recommended for Production)
+
+When no explicit credentials or profile are provided, the AWS SDK uses its default credential provider chain. This is ideal for production environments using IAM roles or EC2/ECS metadata.
+
+Set only the required region in your `.env` file:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+```
+
+The credential provider will automatically find credentials from these sources (in order of precedence):
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. SSO credentials from token cache
+3. Web identity token credentials
+4. Shared credentials and config ini files (`~/.aws/credentials`, `~/.aws/config`)
+5. EC2/ECS Instance Metadata Service
+
+**Note:** The provider stops searching once credentials are found. For example, if environment variables are set, AWS credential files won't be read.
+
+### Option 3: Static Environment Variables (Not Recommended for Temporary Credentials)
+
+For simple setups or long-lived credentials, you can set credentials directly in your `.env` file:
 
 ```bash filename=".env"
 BEDROCK_AWS_DEFAULT_REGION=us-east-1
 BEDROCK_AWS_ACCESS_KEY_ID=your_access_key_id
 BEDROCK_AWS_SECRET_ACCESS_KEY=your_secret_access_key
+# Optional: Only needed for temporary credentials
+BEDROCK_AWS_SESSION_TOKEN=your_session_token
 ```
 
-**Note:** You can also omit the access keys in order to use the default AWS credentials chain but you must set the default region:
-
-```bash filename=".env"
-BEDROCK_AWS_DEFAULT_REGION=us-east-1
-```
-
-Doing so prompts the credential provider to find credentials from the following sources (listed in order of precedence):
-
-- Environment variables exposed via process.env
-- SSO credentials from token cache
-- Web identity token credentials
-- Shared credentials and config ini files
-- The EC2/ECS Instance Metadata Service
-
-The default credential provider will invoke one provider at a time and only continue to the next if no credentials have been located.
-
-For example, if the process finds values defined via the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables, the files at ~/.aws/credentials and ~/.aws/config will not be read, nor will any messages be sent to the Instance Metadata Service.
+**Warning:** This method requires manual updates when credentials expire and is not suitable for temporary credentials that rotate frequently.
 
 ## Configuring models
 


### PR DESCRIPTION
##  docs: update Bedrock authentication with AWS profile support

  - Add AWS profile configuration as Option 1
  - Document credential_process for automatic credential refresh
  - Reorganize authentication methods into three clear options with recommendations
  - Add examples for ~/.aws/config and ~/.aws/credentials setup
  - Include JSON format specification for credential_process output
  - Add links to AWS CLI configuration and external process documentation
  - Clarify when to use each authentication method (profiles vs provider chain vs static)
  - Add warnings about static credentials with temporary tokens

  Aligns documentation with new BEDROCK_AWS_PROFILE feature in LibreChat - PR: https://github.com/danny-avila/LibreChat/pull/10504.