### PR TITLE
docs: Add OpenRouter Image Generation tool documentation

### DIFF
--- a/pages/docs/features/image_gen.mdx
+++ b/pages/docs/features/image_gen.mdx
@@ -15,6 +15,7 @@ Each has its own look, price-point, and setup step (usually just an API key or U
 | **DALL·E (3 / 2)** | Legacy OpenAI Image models. | OpenAI API |
 | **Stable Diffusion** | Local or self-hosted generation, endless community models. | Automatic1111 API |
 | **Flux** | Fast cloud renders, optional fine-tunes. | Flux API |
+| **OpenRouter Image Generation** | Access multiple image models (FLUX.2-Pro, FLUX.2-Flex, Gemini, etc.) through a single API. | OpenRouter API |
 | **MCP** | Bring-your-own-Image-Generators | MCP server with image output support |
 
 **Notes:**
@@ -218,6 +219,30 @@ Choose the **Flux** tool inside the Agent. Prompts are plain text; one call prod
 
 ### Pricing
 See the [Flux pricing page](https://docs.bfl.ml/pricing/) for details on costs associated with image generation.
+
+---
+
+## 6 · OpenRouter Image Generation
+
+Generate images using OpenRouter's unified API, which provides access to multiple image generation models including FLUX.2-Pro, FLUX.2-Flex, Gemini Image Generation, and more.
+
+### Parameters
+• **prompt** – Text description of the desired image (required)  
+• **model** – The image generation model to use (optional, defaults to `black-forest-labs/flux.2-pro`)  
+• **aspect_ratio** – Aspect ratio for the image (optional, only supported by some models like Gemini): `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `21:9`, or `9:21`
+
+### Setup
+
+```bash
+OPENROUTER_API_KEY=sk-or-...
+# Optional
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+```
+
+Then add **"OpenRouter Image Generation"** to your Agent's *Tools* list.
+
+### Pricing
+See [OpenRouter's pricing page](https://openrouter.ai/pricing) for details on costs associated with different image generation models.
 
 ---
 

--- a/pages/docs/features/index.mdx
+++ b/pages/docs/features/index.mdx
@@ -65,6 +65,7 @@ import Image from 'next/image'
   - [**DALL-E**](/docs/features/image_gen#2--dalle-legacy)
   - [**Stable Diffusion**](/docs/features/image_gen#3--stable-diffusion-local)
   - [**Flux**](/docs/features/image_gen#4--flux)
+  - [**OpenRouter Image Generation**](/docs/features/image_gen#6--openrouter-image-generation)
   - [**MCP Servers**](/docs/features/image_gen#5--model-context-protocol-mcp)
 - **Image Creation**: Create high-quality, original images from detailed text descriptions
 - **Image Editing**: Modify existing images based on text instructions and image references with GPT-Image-1.


### PR DESCRIPTION
## Summary
Adds documentation for the OpenRouter Image Generation tool, which allows users to generate images using OpenRouter's unified API with access to multiple image generation models (FLUX.2-Pro, FLUX.2-Flex, Gemini Image Generation, etc.).

## Related
- Implementation PR: [#11024](https://github.com/danny-avila/LibreChat/pull/11024) - feat: Add OpenRouter Image Generation tool
- Feature Request Discussion: [#11027](https://github.com/danny-avila/LibreChat/discussions/11027) - [Enhancement]: OpenRouter Image Generation Tool

## Changes
- Added new section "6 · OpenRouter Image Generation" to `/docs/features/image_gen`
- Updated features overview in `/docs/features/index` to include OpenRouter Image Generation
- Added OpenRouter Image Generation to the tools comparison table in image generation documentation

## Details
The documentation follows the same format and style as other image generation tools (DALL·E, Stable Diffusion, Flux) and includes:
- Parameter descriptions (prompt, model, aspect_ratio)
- Setup instructions with environment variables
- Pricing information link

This documentation corresponds to the OpenRouter Image Generation tool implementation in the main LibreChat repository.