### PR TITLE
docs(ai_endpoints): add Rapid-MLX section to MLX endpoint page

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/mlx.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/mlx.mdx
@@ -35,3 +35,34 @@ description: Example configuration for Apple MLX
 ```
 
 ![MLX](https://github.com/LibreChat-AI/librechat.ai/assets/32828263/e5765729-5ee4-4dbc-b553-df1684486a23)
+
+## Rapid-MLX
+
+[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an alternative
+OpenAI-compatible MLX server for Apple Silicon. It supports streaming and
+tool calling natively (18 built-in parsers), and ships day-0 support for
+recent open models such as Gemma 4 and Qwen3.5.
+
+**Install and run:**
+
+```bash
+pip install rapid-mlx
+rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit
+```
+
+The server listens on `http://localhost:8000/v1` and implements the
+OpenAI chat completions API.
+
+**`librechat.yaml` configuration:**
+
+```yaml
+    - name: "Rapid-MLX"
+      apiKey: "rapid-mlx"
+      baseURL: "http://localhost:8000/v1/"
+      models:
+        default: ["mlx-community/Qwen3.5-4B-MLX-4bit"]
+        fetch: true
+      titleConvo: true
+      titleModel: "current_model"
+      modelDisplayLabel: "Rapid-MLX"
+```


### PR DESCRIPTION
## Summary

Adds a Rapid-MLX section to the existing Apple MLX endpoint docs page.
[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an OpenAI-compatible
inference server for Apple Silicon built on Apple's MLX framework, with
streaming and native tool calling.

## Why

The existing MLX page documents `mlx-lm`'s built-in server. Rapid-MLX is
a second OpenAI-compatible MLX option that adds native tool calling (18
built-in parsers) and day-0 support for recent open models. Mentioning
both in the same page lets Apple Silicon users pick the one that fits
their use case.

## Scope

Docs only. Single file change. The MLX endpoint type already exists in
LibreChat's config schema, so no main repo changes are needed —
`librechat.yaml` accepts the new entry as-is.