### PR TITLE
Very small update to the Environment Variables Docs page

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -326,7 +326,7 @@ For detailed configuration and customization options, see: [Web Search Configura
 
 ### Anthropic
 see: [Anthropic Endpoint](/docs/configuration/pre_configured_ai/anthropic)
-- You can request an access key from https://console.anthropic.com/
+- You can request an access key from https://platform.claude.com/
 - Leave `ANTHROPIC_API_KEY=` blank to disable this endpoint
 - Set `ANTHROPIC_API_KEY=` to "user_provided" to allow users to provide their own API key from the WebUI
 - If you have access to a reverse proxy for `Anthropic`, you can set it with `ANTHROPIC_REVERSE_PROXY=`


### PR DESCRIPTION
Anthropic has changed the console URL from console.anthropic.com to platform.claude.com. Currently, going to console.anthropic.com will auto redirect (HTTP 302) you to platform.claude.com.