### PR TITLE
docs: update roadmap links to 2026 

### DIFF
--- a/components/DocsHub.tsx
+++ b/components/DocsHub.tsx
@@ -98,9 +98,9 @@ const resources = [
   },
   {
     icon: Map,
-    title: '2025 Roadmap',
+    title: '2026 Roadmap',
     description: "What's planned",
-    href: '/blog/2025-02-20_2025_roadmap',
+    href: '/blog/2026-02-18_2026_roadmap',
   },
   {
     icon: MessageSquare,

--- a/components/QuickStartHub.tsx
+++ b/components/QuickStartHub.tsx
@@ -90,9 +90,9 @@ const resources = [
   },
   {
     icon: Map,
-    title: '2025 Roadmap',
+    title: '2026 Roadmap',
     description: "What's planned",
-    href: '/blog/2025-02-20_2025_roadmap',
+    href: '/blog/2026-02-18_2026_roadmap',
   },
   {
     icon: MessageSquare,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,7 +45,7 @@ const nonPermanentRedirects = [
   ['/issues', 'https://github.com/danny-avila/LibreChat/issues'],
   ['/gh-support', 'https://github.com/danny-avila/LibreChat/discussions/categories/support'],
   ['/gh-discussions', 'https://github.com/danny-avila/LibreChat/discussions'],
-  ['/roadmap', '/docs/roadmap'],
+  ['/roadmap', '/blog/2026-02-18_2026_roadmap'],
   ['/features', '/docs/features'],
   ['/docs/configuration/librechat_yaml/ai_endpoints/azure', '/docs/configuration/azure'],
   ['/docs/user_guides/artifacts', '/docs/features/artifacts'],


### PR DESCRIPTION
Updates roadmap references in QuickStartHub, DocsHub, and the `/roadmap` redirect to point to the new 2026 roadmap blog post