### PR TITLE
docs: add hide "base" models flag to model spec

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -125,6 +125,7 @@ modelSpecs:
       preset:
         endpoint: "openAI"
         model: "gpt-5-codex"
+```
 
 In this example, users will only see the "GPT-5 Codex" model spec in the OpenAI endpoint section, not the raw gpt-5-codex base model.
 


### PR DESCRIPTION
## Summary

Adds documentation for the new `hideBaseModels` configuration option in the `modelSpecs` object.

**Related PR:** https://github.com/danny-avila/LibreChat/pull/10915
**Related Discussion:** https://github.com/danny-avila/LibreChat/discussions/10220#discussioncomment-15032610

## Changes

1. Updated the overview to list `hideBaseModels` as a top-level field (changed "3 main fields" to "5 main fields")
2. Added a new `hideBaseModels` section after `prioritize` with:
   - OptionTable definition
   - Default value (`false`)
   - Description explaining the behavior
   - Example YAML configuration

## What is `hideBaseModels`?

When using `modelSpecs` to provide preconfigured models, both the model spec AND the base model can appear in the selector, creating confusion and clutter. The `hideBaseModels` option allows administrators to hide the underlying base models for endpoints that have model specs defined, presenting users with only the curated model options.

```yaml
modelSpecs:
  hideBaseModels: true  # Hide base models when specs exist for an endpoint
  list:
    - name: "My Custom Model"
      # ...
```

**Behavior:**
- When `hideBaseModels: true`, base models are hidden **only** for endpoints that have model specs defined
- Endpoints without any specs will continue to show their models normally
- Defaults to `false` for backwards compatibility
