### PR TITLE
docs: add OPENID_MAX_LOGOUT_URL_LENGTH environment variable

### DIFF
--- a/content/docs/configuration/authentication/OAuth2-OIDC/auth0.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/auth0.mdx
@@ -125,6 +125,9 @@ OPENID_USE_PKCE=true
 # Session Configuration (generate a secure random string)
 OPENID_SESSION_SECRET=your-secure-session-secret-32-chars-or-more
 
+# Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+# OPENID_MAX_LOGOUT_URL_LENGTH=2000
+
 # Optional: Custom button appearance
 OPENID_BUTTON_LABEL=Continue with Auth0
 # OPENID_IMAGE_URL=https://path-to-auth0-logo.png

--- a/content/docs/configuration/authentication/OAuth2-OIDC/authelia.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/authelia.mdx
@@ -39,5 +39,8 @@ description: Learn how to configure LibreChat to use Authelia for user authentic
   OPENID_SCOPE="openid profile email"
   OPENID_IMAGE_URL=https://www.authelia.com/images/branding/logo-cropped.png
   # Optional: redirects the user to the end session endpoint after logging out
-  OPENID_USE_END_SESSION_ENDPOINT=true 
+  OPENID_USE_END_SESSION_ENDPOINT=true
+
+  # Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+  # OPENID_MAX_LOGOUT_URL_LENGTH=2000
   ```

--- a/content/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/authentik.mdx
@@ -49,6 +49,9 @@ OPENID_IMAGE_URL=https://cdn.jsdelivr.net/gh/selfhst/icons/png/authentik.png
 OPENID_GENERATE_NONCE=true
 # Redirects the user to the end session endpoint after logging out
 OPENID_USE_END_SESSION_ENDPOINT=true
+
+# Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+# OPENID_MAX_LOGOUT_URL_LENGTH=2000
 ```
 
 > Note: Make sure nothing is wrapped in quotes in your .env and you have allowed social login.

--- a/content/docs/configuration/authentication/OAuth2-OIDC/aws.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/aws.mdx
@@ -112,6 +112,9 @@ OPENID_CALLBACK_URL=/oauth/openid/callback
 OPENID_USE_END_SESSION_ENDPOINT=true
 # Optional: generates the nonce url parameter.
 OPENID_GENERATE_NONCE=true
+
+# Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+# OPENID_MAX_LOGOUT_URL_LENGTH=2000
 ```
 
 > [!WARNING]  

--- a/content/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
@@ -56,7 +56,10 @@ OPENID_REQUIRED_ROLE_PARAMETER_PATH="roles"
 OPENID_REQUIRED_ROLE="Your Group Name" # Single role or comma-separated roles (e.g., Group1,Group2,Admin)
 
 # Optional: redirects the user to the end session endpoint after logging out
-OPENID_USE_END_SESSION_ENDPOINT=true 
+OPENID_USE_END_SESSION_ENDPOINT=true
+
+# Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+# OPENID_MAX_LOGOUT_URL_LENGTH=2000
 ```
 11. Save the .env file
 

--- a/content/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/keycloak.mdx
@@ -66,5 +66,8 @@ If you want to restrict access to users with specific roles, you can define role
   OPENID_REQUIRED_ROLE_PARAMETER_PATH="realm_access.roles"
 
   # Optional: redirects the user to the end session endpoint after logging out
-  OPENID_USE_END_SESSION_ENDPOINT=true 
+  OPENID_USE_END_SESSION_ENDPOINT=true
+
+  # Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+  # OPENID_MAX_LOGOUT_URL_LENGTH=2000
   ```

--- a/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
@@ -113,6 +113,9 @@ OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE=user.read
 
 # Logout Configuration
 OPENID_USE_END_SESSION_ENDPOINT=true
+
+# Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
+# OPENID_MAX_LOGOUT_URL_LENGTH=2000
 ```
 
 ## Additional Configuration Options
@@ -123,6 +126,7 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 - `OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED`: Enables on-behalf-of flow for user info (Azure-specific)
 - `OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE`: Scope for user info in on-behalf-of flow (Azure-specific)
 - `OPENID_USE_END_SESSION_ENDPOINT`: Enables use of the end session endpoint for logout
+- `OPENID_MAX_LOGOUT_URL_LENGTH`: Maximum URL length before using `logout_hint` instead of `id_token_hint` to prevent "URI too long" errors (default: 2000)
 
 ## Security Considerations
 

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -1040,6 +1040,7 @@ For more information:
     ['OPENID_BUTTON_LABEL', 'string', 'The label for the OpenID login button.','OPENID_BUTTON_LABEL='],
     ['OPENID_IMAGE_URL', 'string', 'The URL of the OpenID login button image.','OPENID_IMAGE_URL='],
     ['OPENID_USE_END_SESSION_ENDPOINT', 'string', 'Whether to use the Issuer End Session Endpoint as a Logout Redirect','OPENID_USE_END_SESSION_ENDPOINT=TRUE'],
+    ['OPENID_MAX_LOGOUT_URL_LENGTH', 'number', 'Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000).','# OPENID_MAX_LOGOUT_URL_LENGTH=2000'],
     ['OPENID_AUTO_REDIRECT', 'boolean', 'Whether to automatically redirect to the OpenID provider.','OPENID_AUTO_REDIRECT=true'],
     ['OPENID_USE_PKCE', 'boolean', 'Use PKCE (Proof Key for Code Exchange) for OpenID authentication.','# OPENID_USE_PKCE=true'],
     ['OPENID_POST_LOGOUT_REDIRECT_URI', 'string', 'Redirect URI after OpenID logout. Defaults to ${DOMAIN_CLIENT}/login.','# OPENID_POST_LOGOUT_REDIRECT_URI='],
@@ -1066,6 +1067,7 @@ LibreChat supports reusing access and refresh tokens issued by your OpenID Conne
     ['OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED', 'boolean', 'Enable on-behalf-of flow for user info.', 'OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED=true'],
     ['OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE', 'string', 'Scope for user info in on-behalf-of flow.', 'OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE=user.read'],
     ['OPENID_USE_END_SESSION_ENDPOINT', 'boolean', 'Enable use of the end session endpoint for logout.', 'OPENID_USE_END_SESSION_ENDPOINT=true'],
+    ['OPENID_MAX_LOGOUT_URL_LENGTH', 'number', 'Maximum logout URL length in characters before switching to logout_hint. Useful to prevent "URI too long" errors when id_token_hint exceeds server limits (default: 2000).', 'OPENID_MAX_LOGOUT_URL_LENGTH=2000'],
   ]}
 />
 


### PR DESCRIPTION
Greetings!

I'm opening this PR to add the new .env variable `OPENID_MAX_LOGOUT_URL_LENGTH`  that was introduced in LibreChat in this PR https://github.com/danny-avila/LibreChat/pull/12326 to the documentation.

Have a good day. 😄 