### PR TITLE
📒 docs: Add documentation for adding default params via custom params

### DIFF
--- a/components/changelog/content/config_v1.3.2.mdx
+++ b/components/changelog/content/config_v1.3.2.mdx
@@ -1,0 +1,9 @@
+- Added `default` field to `customParams.paramDefinitions` for setting default parameter values
+  - Allows specifying default values for parameters that are automatically applied when making API requests
+  - Default values are only applied when the parameter is `undefined`
+  - Follows priority order: `paramDefinitions.default` < `addParams` < `modelOptions` (user selections)
+  - Example: Set `temperature: 0.7` as default, users can still override with their own values
+  - Supports all parameter types including `web_search`, `temperature`, `topP`, `maxTokens`, etc.
+  - Works with all `defaultParamsEndpoint` values (OpenAI, Anthropic, Google, etc.)
+  - Useful for establishing baseline parameter values without requiring manual user configuration
+  - See [Custom Parameters - Setting Default Parameter Values](/docs/configuration/librechat_yaml/object_structure/custom_params#setting-default-parameter-values) for details

--- a/pages/docs/configuration/librechat_yaml/object_structure/custom_params.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/custom_params.mdx
@@ -38,6 +38,40 @@ endpoints:
 ```
 As a result, the `Temperature` slider will be limited to the range of `0.0` and `0.7` with step of `0.1`, and a default of `0.5`. The rest of the parameters will be set to their default values.
 
+### Setting Default Parameter Values
+
+You can specify default values for parameters that will be automatically applied when making API requests. This is useful for setting baseline parameter values for your custom endpoint without requiring users to manually configure them each time.
+
+The `default` field in `paramDefinitions` allows you to set default values that are applied when parameters are undefined. These defaults follow a priority order to ensure proper override behavior:
+
+**Priority Order (lowest to highest):**
+1. **Default values from `paramDefinitions`** - Applied first when parameter is undefined
+2. **`addParams`** - Can override default values
+3. **User-configured `modelOptions`** - Highest priority, overrides everything
+
+```yaml filename="excerpt of librechat.yaml"
+endpoints:
+  custom:
+    - name: 'My Custom LLM'
+      apiKey: ...
+      baseURL: ...
+      customParams:
+        defaultParamsEndpoint: 'openAI'
+        paramDefinitions:
+          - key: temperature
+            default: 0.7
+          - key: topP
+            default: 0.9
+          - key: maxTokens
+            default: 2000
+```
+
+In this example:
+- If a user doesn't specify `temperature`, it defaults to `0.7`
+- If a user explicitly sets `temperature` to `0.5`, their value (`0.5`) takes precedence
+- The `addParams` field (if configured) can override these defaults
+- User selections in the UI always have the highest priority
+
 ### Anthropic
 
 When using `defaultParamsEndpoint: 'anthropic'`, the system provides special handling that goes beyond just displaying and using Anthropic parameter sets:


### PR DESCRIPTION
This pull request introduces documentation for setting default parameter values in custom API endpoints using the `default` configuration field and documents the update in v1.3.2's changelog.

Related to https://github.com/danny-avila/LibreChat/pull/10457