### PR TITLE
docs: add OpenID connect variables

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -490,6 +490,34 @@ headers:
   X-Message-ID: "{{LIBRECHAT_BODY_MESSAGEID}}"
 ```
 
+**OpenID Connect Token Placeholders:**
+
+These placeholders are available when [OpenID Connect Token Reuse](/docs/configuration/authentication/OAuth2-OIDC/token-reuse) is configured:
+
+| Placeholder | Type | Description |
+|------------|------|-------------|
+| `{{LIBRECHAT_OPENID_TOKEN}}` | String | Raw OIDC access token from your identity provider. Use when your backend performs the OBO flow. |
+| `{{LIBRECHAT_OPENID_ID_TOKEN}}` | String | OpenID Connect ID token containing user identity claims. Use when your service needs to verify user identity or extract embedded metadata. |
+| `{{LIBRECHAT_OPENID_USER_ID}}` | String | User ID extracted from the OIDC token |
+| `{{LIBRECHAT_OPENID_USER_EMAIL}}` | String | User email from the OIDC token |
+| `{{LIBRECHAT_OPENID_USER_NAME}}` | String | User name from the OIDC token |
+| `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` | String | Microsoft Graph API access token. LibreChat performs the OBO exchange automatically. Requires Microsoft Entra ID. |
+
+**Example using OIDC tokens:**
+
+```yaml filename="endpoints / custom / headers with OIDC tokens"
+endpoints:
+  custom:
+    - name: "MyEnterpriseAPI"
+      apiKey: "user_provided"
+      baseURL: "https://api.example.com/v1"
+      headers:
+        Authorization: "Bearer {{LIBRECHAT_OPENID_TOKEN}}"
+        X-User-Email: "{{LIBRECHAT_OPENID_USER_EMAIL}}"
+      models:
+        default: ["gpt-4"]
+```
+
 ## directEndpoint
 
 **Key:**

--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -162,6 +162,19 @@ mcpServers:
     Authorization: "Bearer ${SOME_AUTH_TOKEN}"
   ```
 
+**OpenID Connect Token Placeholders:**
+
+These placeholders are available when [OpenID Connect Token Reuse](/docs/configuration/authentication/OAuth2-OIDC/token-reuse) is configured:
+
+| Placeholder | Type | Description |
+|------------|------|-------------|
+| `{{LIBRECHAT_OPENID_TOKEN}}` | String | Raw OIDC access token from your identity provider |
+| `{{LIBRECHAT_OPENID_ID_TOKEN}}` | String | OpenID Connect ID token containing user identity claims |
+| `{{LIBRECHAT_OPENID_USER_ID}}` | String | User ID from the OIDC token |
+| `{{LIBRECHAT_OPENID_USER_EMAIL}}` | String | User email from the OIDC token |
+| `{{LIBRECHAT_OPENID_USER_NAME}}` | String | User name from the OIDC token |
+| `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` | String | Microsoft Graph API token (after OBO exchange). Requires Microsoft Entra ID. |
+
 #### `iconPath`
 
 - **Type:** String (Optional)

--- a/pages/docs/features/mcp.mdx
+++ b/pages/docs/features/mcp.mdx
@@ -222,6 +222,56 @@ Available placeholders include:
 - `{{LIBRECHAT_USER_USERNAME}}` - Username
 - And many more (see [MCP Servers Configuration](/docs/configuration/librechat_yaml/object_structure/mcp_servers#headers) for complete list)
 
+### OpenID Connect & Microsoft Graph Token Support
+
+LibreChat supports passing OpenID Connect tokens and Microsoft Graph API tokens to MCP servers, enabling seamless integration with enterprise services.
+
+#### Available Token Placeholders
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{{LIBRECHAT_OPENID_TOKEN}}` | Raw OIDC access token from your identity provider |
+| `{{LIBRECHAT_OPENID_ID_TOKEN}}` | OpenID Connect ID token containing user identity claims |
+| `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` | Microsoft Graph API token (after OBO exchange) |
+
+#### Choosing Between Token Types
+
+**Use `{{LIBRECHAT_OPENID_TOKEN}}`** when:
+- Your MCP server can perform its own On-Behalf-Of (OBO) token exchange
+- You need the raw identity provider token for custom authentication flows
+- You're integrating with non-Microsoft services that accept OIDC tokens
+
+**Use `{{LIBRECHAT_OPENID_ID_TOKEN}}`** when:
+- You need to verify user identity claims (name, email, groups) without making API calls
+- Your service validates the ID token signature to authenticate users
+- You want to extract user metadata that's embedded in the token payload
+
+**Use `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}`** when:
+- You want LibreChat to handle the OBO token exchange automatically
+- Your MCP server needs a ready-to-use Microsoft Graph API token
+- You're building Microsoft 365 integrations (Outlook, OneDrive, SharePoint, Teams)
+
+#### Microsoft 365 MCP Server Example
+
+```yaml
+mcpServers:
+  Microsoft365:
+    type: streamable-http
+    url: https://your-mcp-server.example.com/mcp
+    timeout: 45000
+    initTimeout: 150000
+    startup: true
+    headers:
+      Authorization: "Bearer {{LIBRECHAT_GRAPH_ACCESS_TOKEN}}"
+    serverInstructions: "Use M365 tools to interact with Microsoft 365 services including Outlook, OneDrive, SharePoint, Teams, and other Microsoft Graph APIs."
+```
+
+#### Requirements
+
+- **OpenID Connect Token Reuse** must be configured. See [Token Reuse Configuration](/docs/configuration/authentication/OAuth2-OIDC/token-reuse)
+- For `LIBRECHAT_GRAPH_ACCESS_TOKEN`: Microsoft Entra ID as your OIDC provider
+- Optional: Set `GRAPH_API_SCOPES` environment variable (defaults to `https://graph.microsoft.com/.default`)
+
 ### Server Instructions
 
 `serverInstructions` is a LibreChat feature that dynamically adds configured instructions when any tool from that MCP server is selected:


### PR DESCRIPTION
## Summary

Adds documentation for OpenID Connect and Microsoft Graph token placeholder support in LibreChat, covering features from PRs #9931 and #10867.

## Changes

*pages/docs/features/mcp.mdx*

- Added new "OpenID Connect & Microsoft Graph Token Support" section under LibreChat-Specific Features
- Documents available token placeholders with guidance on when to use each
- Includes Microsoft 365 MCP server configuration example

*pages/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx*

- Added "OpenID Connect Token Placeholders" section after existing placeholder tables
- Documents all 6 OIDC/Graph placeholders with descriptions
- Includes example configuration for custom endpoints

*pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx*

- Added matching "OpenID Connect Token Placeholders" section for consistency

## New Placeholders Documented

| Placeholder                      | Description                                             |
|----------------------------------|---------------------------------------------------------|
| {{LIBRECHAT_OPENID_TOKEN}}       | Raw OIDC access token (backend performs OBO flow)       |
| {{LIBRECHAT_OPENID_ID_TOKEN}}    | ID token for identity verification                      |
| {{LIBRECHAT_OPENID_USER_ID}}     | User ID from OIDC token                                 |
| {{LIBRECHAT_OPENID_USER_EMAIL}}  | User email from OIDC token                              |
| {{LIBRECHAT_OPENID_USER_NAME}}   | User name from OIDC token                               |
| {{LIBRECHAT_GRAPH_ACCESS_TOKEN}} | Microsoft Graph API token (LibreChat performs OBO flow) |

## Related PRs

- #9931 - OpenID Connect federated provider token support
- #10867 - Microsoft Graph token support with automatic OBO exchange