### PR TITLE
docs: enhance interface documentation for prompts and agents permissions

### DIFF
--- a/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/pages/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -270,11 +270,9 @@ interface:
 
 **Important: Boolean vs Object Configuration**
 
-- **Boolean (`prompts: true`)**: Only updates the `use` permission. Existing `create`, `share`, and `public` permission values are **preserved** from the database. Use this when you want to enable/disable prompts without affecting other settings that may have been configured through the admin panel.
+- **Boolean (`prompts: true`)**: Only updates the `use` permission. Existing `create`, `share`, and `public` permission values are **preserved** from the database. Use this as a simple feature toggle without affecting other settings configured through the admin panel.
 
-- **Object (`prompts: { use: true, create: false }`)**: Updates only the specified sub-permissions. The `share` and `public` permissions are only updated if explicitly included in the config. This allows you to control `use` and `create` without affecting sharing settings.
-
-- **Object with sharing (`prompts: { use: true, share: true }`)**: Updates all specified sub-permissions including sharing. Use this when you want explicit control over sharing permissions via the configuration file.
+- **Object**: Updates only the sub-permissions that are explicitly specified. Any permissions not included in the config are preserved from the database.
 
 When using the object structure:
 
@@ -288,13 +286,22 @@ When using the object structure:
   ]}
 />
 
-**Example (boolean - preserves existing create/share/public settings):**
+**Example (boolean - simple feature toggle):**
 ```yaml filename="interface / prompts (boolean)"
 interface:
-  prompts: true  # Enables USE, but create/share/public settings remain unchanged
+  prompts: true  # Only updates USE; create/share/public remain unchanged
 ```
 
-**Example (object - explicit control):**
+**Example (object - granular control):**
+```yaml filename="interface / prompts (object)"
+interface:
+  prompts:
+    use: true
+    create: false  # Disable creation while allowing use
+    # share and public not specified - preserves existing values
+```
+
+**Example (object - full control):**
 ```yaml filename="interface / prompts (object)"
 interface:
   prompts:
@@ -372,11 +379,9 @@ More info on [Agents](/docs/features/agents)
 
 **Important: Boolean vs Object Configuration**
 
-- **Boolean (`agents: true`)**: Only updates the `use` permission. Existing `create`, `share`, and `public` permission values are **preserved** from the database. Use this when you want to enable/disable agents without affecting other settings that may have been configured through the admin panel.
+- **Boolean (`agents: true`)**: Only updates the `use` permission. Existing `create`, `share`, and `public` permission values are **preserved** from the database. Use this as a simple feature toggle without affecting other settings configured through the admin panel.
 
-- **Object (`agents: { use: true, create: false }`)**: Updates only the specified sub-permissions. The `share` and `public` permissions are only updated if explicitly included in the config. This allows you to control `use` and `create` without affecting sharing settings.
-
-- **Object with sharing (`agents: { use: true, share: true }`)**: Updates all specified sub-permissions including sharing. Use this when you want explicit control over sharing permissions via the configuration file.
+- **Object**: Updates only the sub-permissions that are explicitly specified. Any permissions not included in the config are preserved from the database.
 
 When using the object structure:
 
@@ -390,13 +395,22 @@ When using the object structure:
   ]}
 />
 
-**Example (boolean - preserves existing create/share/public settings):**
+**Example (boolean - simple feature toggle):**
 ```yaml filename="interface / agents (boolean)"
 interface:
-  agents: true  # Enables USE, but create/share/public settings remain unchanged
+  agents: true  # Only updates USE; create/share/public remain unchanged
 ```
 
-**Example (object - explicit control):**
+**Example (object - granular control):**
+```yaml filename="interface / agents (object)"
+interface:
+  agents:
+    use: true
+    create: false  # Disable creation while allowing use
+    # share and public not specified - preserves existing values
+```
+
+**Example (object - full control):**
 ```yaml filename="interface / agents (object)"
 interface:
   agents:


### PR DESCRIPTION
Added 'create' permission to both prompts and agents sections, clarifying the configuration options. Updated examples to reflect changes in permission handling for boolean and object structures, ensuring users understand the implications of each setting.