### PR TITLE
docs: Add EUrouter AI endpoint configuration

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/eurouter.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/eurouter.mdx
@@ -1,0 +1,30 @@
+---
+title: EUrouter
+description: Learn how to configure EUrouter — a GDPR-compliant, OpenRouter-compatible AI gateway for EU customers — as a custom endpoint in LibreChat.
+icon: Plug
+---
+
+[EUrouter](https://www.eurouter.ai) is a GDPR-compliant AI routing gateway for EU customers. It's API-compatible with OpenRouter, routing all requests through EU-based infrastructure.
+
+> EUrouter API key: [https://www.eurouter.ai](https://www.eurouter.ai) — generate your API key from the EUrouter dashboard.
+
+**Notes:**
+
+- EUrouter uses the same model ID format as OpenRouter (e.g., `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`).
+- `fetch: true` pulls the full model list from EUrouter's `/v1/models` endpoint.
+- Set `EUROUTER_API_KEY` in your `.env` file.
+- Streaming is fully supported.
+
+```yaml title="librechat.yaml"
+    - name: "EUrouter"
+      apiKey: "${EUROUTER_API_KEY}"
+      baseURL: "https://api.eurouter.ai/api/v1"
+      models:
+        default: ["openai/gpt-4o", "anthropic/claude-sonnet-4-20250514"]
+        fetch: true
+      titleConvo: true
+      titleModel: "openai/gpt-4o-mini"
+      summarize: false
+      dropParams: ["stop"]
+      modelDisplayLabel: "EUrouter"
+```

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -8,6 +8,7 @@
     "cohere",
     "databricks",
     "deepseek",
+    "eurouter",
     "fireworks",
     "groq",
     "helicone",


### PR DESCRIPTION
## Summary

- Adds [EUrouter](https://www.eurouter.ai) as a custom AI endpoint in the LibreChat documentation
- EUrouter is a GDPR-compliant AI routing gateway for EU customers, API-compatible with OpenRouter
- Adds `eurouter.mdx` with setup instructions and YAML config
- Adds `eurouter` to `meta.json` navigation in alphabetical order

## Change Type

- [x] Documentation update

## Testing

- [x] Verified `pnpm build` completes without errors
- [x] Confirmed sidebar navigation shows EUrouter in correct alphabetical position (between DeepSeek and Fireworks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)