### PR TITLE
docs: Update Traefik to v3.6 to support Docker v29

### DIFF
--- a/pages/docs/remote/traefik.mdx
+++ b/pages/docs/remote/traefik.mdx
@@ -35,7 +35,7 @@ services:
         - ./librechat.yaml:/app/librechat.yaml
   
     traefik:
-      image: traefik:v3.0
+      image: traefik:v3.6
       ports:
         - "80:80"
         - "443:443"


### PR DESCRIPTION
Docker v29 dropped support for Docker API 1.24 which was the API version Traefik was using, see [here](https://github.com/traefik/traefik/issues/12257). This caused Traefik to not launch, Traefik fixed this issue in v3.6.1, I updated my setup and it fixed the issue.