### PR TITLE
docs: add Northflank one-click deploy guide

### DIFF
--- a/pages/docs/remote/_meta.ts
+++ b/pages/docs/remote/_meta.ts
@@ -4,6 +4,7 @@ export default {
   docker_linux: 'Docker (Remote Linux)',
   huggingface: 'Hugging Face',
   railway: 'Railway',
+  northflank: 'Northflank',
   tunnels_proxies: {
     // "title": "Contributing",
     type: 'separator',

--- a/pages/docs/remote/northflank.mdx
+++ b/pages/docs/remote/northflank.mdx
@@ -1,0 +1,59 @@
+---
+title: Northflank (one-click)
+description: Deploying LibreChat on Northflank
+---
+
+# Deploying LibreChat on Northflank (One-Click Deploy)
+
+Northflank provides a one-click deployment template for LibreChat. It sets up all required services for you so you can get started quickly.
+
+## Overview
+
+The template automatically provisions the databases, search engine, RAG API, and the LibreChat service.
+
+## Prerequisites
+
+You need a Northflank account. [Create one here](https://app.northflank.com/signup)
+
+## Step 1: Open the deployment template
+
+Click the button below to open the LibreChat one-click template.
+
+<p align="left">
+  <a href="https://northflank.com/stacks/deploy-librechat">
+    <img
+      src="https://assets.northflank.com/deploy_to_northflank_smm_36700fb050.svg"
+      alt="Deploy to Northflank"
+      height="30"
+    />
+  </a>
+</p>
+
+## Step 2: Start the deployment
+
+Click **Deploy LibreChat Now** to begin.
+
+## Step 3: Check environment variables
+
+Each service comes with pre-filled environment variables. Review them and adjust anything you need before deploying.
+
+## Step 4: Deploy
+
+Click **Deploy**.
+
+Northflank will create a project and set up the following services:
+
+- PostgreSQL with pgvector
+- MongoDB
+- Meilisearch
+- RAG API
+- LibreChat
+
+## Step 5: Access LibreChat
+
+When the deployment completes, Northflank will provide a public URL where you can access your LibreChat instance.
+
+## Additional tips
+
+- Check the LibreChat repository for updates and redeploy when new versions are available.
+- For troubleshooting or more detailed guidance, see the Northflank LibreChat [deployment guide](https://northflank.com/guides/how-to-deploy-librechat-step-by-step-deployment-guide).


### PR DESCRIPTION
Add docs page covering the LibreChat one-click deploy on Northflank.