### PR TITLE
Added docs for OCR document parser strategy

### DIFF
--- a/content/docs/features/ocr.mdx
+++ b/content/docs/features/ocr.mdx
@@ -163,11 +163,23 @@ ocr:
 3. Download the service account JSON key file
 4. Set the `GOOGLE_SERVICE_KEY_FILE` environment variable using one of the supported methods
 
-### 4. Custom OCR (Planned)
+### 4. Document Parser
+
+The built-in document parser OCR strategy supports native parsing of some
+document file formats (like PDF, DOCX, and XLSX) as text.
+
+**Configuration:**
+```yaml
+# `librechat.yaml`
+ocr:
+  strategy: "document_parser"
+```
+
+### 5. Custom OCR (Planned)
 
 Support for custom OCR providers and user-defined strategies is planned for future releases.
 
-### 5. Upload Files to Provider (Direct)
+### 6. Upload Files to Provider (Direct)
 
 For supported LLM Providers (**OpenAI, AzureOpenAI, Anthropic, Google, and AWS Bedrock**) and their respective models, files can now be sent directly to the provider APIs as message attachments,
 allowing the provider to use their own native OCR implementations to parse files using the `Upload to Provider` option in the file attachment dropdown menu. 


### PR DESCRIPTION
I was not sure if we should callout that it's technically not OCR, can update if we want to do that.

Related PR here: https://github.com/danny-avila/LibreChat/pull/11519