### PR TITLE
add 'bedrock' to endpoints example in dotenv config

### DIFF
--- a/pages/docs/configuration/dotenv.mdx
+++ b/pages/docs/configuration/dotenv.mdx
@@ -262,7 +262,7 @@ Uncomment `ENDPOINTS` to customize the available endpoints in LibreChat.
 
 <OptionTable
   options={[
-    ['ENDPOINTS', 'string', 'Comma-separated list of available endpoints.', '# ENDPOINTS=openAI,agents,assistants,gptPlugins,azureOpenAI,google,anthropic,bingAI,custom'],
+    ['ENDPOINTS', 'string', 'Comma-separated list of available endpoints.', '# ENDPOINTS=openAI,agents,assistants,gptPlugins,azureOpenAI,google,anthropic,bingAI,bedrock,custom'],
     ['PROXY', 'string', 'Proxy setting for all endpoints.', 'PROXY='],
     ['TITLE_CONVO', 'boolean', 'Enable titling for all endpoints.', 'TITLE_CONVO=true'],
   ]}


### PR DESCRIPTION
It was hard for me to find out why bedrock endpoint is not showing in dropdown. Then I read docs https://www.librechat.ai/docs/configuration/dotenv and found that 'bedrock' is missing in the 'ENDPOINTS' example.

I know its just an example, but for me it'll save lot of time, please merge it.

Reference:
https://github.com/danny-avila/LibreChat/blob/main/packages/data-provider/src/schemas.ts