### PR TITLE
📚 docs: Update model_specs.mdx

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -276,6 +276,122 @@ Controls whether the model's icon appears in the header dropdown button, left of
 
 ---
 
+### authType
+
+<OptionTable
+  options={[
+    ['authType', 'String', 'Authentication type required for the model spec.', 'Optional. Possible values: "override_auth", "user_provided", "system_defined"'],
+  ]}
+/>
+
+**Description:**  
+Authentication type required for the model spec. Determines whether authentication is overridden, provided by the user, or defined by the system.
+
+---
+
+### webSearch
+
+<OptionTable
+  options={[
+    ['webSearch', 'Boolean', 'Enables web search capability for this model spec.', 'When true, the model can perform web searches.'],
+  ]}
+/>
+
+**Description:**  
+Enables web search capability for this model spec. When set to `true`, the model can perform web searches to retrieve current information.
+
+**Example:**
+```yaml filename="modelSpecs / webSearch"
+modelSpecs:
+  list:
+    - name: "research-assistant"
+      label: "Research Assistant"
+      webSearch: true
+      preset:
+        endpoint: "openAI"
+        model: "gpt-4o"
+```
+
+---
+
+### fileSearch
+
+<OptionTable
+  options={[
+    ['fileSearch', 'Boolean', 'Enables file search capability for this model spec.', 'When true, the model can search through uploaded files.'],
+  ]}
+/>
+
+**Description:**  
+Enables file search capability for this model spec. When set to `true`, the model can search through and reference uploaded files.
+
+**Example:**
+```yaml filename="modelSpecs / fileSearch"
+modelSpecs:
+  list:
+    - name: "document-analyst"
+      label: "Document Analyst"
+      fileSearch: true
+      preset:
+        endpoint: "openAI"
+        model: "gpt-4o"
+```
+
+---
+
+### executeCode
+
+<OptionTable
+  options={[
+    ['executeCode', 'Boolean', 'Enables code execution capability for this model spec.', 'When true, the model can execute code.'],
+  ]}
+/>
+
+**Description:**  
+Enables code execution capability for this model spec. When set to `true`, the model can execute code in a sandboxed environment.
+
+**Example:**
+```yaml filename="modelSpecs / executeCode"
+modelSpecs:
+  list:
+    - name: "code-assistant"
+      label: "Code Assistant"
+      executeCode: true
+      preset:
+        endpoint: "openAI"
+        model: "gpt-4o"
+```
+
+---
+
+### mcpServers
+
+<OptionTable
+  options={[
+    ['mcpServers', 'Array of Strings', 'List of Model Context Protocol (MCP) server names to enable for this model spec.', 'Each string should match a configured MCP server name.'],
+  ]}
+/>
+
+**Description:**  
+List of Model Context Protocol (MCP) server names to enable for this model spec. MCP servers extend the model's capabilities with custom tools and resources.
+
+**Example:**
+```yaml filename="modelSpecs / mcpServers"
+modelSpecs:
+  list:
+    - name: "enhanced-assistant"
+      label: "Enhanced Assistant"
+      mcpServers:
+        - "filesystem"
+        - "sequential-thinking"
+        - "fetch"
+      preset:
+        endpoint: "openAI"
+        model: "gpt-4o"
+```
+
+---
+
 ### preset
 
 <OptionTable


### PR DESCRIPTION
This pull request adds documentation for five configuration options available in the `modelSpecs` section of the `librechat.yaml`.

New model spec configuration options:

* Added documentation for the `authType` field, describing how to specify the authentication method for a model spec.
* Added documentation for the `webSearch` field, explaining how to enable web search capabilities for a model spec.
* Added documentation for the `fileSearch` field, detailing how to allow models to search uploaded files.
* Added documentation for the `executeCode` field, describing how to enable code execution within a model spec.
* Added documentation for the `mcpServers` field, showing how to specify which Model Context Protocol servers to enable for a model spec.