### PR TITLE
 docs: add Tigris to S3-compatible providers

### DIFF
--- a/content/docs/configuration/cdn/s3.mdx
+++ b/content/docs/configuration/cdn/s3.mdx
@@ -98,7 +98,7 @@ AWS_ENDPOINT_URL=your_endpoint_url
 - **AWS_SECRET_ACCESS_KEY:** Your IAM user's secret key.
 - **AWS_REGION:** The AWS region where your S3 bucket is located.
 - **AWS_BUCKET_NAME:** The name of the S3 bucket you created.
-- **AWS_ENDPOINT_URL:** (Optional) The custom AWS endpoint URL. Required for S3-compatible services such as MinIO, Cloudflare R2, Hetzner Object Storage, and Backblaze B2.
+- **AWS_ENDPOINT_URL:** (Optional) The custom AWS endpoint URL. Required for S3-compatible services such as MinIO, Cloudflare R2, Hetzner Object Storage, Backblaze B2, and Tigris.
 - **AWS_FORCE_PATH_STYLE:** (Optional) Set to `true` for providers that require path-style URLs (`endpoint/bucket/key`) rather than virtual-hosted-style (`bucket.endpoint/key`). Required for Hetzner Object Storage, MinIO, and similar providers whose SSL certificates don't cover bucket subdomains. Not needed for AWS S3 or Cloudflare R2. Default: `false`.
 
 If you are using **IRSA** on Kubernetes, you do **not** need to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your environment. The AWS SDK will automatically obtain temporary credentials via the service account assigned to your pod. Ensure that `AWS_REGION` and `AWS_BUCKET_NAME` are still provided.
@@ -150,4 +150,25 @@ With these steps, your LibreChat application will use Amazon S3 to handle file u
 
 <Callout type="info" title="Note">
   Always ensure your AWS credentials remain secure. Do not commit them to a public repository. Adjust IAM policies to follow the principle of least privilege as needed.
+</Callout>
+
+## S3-Compatible Providers
+
+The same `fileStrategy: "s3"` configuration works with any S3-compatible service. Set `AWS_ENDPOINT_URL` to the provider's endpoint and adjust credentials accordingly.
+
+### Tigris
+
+[Tigris](https://www.tigrisdata.com/) is S3-compatible object storage with zero egress fees and a free tier (5 GB). Create credentials from the [Tigris Dashboard](https://console.tigris.dev/).
+
+```bash filename=".env"
+AWS_ACCESS_KEY_ID=tid_your_access_key
+AWS_SECRET_ACCESS_KEY=tsec_your_secret_key
+AWS_REGION=auto
+AWS_BUCKET_NAME=librechat
+AWS_ENDPOINT_URL=https://t3.storage.dev
+# AWS_FORCE_PATH_STYLE=false
+```
+
+<Callout type="info" title="Note">
+  Tigris uses virtual-hosted-style addressing by default. Do not set `AWS_FORCE_PATH_STYLE` to `true`.
 </Callout>


### PR DESCRIPTION
### Summary
Hey! 👋 This PR adds Tigris as an example S3-compatible provider to the existing Amazon S3 file storage docs.

- Adds "Tigris" to the list of S3-compatible services in the `AWS_ENDPOINT_URL` description
- Adds an "S3-Compatible Providers" section at the bottom of the S3 page with a Tigris `.env` example — just the values that differ from the standard AWS setup
- The section is structured so other providers' examples can be added in the same format

### Why
MinIO's open-source repo was archived in February 2026, and users looking for S3-compatible alternatives need documented options. The page already mentions MinIO, R2, Hetzner, and Backblaze B2 by name — this adds Tigris with a concrete configuration example so users can get started quickly.

### Test plan
- [X]  Verified env var names match the codebase (AWS_ENDPOINT_URL, AWS_REGION, AWS_FORCE_PATH_STYLE in packages/api/src/storage/s3/s3Config.ts and packages/api/src/cdn/s3.ts)
- [X]  No new files — single-page edit to content/docs/configuration/cdn/s3.mdx
- [X]  Docs build cleanly