### PR TITLE
docs: add MCP OAuth Callback URL

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -284,7 +284,7 @@ mcpServers:
   - `token_url`: String - The OAuth token endpoint URL  
   - `client_id`: String - OAuth client identifier
   - `client_secret`: String - OAuth client secret
-  - `redirect_uri`: String - OAuth redirect URI (eg. `http://localhost:3080/api/mcp/${serverName}/oauth/callback`, see [MCP OAuth Callback URL](/docs/features/mcp#oauth-callback-url))
+  - `redirect_uri`: String - [OAuth redirect URI](/docs/features/mcp#oauth-callback-url) (eg. `http://localhost:3080/api/mcp/${serverName}/oauth/callback`)
   - `scope`: String - OAuth scopes (space-separated)
 - **Optional Subkeys:**
   - `grant_types_supported`: Array of Strings - Supported grant types (defaults to `["authorization_code", "refresh_token"]`)

--- a/pages/docs/features/mcp.mdx
+++ b/pages/docs/features/mcp.mdx
@@ -367,18 +367,16 @@ When you first configure an OAuth-enabled MCP server:
 
 #### OAuth Callback URL
 
-When an MCP server uses OAuth for authentication, LibreChat exposes a callback URL that the OAuth provider needs to redirect to after a successful authorization.
+When an MCP server uses OAuth, LibreChat exposes a callback endpoint that the OAuth provider redirects to after successful authorization.
 
-LibreChat expects the OAuth redirect to use the following API route:
+The callback URL must follow this format: 
 
 `${baseUrl}/api/mcp/${serverName}/oauth/callback`
 
-Where `${serverName}` corresponds to the MCP server key defined in your `librechat.yaml` configuration.
-
-After the OAuth provider redirects back to this endpoint, LibreChat automatically completes the token exchange and associates the credentials with the corresponding MCP server.
+Where `${serverName}` is the MCP server key defined in your `librechat.yaml` configuration. LibreChat handles the redirect at this endpoint, completes the token exchange, and associates the credentials with the corresponding MCP server.
 
 <Callout type="info" title="OAuth Callback URL Example">
-Using the Spotify-MCP example, the callback URL would be:
+Given the following MCP server configuration:
 
 ```yaml
 mcpServers:
@@ -391,9 +389,11 @@ mcpServers:
     url: 'https://mcp-spotify-oauth-example.account.workers.dev/mcp'
 ```
 
-`${baseUrl}/api/mcp/spotify/oauth/callback`
 
+The callback URL would be `${baseUrl}/api/mcp/spotify/oauth/callback`.
 </Callout>
+
+Note:
 
 - The callback URL must be registered exactly with the OAuth provider for the flow to work.
 - Other paths such as `/api/oauth/callback` or `/api/oauth/openid/callback` are not valid for MCP OAuth flows.


### PR DESCRIPTION
This PR documents the specific callback URI necessary to complete an MCP OAuth flow.
The correct UIR is mentioned in https://github.com/LibreChat-AI/librechat.ai/issues/388#issuecomment-3185564795 and https://github.com/danny-avila/LibreChat/discussions/9101