### PR TITLE
docs: Add Bedrock Guardrails support

### DIFF
--- a/pages/docs/configuration/pre_configured_ai/bedrock.mdx
+++ b/pages/docs/configuration/pre_configured_ai/bedrock.mdx
@@ -57,6 +57,10 @@ endpoints:
       - "us-west-2"
     streamRate: 35
     titleModel: 'anthropic.claude-3-haiku-20240307-v1:0'
+    guardrailConfig:
+      guardrailIdentifier: "abc123xyz"
+      guardrailVersion: "1"
+      trace: "enabled"
 ```
 
 - `streamRate`: (Optional) Set the rate of processing each new token in milliseconds.
@@ -69,6 +73,12 @@ endpoints:
 - `availableRegions`: (Optional) Specify the AWS regions you want to make available.
     - If provided, users will see a dropdown to select the region. If not selected, the default region is used.
     - ![image](https://github.com/user-attachments/assets/6f3c5e82-9c6b-4643-8487-07db1061ba49)
+
+- `guardrailConfig`: (Optional) Configure AWS Bedrock Guardrails for content filtering.
+    - `guardrailIdentifier`: The guardrail ID or ARN from your AWS Bedrock Console.
+    - `guardrailVersion`: The guardrail version number (e.g., `"1"`) or `"DRAFT"`.
+    - `trace`: (Optional) Enable trace logging: `"enabled"`, `"disabled"`, or `"enabled_full"`.
+    - See [AWS Bedrock Guardrails documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-how.html) for creating and managing guardrails.
 
 ## Notes
 


### PR DESCRIPTION
Add Bedrock Guardrails configuration documentation in support of https://github.com/danny-avila/LibreChat/pull/11141