### PR TITLE
docs: add branding config and disableProviderUpload per-endpoint field

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/branding.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/branding.mdx
@@ -1,0 +1,156 @@
+---
+title: "Branding Object Structure"
+icon: Palette
+---
+
+## Overview
+
+The `branding` object enables white-label customization of LibreChat. It provides runtime control over logos, favicons, browser metadata, color themes, and UI behavior — without requiring source code changes.
+
+Branding is resolved through the same app-config pipeline as `interface` and `turnstile`, and is delivered to the frontend via the `/api/config` startup payload.
+
+These are the top-level fields under `branding`:
+
+- `appLogo`
+- `authLogo`
+- `favicon`
+- `meta`
+- `theme`
+- `ui`
+
+## Example
+
+```yaml filename="librechat.yaml"
+branding:
+  appLogo: "/assets/my-logo.svg"
+  authLogo: "/assets/my-auth-logo.svg"
+  favicon: "/assets/my-favicon.png"
+  meta:
+    title: "My Chat App"
+    description: "Powered by LibreChat"
+    themeColor: "#0f766e"
+    pwaName: "My Chat App"
+    pwaShortName: "ChatApp"
+    pwaBackgroundColor: "#ffffff"
+    pwaThemeColor: "#0f766e"
+  theme:
+    light:
+      rgb-primary: "15 118 110"
+      rgb-accent: "13 148 136"
+      rgb-surface-primary: "248 250 252"
+    dark:
+      rgb-primary: "45 212 191"
+      rgb-accent: "20 184 166"
+      rgb-surface-primary: "15 23 42"
+  ui:
+    hideProviderUploadForEndpoints:
+      - "openAI"
+      - "custom"
+```
+
+## branding
+
+<OptionTable
+  options={[
+    ['branding', 'Object', 'White-label branding configuration. All fields are optional. When omitted, LibreChat defaults apply.'],
+  ]}
+/>
+
+### appLogo
+
+<OptionTable
+  options={[
+    ['appLogo', 'String', 'Path or URL to the main application logo. Used in the app header and other in-app contexts.', '/assets/logo.svg'],
+  ]}
+/>
+
+### authLogo
+
+<OptionTable
+  options={[
+    ['authLogo', 'String', 'Path or URL to the logo shown on the login and registration pages. Falls back to `appLogo`, then to the default LibreChat logo.', '/assets/logo.svg'],
+  ]}
+/>
+
+### favicon
+
+<OptionTable
+  options={[
+    ['favicon', 'String', 'Path or URL to the browser favicon. Replaces the default LibreChat favicon at runtime.', '/assets/favicon-32x32.png'],
+  ]}
+/>
+
+### meta
+
+Browser and PWA metadata applied at runtime.
+
+<OptionTable
+  options={[
+    ['title', 'String', 'Sets the browser tab title. Overrides `appTitle` from the top-level config when both are present.', 'My Chat App'],
+    ['description', 'String', 'Sets the `<meta name="description">` tag content.', 'Powered by LibreChat'],
+    ['themeColor', 'String', 'Sets the `<meta name="theme-color">` tag. Controls the browser chrome color on mobile devices.', '#0f766e'],
+    ['pwaName', 'String', 'Full name of the app when installed as a Progressive Web App.', 'My Chat App'],
+    ['pwaShortName', 'String', 'Short name shown on the home screen when installed as a PWA.', 'ChatApp'],
+    ['pwaBackgroundColor', 'String', 'Background color of the PWA splash screen.', '#ffffff'],
+    ['pwaThemeColor', 'String', 'Theme color for the PWA shell.', '#0f766e'],
+  ]}
+/>
+
+### theme
+
+Runtime color theme tokens injected into the `ThemeProvider`. Supports separate palettes for `light` and `dark` modes. Both are optional — if only one is provided, it is used for both modes.
+
+Each palette is a map of CSS variable names (without the `--` prefix) to RGB values as space-separated strings (e.g. `"15 118 110"` for `rgb(15, 118, 110)`).
+
+<OptionTable
+  options={[
+    ['light', 'Object', 'Color tokens applied in light mode. Keys are CSS variable names; values are space-separated RGB triplets.'],
+    ['dark', 'Object', 'Color tokens applied in dark mode. Keys are CSS variable names; values are space-separated RGB triplets.'],
+  ]}
+/>
+
+**Common theme tokens:**
+
+<OptionTable
+  options={[
+    ['rgb-primary', 'String', 'Primary brand color used for buttons, links, and focus rings.', '"15 118 110"'],
+    ['rgb-accent', 'String', 'Accent color used for highlights and hover states.', '"13 148 136"'],
+    ['rgb-surface-primary', 'String', 'Main background surface color.', '"248 250 252"'],
+    ['rgb-surface-secondary', 'String', 'Secondary surface color for panels and cards.', '"226 232 240"'],
+    ['rgb-surface-hover', 'String', 'Surface color on hover.', '"203 213 225"'],
+    ['rgb-text-primary', 'String', 'Primary text color.', '"15 23 42"'],
+    ['rgb-text-secondary', 'String', 'Secondary/muted text color.', '"51 65 85"'],
+    ['rgb-border-light', 'String', 'Light border color.', '"203 213 225"'],
+    ['rgb-border-medium', 'String', 'Medium border color.', '"148 163 184"'],
+    ['rgb-ring-primary', 'String', 'Focus ring color.', '"15 118 110"'],
+  ]}
+/>
+
+### ui
+
+UI behavior overrides.
+
+<OptionTable
+  options={[
+    ['hideProviderUploadForEndpoints', 'String[]', 'List of endpoint names for which the "Upload to Provider" option is hidden in the attachment menu. "Upload as Text" and "File Search" remain available. Matching is case-insensitive.', '["openAI", "custom"]'],
+  ]}
+/>
+
+**Example — hide provider upload for a specific endpoint:**
+
+```yaml
+branding:
+  ui:
+    hideProviderUploadForEndpoints:
+      - "openAI"
+```
+
+---
+
+## Notes
+
+- All `branding` fields are optional. Omitting the block entirely leaves default LibreChat behavior unchanged.
+- Logo and favicon paths should be relative to the app's public assets directory or absolute URLs.
+- Theme tokens are applied after the user's theme preference (light/dark) is resolved. The correct palette is selected automatically.
+- `hideProviderUploadForEndpoints` accepts both built-in endpoint names (e.g. `openAI`, `azureOpenAI`, `anthropic`) and custom endpoint names as defined in your config.
+- The `meta.title` field takes precedence over the top-level `appTitle` config field when both are set.

--- a/content/docs/configuration/librechat_yaml/object_structure/branding.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/branding.mdx
@@ -5,7 +5,7 @@ icon: Palette
 
 ## Overview
 
-The `branding` object enables white-label customization of LibreChat. It provides runtime control over logos, favicons, browser metadata, color themes, and UI behavior — without requiring source code changes.
+The `branding` object enables white-label customization of LibreChat. It provides runtime control over logos, favicons, browser metadata, and color themes — without requiring source code changes.
 
 Branding is resolved through the same app-config pipeline as `interface` and `turnstile`, and is delivered to the frontend via the `/api/config` startup payload.
 
@@ -16,7 +16,6 @@ These are the top-level fields under `branding`:
 - `favicon`
 - `meta`
 - `theme`
-- `ui`
 
 ## Example
 
@@ -42,10 +41,6 @@ branding:
       rgb-primary: "45 212 191"
       rgb-accent: "20 184 166"
       rgb-surface-primary: "15 23 42"
-  ui:
-    hideProviderUploadForEndpoints:
-      - "openAI"
-      - "custom"
 ```
 
 ## branding
@@ -126,25 +121,6 @@ Each palette is a map of CSS variable names (without the `--` prefix) to RGB val
   ]}
 />
 
-### ui
-
-UI behavior overrides.
-
-<OptionTable
-  options={[
-    ['hideProviderUploadForEndpoints', 'String[]', 'List of endpoint names for which the "Upload to Provider" option is hidden in the attachment menu. "Upload as Text" and "File Search" remain available. Matching is case-insensitive.', '["openAI", "custom"]'],
-  ]}
-/>
-
-**Example — hide provider upload for a specific endpoint:**
-
-```yaml
-branding:
-  ui:
-    hideProviderUploadForEndpoints:
-      - "openAI"
-```
-
 ---
 
 ## Notes
@@ -152,5 +128,4 @@ branding:
 - All `branding` fields are optional. Omitting the block entirely leaves default LibreChat behavior unchanged.
 - Logo and favicon paths should be relative to the app's public assets directory or absolute URLs.
 - Theme tokens are applied after the user's theme preference (light/dark) is resolved. The correct palette is selected automatically.
-- `hideProviderUploadForEndpoints` accepts both built-in endpoint names (e.g. `openAI`, `azureOpenAI`, `anthropic`) and custom endpoint names as defined in your config.
 - The `meta.title` field takes precedence over the top-level `appTitle` config field when both are set.

--- a/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -311,6 +311,8 @@ This priority system allows features like "Upload as Text" to work without requi
       - The total maximum size for all files in a single request. In units of MB (e.g. use `20` for 20 megabytes)
   - `supportedMimeTypes`
       - A list of [Regular Expressions](https://en.wikipedia.org/wiki/Regular_expression) specifying what MIME types are allowed for upload. This can be customized to restrict file types.
+  - `disableProviderUpload`
+      - When `true`, hides the "Upload to Provider" option in the attachment menu for this endpoint. "Upload as Text" and "File Search" remain available.
 
 ## disabled
 
@@ -392,3 +394,28 @@ assistants:
       - "image/.*"
       - "application/pdf"
 ```
+
+## disableProviderUpload
+
+<OptionTable
+  options={[
+    ['disableProviderUpload', 'Boolean', 'When true, hides the "Upload to Provider" option in the attachment menu for this endpoint. "Upload as Text" and "File Search" remain available.', 'Use when an endpoint does not support direct file uploads (e.g. a LiteLLM-proxied model).'],
+  ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+```yaml filename="fileConfig / endpoints / {endpoint_record} / disableProviderUpload"
+fileConfig:
+  endpoints:
+    litellm:
+      disableProviderUpload: true
+    custom:
+      disableProviderUpload: true
+```
+
+**Notes:**
+- Only hides "Upload to Provider". "Upload as Text" (RAG) and "File Search" are not affected.
+- Can be set on any endpoint key: named custom endpoints (e.g. `litellm`), the generic `custom` fallback, or built-in endpoints like `openAI`.
+- If set on `default`, it applies to all endpoints that do not have their own entry.

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -29,6 +29,7 @@ These are fields under `interface`:
   - `fileCitations`
   - `peoplePicker`
   - `marketplace`
+  - `hideProviderUploadForEndpoints`
 
 **Notes:**
 
@@ -650,4 +651,29 @@ marketplace:
 interface:
   marketplace:
     use: true  # Enable marketplace access
+```
+
+## hideProviderUploadForEndpoints
+
+Hides the "Upload to Provider" option in the attachment menu for specified endpoints. "Upload as Text" and "File Search" remain unaffected.
+
+Use this when a model endpoint does not support direct file uploads (e.g. a LiteLLM-proxied model), to prevent users from seeing an option that would result in an error.
+
+<OptionTable
+  options={[
+    ['hideProviderUploadForEndpoints', 'String[]', 'List of endpoint names for which "Upload to Provider" is hidden. Matching is case-insensitive and checks both the endpoint type and the active provider name.', '["openAI", "custom"]'],
+  ]}
+/>
+
+**Example:**
+```yaml filename="interface / hideProviderUploadForEndpoints"
+interface:
+  hideProviderUploadForEndpoints:
+    - "openAI"
+    - "custom"
+```
+
+**Notes:**
+- Accepts both built-in endpoint names (e.g. `openAI`, `azureOpenAI`, `anthropic`) and custom endpoint names as defined in your config.
+- Matching is case-insensitive.
 ```

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -29,7 +29,6 @@ These are fields under `interface`:
   - `fileCitations`
   - `peoplePicker`
   - `marketplace`
-  - `hideProviderUploadForEndpoints`
 
 **Notes:**
 
@@ -653,27 +652,3 @@ interface:
     use: true  # Enable marketplace access
 ```
 
-## hideProviderUploadForEndpoints
-
-Hides the "Upload to Provider" option in the attachment menu for specified endpoints. "Upload as Text" and "File Search" remain unaffected.
-
-Use this when a model endpoint does not support direct file uploads (e.g. a LiteLLM-proxied model), to prevent users from seeing an option that would result in an error.
-
-<OptionTable
-  options={[
-    ['hideProviderUploadForEndpoints', 'String[]', 'List of endpoint names for which "Upload to Provider" is hidden. Matching is case-insensitive and checks both the endpoint type and the active provider name.', '["openAI", "custom"]'],
-  ]}
-/>
-
-**Example:**
-```yaml filename="interface / hideProviderUploadForEndpoints"
-interface:
-  hideProviderUploadForEndpoints:
-    - "openAI"
-    - "custom"
-```
-
-**Notes:**
-- Accepts both built-in endpoint names (e.g. `openAI`, `azureOpenAI`, `anthropic`) and custom endpoint names as defined in your config.
-- Matching is case-insensitive.
-```

--- a/content/docs/configuration/librechat_yaml/object_structure/meta.json
+++ b/content/docs/configuration/librechat_yaml/object_structure/meta.json
@@ -5,6 +5,7 @@
     "---General---",
     "config",
     "interface",
+    "branding",
     "registration",
     "turnstile",
     "---Models & Specs---",


### PR DESCRIPTION
## Summary

Documentation updates accompanying the implementation PR: [danny-avila/LibreChat#12622](https://github.com/danny-avila/LibreChat/pull/12622)

- **New page**: `branding` object structure — documents the new `branding` config block with fields for `appLogo`, `authLogo`, `favicon`, `meta`, and `theme` (light/dark RGB token maps)
- **Updated**: `fileConfig` object structure — adds `disableProviderUpload` field under endpoint config

## Changes

### New
- `content/docs/configuration/librechat_yaml/object_structure/branding.mdx` — full `branding` block reference with examples
- Registered in `meta.json` under the General section

### Modified
- `content/docs/configuration/librechat_yaml/object_structure/file_config.mdx`
  - Added `disableProviderUpload` to the endpoints overview list
  - Added `## disableProviderUpload` section with description, default, and YAML example

- `content/docs/configuration/librechat_yaml/object_structure/interface.mdx`
  - Removed `hideProviderUploadForEndpoints` section

## Config shape (new `branding` block)

```yaml
branding:
  appLogo: "https://cdn.example.com/logo.svg"
  authLogo: "https://cdn.example.com/auth-logo.svg"
  favicon: "https://cdn.example.com/favicon.ico"
  meta:
    title: "My AI Assistant"
    description: "Powered by LibreChat"
  theme:
    light:
      primary: "210 100% 40%"
      background: "0 0% 100%"
    dark:
      primary: "210 100% 60%"
      background: "222 20% 10%"
```

## Config shape (`disableProviderUpload`)

```yaml
fileConfig:
  endpoints:
    litellm:
      disableProviderUpload: true
    custom:
      disableProviderUpload: true
    openAI:
      disableProviderUpload: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)