### PR TITLE
feat: Add Terms of Service and Privacy Policy for LibreChat Demo

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -37,7 +37,7 @@ async function getSearchIndex(): Promise<SearchDoc[]> {
         const filePath = join(process.cwd(), 'content/docs', page.file.path)
         const raw = await readFile(filePath, 'utf-8')
         const content = raw.replace(/^---[\s\S]*?---\n*/, '').slice(0, 3000)
-        const title = page.data.title
+        const { title } = page.data
         const description = page.data.description ?? ''
 
         return {
@@ -69,9 +69,7 @@ const pageContentCache = new Map<string, string | null>()
 let pagesByUrl: Map<string, ReturnType<typeof docsSource.getPages>[number]> | null = null
 
 function getPageByUrl(url: string) {
-  if (!pagesByUrl) {
-    pagesByUrl = new Map(docsSource.getPages().map((p) => [p.url, p]))
-  }
+  pagesByUrl ||= new Map(docsSource.getPages().map((p) => [p.url, p]))
   return pagesByUrl.get(url) ?? null
 }
 
@@ -213,9 +211,7 @@ export async function POST(req: Request) {
   const rawPageUrl = req.headers.get('x-chat-page')
   // Validate page URL: must be a relative docs path, no traversal
   const pageUrl =
-    rawPageUrl && rawPageUrl.startsWith('/docs/') && !rawPageUrl.includes('..')
-      ? rawPageUrl
-      : null
+    rawPageUrl && rawPageUrl.startsWith('/docs/') && !rawPageUrl.includes('..') ? rawPageUrl : null
 
   if (!process.env.OPENROUTER_API_KEY) {
     return new Response(JSON.stringify({ error: 'OPENROUTER_API_KEY is not configured' }), {
@@ -224,7 +220,9 @@ export async function POST(req: Request) {
     })
   }
 
-  const modelMessages = await convertToModelMessages(messages as Parameters<typeof convertToModelMessages>[0])
+  const modelMessages = await convertToModelMessages(
+    messages as Parameters<typeof convertToModelMessages>[0],
+  )
 
   // "This page" mode — no tools, page content as context
   if (mode === 'page' && pageUrl) {

--- a/app/demo/privacy/page.tsx
+++ b/app/demo/privacy/page.tsx
@@ -1,0 +1,412 @@
+import Link from 'next/link'
+import { HomeLayout } from 'fumadocs-ui/layouts/home'
+import { baseOptions } from '@/app/layout.config'
+import FooterMenu from '@/components/FooterMenu'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — LibreChat Demo',
+  description: 'Privacy Policy for the LibreChat Demo instance at chat.librechat.ai.',
+}
+
+export default function DemoPrivacyPage() {
+  return (
+    <HomeLayout {...baseOptions}>
+      <main className="min-h-screen px-4 py-16 sm:px-6 md:py-24 lg:px-8">
+        <article className="prose prose-neutral dark:prose-invert mx-auto max-w-3xl">
+          <header className="mb-12 not-prose text-center">
+            <p className="mb-4 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              LibreChat Demo
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+              Privacy Policy
+            </h1>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Effective Date: March 12, 2026 &middot; Last Updated: March 12, 2026
+            </p>
+          </header>
+
+          <p>
+            This Privacy Policy explains how the LibreChat Project, maintained by Danny Avila
+            (&ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;), collects, uses, stores, and
+            protects your personal data when you use the LibreChat Demo (&ldquo;Demo&rdquo;,
+            &ldquo;Service&rdquo;), accessible at{' '}
+            <Link href="https://chat.librechat.ai">chat.librechat.ai</Link>. We are committed to
+            protecting your privacy and processing your data in accordance with Regulation (EU)
+            2016/679 (the General Data Protection Regulation, &ldquo;GDPR&rdquo;) and other
+            applicable data protection laws.
+          </p>
+
+          <h2>1. Data Controller</h2>
+          <p>The data controller for this Service is:</p>
+          <p>
+            <strong>The LibreChat Project</strong>
+            <br />
+            Maintained by: Danny Avila
+            <br />
+            Email: <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link>
+            <br />
+            GitHub:{' '}
+            <Link href="https://github.com/danny-avila/LibreChat">
+              github.com/danny-avila/LibreChat
+            </Link>
+          </p>
+          <p>
+            If you have questions or concerns about how your data is handled, you may contact us at
+            the address above.
+          </p>
+
+          <h2>2. What Data We Collect</h2>
+
+          <h3>2.1 Account Data</h3>
+          <p>When you create an account, we collect:</p>
+          <ul>
+            <li>
+              <strong>Email address</strong> — provided directly by you during registration or
+              obtained via a social login provider.
+            </li>
+            <li>
+              <strong>Display name</strong> — provided by you or obtained from your social login
+              profile.
+            </li>
+            <li>
+              <strong>Avatar image</strong> — obtained from your social login provider, if
+              applicable.
+            </li>
+            <li>
+              <strong>Authentication identifiers</strong> — such as your Google or GitHub user ID,
+              if you use social login.
+            </li>
+          </ul>
+
+          <h3>2.2 Usage Data</h3>
+          <p>When you use the Service, we process:</p>
+          <ul>
+            <li>
+              <strong>Conversation messages</strong> — the text you submit to the AI and the
+              AI-generated responses.
+            </li>
+            <li>
+              <strong>Uploaded files</strong> — any files you attach to conversations (documents,
+              images, etc.).
+            </li>
+            <li>
+              <strong>Technical metadata</strong> — including your IP address, browser user agent,
+              timestamps of requests, and session identifiers.
+            </li>
+          </ul>
+
+          <h3>2.3 Data We Do Not Collect</h3>
+          <ul>
+            <li>We do not use analytics services or third-party tracking tools on the Demo.</li>
+            <li>We do not use advertising cookies or tracking pixels.</li>
+            <li>We do not collect payment information (the Demo is free).</li>
+          </ul>
+
+          <h2>3. How We Use Your Data</h2>
+          <p>
+            We process your personal data for the following purposes and on the following legal
+            bases:
+          </p>
+
+          <div className="not-prose overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-3 pr-4 text-left font-semibold text-foreground">Purpose</th>
+                  <th className="py-3 pr-4 text-left font-semibold text-foreground">
+                    Data Involved
+                  </th>
+                  <th className="py-3 text-left font-semibold text-foreground">
+                    Legal Basis (GDPR Art. 6)
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">
+                    Providing the Service (account creation, authentication, AI chat functionality)
+                  </td>
+                  <td className="py-3 pr-4">Account data, conversation messages, uploaded files</td>
+                  <td className="py-3">Performance of contract (Art. 6(1)(b))</td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">
+                    Maintaining security and preventing abuse (rate limiting, ban enforcement, fraud
+                    detection)
+                  </td>
+                  <td className="py-3 pr-4">IP address, user agent, usage patterns</td>
+                  <td className="py-3">Legitimate interest (Art. 6(1)(f))</td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">
+                    Complying with legal obligations (responding to lawful requests, DSA compliance)
+                  </td>
+                  <td className="py-3 pr-4">Account data, content data, technical metadata</td>
+                  <td className="py-3">Legal obligation (Art. 6(1)(c))</td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Improving and debugging the Service</td>
+                  <td className="py-3 pr-4">Aggregated, anonymized usage statistics</td>
+                  <td className="py-3">Legitimate interest (Art. 6(1)(f))</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            We do not use your data for profiling, automated decision-making, or direct marketing.
+          </p>
+
+          <h2>4. Third-Party AI Model Providers</h2>
+          <p>
+            The Demo connects to third-party AI model providers (such as OpenAI, Anthropic, Google,
+            and others) to process your conversation messages. When you send a message, the text of
+            your message (and any attached files, where supported) is transmitted to the selected AI
+            provider for processing.
+          </p>
+          <p>
+            Each AI provider processes your data in accordance with their own privacy policies and
+            terms. We encourage you to review the privacy policies of the AI providers you use
+            through the Service. We are not responsible for the data practices of third-party AI
+            providers.
+          </p>
+
+          <h2>5. Third-Party Authentication Providers</h2>
+          <p>
+            If you use social login (such as Google or GitHub), the authentication provider may
+            share your name, email address, and profile picture with us in accordance with the
+            permissions you grant during the login process. We receive only the data necessary for
+            account creation and do not access your contacts, files, or other account data from
+            those providers.
+          </p>
+
+          <h2>6. Data Sharing and Sub-Processors</h2>
+          <p>
+            We do not sell, rent, or trade your personal data. We share your data only with the
+            following categories of recipients, and only to the extent necessary:
+          </p>
+          <ul>
+            <li>
+              <strong>Hosting provider</strong> — Hetzner Online GmbH (Gunzenhausen, Germany).
+              Servers are located in the EU (Falkenstein, Germany).
+            </li>
+            <li>
+              <strong>AI model providers</strong> — as described in Section 4, your conversation
+              data is transmitted to the AI provider selected for each interaction.
+            </li>
+            <li>
+              <strong>Social login providers</strong> — Google LLC, GitHub Inc., as applicable, for
+              authentication purposes only.
+            </li>
+            <li>
+              <strong>Law enforcement or regulatory authorities</strong> — where required by law,
+              court order, or binding regulatory request.
+            </li>
+          </ul>
+          <p>
+            All sub-processors that handle personal data on our behalf are contractually bound to
+            process your data only on our instructions and to implement appropriate technical and
+            organizational security measures.
+          </p>
+
+          <h2>7. International Data Transfers</h2>
+          <p>
+            Your data is primarily stored on servers located in the European Union (Germany).
+            However, when you use AI model providers whose servers are located outside the EU (such
+            as in the United States), your conversation data is transferred to those jurisdictions.
+          </p>
+          <p>Where personal data is transferred outside the EU/EEA, we rely on:</p>
+          <ul>
+            <li>The European Commission&apos;s adequacy decisions, where available.</li>
+            <li>Standard Contractual Clauses (SCCs) approved by the European Commission.</li>
+            <li>Other appropriate safeguards as required by the GDPR.</li>
+          </ul>
+
+          <h2>8. Data Retention</h2>
+          <p>We retain your data for the following periods:</p>
+
+          <div className="not-prose overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-3 pr-4 text-left font-semibold text-foreground">Data Type</th>
+                  <th className="py-3 text-left font-semibold text-foreground">Retention Period</th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Account data (email, name, avatar)</td>
+                  <td className="py-3">
+                    Until you delete your account, or until we perform periodic Demo cleanups
+                  </td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Conversation messages</td>
+                  <td className="py-3">
+                    Until you delete them, until your account is deleted, or until periodic Demo
+                    cleanups
+                  </td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Uploaded files</td>
+                  <td className="py-3">Up to 30 days, subject to automatic deletion</td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Technical logs (IP, user agent)</td>
+                  <td className="py-3">Up to 30 days</td>
+                </tr>
+                <tr className="border-b border-border">
+                  <td className="py-3 pr-4">Rate limiting and ban records</td>
+                  <td className="py-3">Up to 90 days</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            As this is a demonstration service, we may perform periodic database cleanups that
+            result in the deletion of all user data. We do not guarantee long-term persistence of
+            any data on the Demo.
+          </p>
+
+          <h2>9. Your Rights Under the GDPR</h2>
+          <p>
+            If you are located in the European Economic Area (EEA), you have the following rights
+            regarding your personal data:
+          </p>
+          <ul>
+            <li>
+              <strong>Right of Access</strong> (Art. 15) — You may request a copy of the personal
+              data we hold about you.
+            </li>
+            <li>
+              <strong>Right to Rectification</strong> (Art. 16) — You may request that we correct
+              inaccurate or incomplete data.
+            </li>
+            <li>
+              <strong>Right to Erasure</strong> (Art. 17) — You may request that we delete your
+              personal data (&ldquo;right to be forgotten&rdquo;).
+            </li>
+            <li>
+              <strong>Right to Restriction of Processing</strong> (Art. 18) — You may request that
+              we restrict the processing of your data in certain circumstances.
+            </li>
+            <li>
+              <strong>Right to Data Portability</strong> (Art. 20) — You may request to receive your
+              data in a structured, commonly used, machine-readable format.
+            </li>
+            <li>
+              <strong>Right to Object</strong> (Art. 21) — You may object to processing based on
+              legitimate interests.
+            </li>
+            <li>
+              <strong>Right to Lodge a Complaint</strong> — You have the right to lodge a complaint
+              with a supervisory authority. If you are located in Italy, the competent authority is
+              the Garante per la protezione dei dati personali (
+              <Link href="https://www.garanteprivacy.it">garanteprivacy.it</Link>).
+            </li>
+          </ul>
+          <p>
+            To exercise any of these rights, contact us at{' '}
+            <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link>. We will respond
+            within 30 days.
+          </p>
+
+          <h2>10. Cookies and Local Storage</h2>
+          <p>
+            The Demo uses only <strong>strictly necessary cookies</strong> for:
+          </p>
+          <ul>
+            <li>Session management (maintaining your login state).</li>
+            <li>Security (CSRF protection tokens).</li>
+          </ul>
+          <p>
+            We do not use analytics cookies, advertising cookies, or any form of cross-site
+            tracking. No cookie consent banner is required as we rely solely on cookies that are
+            exempt under Article 5(3) of the ePrivacy Directive (Directive 2002/58/EC) because they
+            are strictly necessary for the provision of the Service.
+          </p>
+
+          <h2>11. Security Measures</h2>
+          <p>
+            We implement appropriate technical and organizational measures to protect your personal
+            data, including:
+          </p>
+          <ul>
+            <li>Encryption in transit (TLS/HTTPS for all connections).</li>
+            <li>Access controls and authentication for server infrastructure.</li>
+            <li>Regular security updates and monitoring.</li>
+            <li>Firewall rules restricting access to internal services.</li>
+          </ul>
+          <p>
+            However, no method of transmission over the Internet or electronic storage is 100%
+            secure. We cannot guarantee absolute security and are not liable for breaches resulting
+            from circumstances beyond our reasonable control.
+          </p>
+
+          <h2>12. Data Breach Notification</h2>
+          <p>
+            In the event of a personal data breach that is likely to result in a risk to your rights
+            and freedoms, we will:
+          </p>
+          <ul>
+            <li>
+              Notify the competent supervisory authority within 72 hours of becoming aware of the
+              breach, as required by GDPR Art. 33.
+            </li>
+            <li>
+              Notify affected users without undue delay where the breach is likely to result in a
+              high risk to their rights and freedoms, as required by GDPR Art. 34.
+            </li>
+          </ul>
+
+          <h2>13. Children&apos;s Privacy</h2>
+          <p>
+            The Service is not directed at children under the age of 16. We do not knowingly collect
+            personal data from children under 16. If we become aware that we have collected personal
+            data from a child under 16, we will take steps to delete that data promptly. If you
+            believe a child under 16 has provided us with personal data, please contact us at the
+            address in Section 1.
+          </p>
+
+          <h2>14. Changes to This Privacy Policy</h2>
+          <p>
+            We may update this Privacy Policy from time to time. Material changes will be
+            communicated through the Service interface. Your continued use of the Service after the
+            effective date of any changes constitutes your acceptance of the updated Privacy Policy.
+          </p>
+
+          <h2>15. Contact Us</h2>
+          <p>
+            For any privacy-related questions, data subject requests, or concerns, please contact:
+          </p>
+          <p>
+            <strong>The LibreChat Project</strong>
+            <br />
+            Maintained by: Danny Avila
+            <br />
+            Email: <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link>
+            <br />
+            GitHub:{' '}
+            <Link href="https://github.com/danny-avila/LibreChat">
+              github.com/danny-avila/LibreChat
+            </Link>
+          </p>
+
+          <hr />
+
+          <p className="text-sm text-muted-foreground">
+            By using the LibreChat Demo, you acknowledge that your data is processed as described in
+            this Privacy Policy.
+          </p>
+        </article>
+      </main>
+      <div className="border-t border-border px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <FooterMenu />
+        </div>
+      </div>
+    </HomeLayout>
+  )
+}

--- a/app/demo/terms/page.tsx
+++ b/app/demo/terms/page.tsx
@@ -1,0 +1,339 @@
+import Link from 'next/link'
+import { HomeLayout } from 'fumadocs-ui/layouts/home'
+import { baseOptions } from '@/app/layout.config'
+import FooterMenu from '@/components/FooterMenu'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — LibreChat Demo',
+  description: 'Terms of Service for the LibreChat Demo instance at chat.librechat.ai.',
+}
+
+export default function DemoTermsPage() {
+  return (
+    <HomeLayout {...baseOptions}>
+      <main className="min-h-screen px-4 py-16 sm:px-6 md:py-24 lg:px-8">
+        <article className="prose prose-neutral dark:prose-invert mx-auto max-w-3xl">
+          <header className="mb-12 not-prose text-center">
+            <p className="mb-4 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              LibreChat Demo
+            </p>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+              Terms of Service
+            </h1>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Effective Date: March 12, 2026 &middot; Last Updated: March 12, 2026
+            </p>
+          </header>
+
+          <p>
+            Welcome to the LibreChat Demo (&ldquo;Demo&rdquo;, &ldquo;Service&rdquo;), a free
+            demonstration instance of the open-source LibreChat platform operated by the LibreChat
+            Project, maintained by Danny Avila (&ldquo;we&rdquo;, &ldquo;us&rdquo;,
+            &ldquo;our&rdquo;). The Demo is accessible at{' '}
+            <Link href="https://chat.librechat.ai">chat.librechat.ai</Link>.
+          </p>
+
+          <p>
+            By creating an account or using this Service, you agree to be bound by these Terms of
+            Service (&ldquo;Terms&rdquo;) and our <Link href="/demo/privacy">Privacy Policy</Link>.
+            If you do not agree to these Terms, do not use the Service.
+          </p>
+
+          <h2>1. Nature of the Service</h2>
+          <p>
+            The Demo is a <strong>free, public demonstration</strong> of the LibreChat open-source
+            software. It is provided for evaluation, testing, and educational purposes only. The
+            Demo is not intended for production use, commercial deployment, or the processing of
+            sensitive, confidential, or regulated data.
+          </p>
+          <p>
+            We make no guarantees regarding availability, uptime, performance, or continuity of the
+            Service. The Demo may be modified, suspended, or discontinued at any time without prior
+            notice.
+          </p>
+
+          <h2>2. Eligibility</h2>
+          <p>
+            You must be at least 16 years of age to use this Service. By using the Service, you
+            represent and warrant that you meet this age requirement. If you are between 16 and 18
+            years of age, you represent that you have reviewed these Terms with a parent or legal
+            guardian and that they consent to your use of the Service.
+          </p>
+
+          <h2>3. Account Registration</h2>
+          <p>
+            To access the Service, you may be required to create an account using an email address
+            or through a third-party social login provider (such as Google or GitHub). You agree to
+            provide accurate information during registration and to keep your credentials secure.
+            You are solely responsible for all activity that occurs under your account.
+          </p>
+          <p>
+            We reserve the right to suspend or terminate any account at our sole discretion, with or
+            without cause, and with or without notice.
+          </p>
+
+          <h2>4. Acceptable Use</h2>
+          <p>
+            You agree to use the Service only for lawful purposes. The following activities are
+            strictly prohibited:
+          </p>
+          <ul>
+            <li>
+              Submitting, uploading, or generating content that is illegal, defamatory, obscene,
+              threatening, abusive, hateful, discriminatory, or that incites violence.
+            </li>
+            <li>
+              Uploading content that infringes on the intellectual property rights, privacy rights,
+              or other rights of any third party.
+            </li>
+            <li>
+              Uploading content that depicts, promotes, or facilitates the sexual exploitation or
+              abuse of minors (CSAM). Any such content will be immediately removed and reported to
+              the relevant authorities.
+            </li>
+            <li>Using the Service to harass, stalk, impersonate, or intimidate any person.</li>
+            <li>
+              Attempting to gain unauthorized access to the Service, other user accounts, or any
+              systems or networks connected to the Service.
+            </li>
+            <li>
+              Using automated tools (bots, scrapers, crawlers) to access the Service without our
+              prior written consent.
+            </li>
+            <li>Circumventing rate limits, usage restrictions, or security measures.</li>
+            <li>
+              Using the Service to develop, train, or improve competing AI products or services
+              without our prior written consent.
+            </li>
+            <li>
+              Engaging in any activity that disrupts, degrades, or interferes with the Service or
+              the experience of other users.
+            </li>
+            <li>
+              Using the Service for any high-risk, safety-critical, or regulated purpose, including
+              but not limited to medical diagnosis, legal advice, financial trading, or autonomous
+              vehicle operation.
+            </li>
+          </ul>
+
+          <h2>5. User-Generated Content</h2>
+
+          <h3>5.1 Your Content</h3>
+          <p>
+            &ldquo;User Content&rdquo; means any text, files, images, or other material you submit,
+            upload, or input to the Service, including conversation messages and file attachments.
+            You retain ownership of your User Content.
+          </p>
+          <p>
+            By submitting User Content, you grant us a limited, non-exclusive, royalty-free,
+            worldwide license to store, process, and transmit your content solely for the purpose of
+            operating the Service. This license terminates when your content is deleted from the
+            Service.
+          </p>
+
+          <h3>5.2 Content Responsibility</h3>
+          <p>
+            You are solely responsible for your User Content. We do not pre-screen, monitor, or
+            endorse User Content. We act as a passive hosting provider and do not exercise editorial
+            control over content submitted by users.
+          </p>
+
+          <h3>5.3 Content Removal and Reporting</h3>
+          <p>
+            In accordance with Regulation (EU) 2022/2065 (the Digital Services Act,
+            &ldquo;DSA&rdquo;), we provide mechanisms for reporting illegal content. If you believe
+            any content on the Service is illegal or violates these Terms, you may report it by
+            contacting us at the address specified in Section 14.
+          </p>
+          <p>
+            Upon receiving a valid notice of illegal content, we will act expeditiously to assess
+            the report and, where appropriate, remove or disable access to the content in question.
+            We will inform the reporting party and, where feasible, the content uploader of any
+            action taken and the reasons for it.
+          </p>
+
+          <h3>5.4 Repeat Infringers</h3>
+          <p>
+            We reserve the right to suspend or terminate the accounts of users who repeatedly
+            violate these Terms or who are the subject of repeated valid reports of illegal content.
+          </p>
+
+          <h2>6. AI-Generated Output</h2>
+          <p>
+            The Service provides access to third-party artificial intelligence models. AI-generated
+            output (&ldquo;AI Output&rdquo;) may be inaccurate, incomplete, biased, or otherwise
+            unreliable. You acknowledge and agree that:
+          </p>
+          <ul>
+            <li>
+              AI Output does not constitute professional advice of any kind (legal, medical,
+              financial, or otherwise).
+            </li>
+            <li>You are solely responsible for evaluating and using AI Output.</li>
+            <li>
+              We do not guarantee the accuracy, reliability, completeness, or fitness for any
+              particular purpose of AI Output.
+            </li>
+            <li>
+              AI Output may be subject to the terms and conditions of the underlying AI model
+              providers.
+            </li>
+          </ul>
+
+          <h2>7. Intellectual Property</h2>
+          <p>
+            The LibreChat software is open-source and licensed under the MIT License. These Terms do
+            not grant you any additional rights to the LibreChat trademark, logo, or brand assets
+            beyond what the MIT License permits.
+          </p>
+          <p>
+            Third-party AI model providers retain all rights to their respective models, and use of
+            those models through the Service is subject to their terms of service.
+          </p>
+
+          <h2>8. Data Retention and Deletion</h2>
+          <p>As this is a demonstration service:</p>
+          <ul>
+            <li>
+              Conversation data, uploaded files, and account information may be deleted at any time
+              without prior notice.
+            </li>
+            <li>
+              We may implement automatic data retention limits. Currently, uploaded files may be
+              retained for up to 30 days before automatic deletion.
+            </li>
+            <li>
+              Account data is retained while your account is active. Upon account deletion, we will
+              remove your personal data within 30 days, subject to any legal obligations requiring
+              longer retention.
+            </li>
+            <li>
+              We perform periodic cleanups of the Demo database. Your conversations and data may not
+              persist indefinitely.
+            </li>
+          </ul>
+          <p>
+            For details on what data we collect and how we process it, see our{' '}
+            <Link href="/demo/privacy">Privacy Policy</Link>.
+          </p>
+
+          <h2>9. Disclaimer of Warranties</h2>
+          <p className="uppercase text-sm">
+            The Service is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo; without
+            warranties of any kind, whether express, implied, or statutory, including but not
+            limited to implied warranties of merchantability, fitness for a particular purpose,
+            non-infringement, and accuracy.
+          </p>
+          <p className="uppercase text-sm">
+            We do not warrant that the Service will be uninterrupted, secure, error-free, or free of
+            viruses or other harmful components. We do not warrant that AI Output will be accurate,
+            complete, or reliable.
+          </p>
+
+          <h2>10. Limitation of Liability</h2>
+          <p className="uppercase text-sm">
+            To the maximum extent permitted by applicable law, in no event shall we, our officers,
+            directors, employees, affiliates, or contributors be liable for any indirect,
+            incidental, special, consequential, or punitive damages, or any loss of profits, data,
+            use, goodwill, or other intangible losses, resulting from:
+          </p>
+          <ul className="uppercase text-sm">
+            <li>Your use of or inability to use the Service;</li>
+            <li>Any AI Output or User Content accessed through the Service;</li>
+            <li>Unauthorized access to or alteration of your data;</li>
+            <li>Any third-party conduct on the Service;</li>
+            <li>Any other matter relating to the Service.</li>
+          </ul>
+          <p className="uppercase text-sm">
+            Our total aggregate liability for all claims arising out of or relating to these Terms
+            or the Service shall not exceed EUR 100.
+          </p>
+          <p>
+            Nothing in these Terms excludes or limits liability for death or personal injury caused
+            by negligence, fraud or fraudulent misrepresentation, or any other liability that cannot
+            be excluded or limited by applicable law.
+          </p>
+
+          <h2>11. Indemnification</h2>
+          <p>
+            You agree to defend, indemnify, and hold harmless the LibreChat Project, Danny Avila,
+            and its contributors from and against any claims, liabilities, damages, losses, costs,
+            or expenses (including reasonable legal fees) arising out of or in connection with your
+            use of the Service, your User Content, or your violation of these Terms.
+          </p>
+
+          <h2>12. Modifications to the Terms</h2>
+          <p>
+            We reserve the right to modify these Terms at any time. Material changes will be
+            communicated through the Service interface (for example, by requiring re-acceptance of
+            updated Terms). Your continued use of the Service after the effective date of any
+            changes constitutes your acceptance of the updated Terms.
+          </p>
+
+          <h2>13. Governing Law and Jurisdiction</h2>
+          <p>
+            These Terms shall be governed by and construed in accordance with the laws of the State
+            of Delaware, United States, without regard to its conflict of law provisions, and where
+            applicable, the mandatory consumer protection laws of the European Union.
+          </p>
+          <p>
+            If you are a consumer habitually resident in the European Union, you shall benefit from
+            any mandatory provisions of the law of your country of residence. Nothing in these Terms
+            affects your rights as a consumer under applicable EU law, including Regulation (EU)
+            2022/2065 (Digital Services Act).
+          </p>
+          <p>
+            For EU-based users, disputes may be submitted to the Online Dispute Resolution platform
+            provided by the European Commission at{' '}
+            <Link href="https://ec.europa.eu/consumers/odr">ec.europa.eu/consumers/odr</Link>.
+          </p>
+
+          <h2>14. Contact Information</h2>
+          <p>
+            For questions about these Terms, to report illegal content, or to submit a DSA-compliant
+            notice, please contact us at:
+          </p>
+          <p>
+            <strong>The LibreChat Project</strong>
+            <br />
+            Maintained by: Danny Avila
+            <br />
+            Email: <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link>
+            <br />
+            GitHub:{' '}
+            <Link href="https://github.com/danny-avila/LibreChat">
+              github.com/danny-avila/LibreChat
+            </Link>
+          </p>
+
+          <h2>15. Severability</h2>
+          <p>
+            If any provision of these Terms is held to be invalid or unenforceable, the remaining
+            provisions shall continue in full force and effect. The invalid or unenforceable
+            provision shall be modified to the minimum extent necessary to make it valid and
+            enforceable.
+          </p>
+
+          <h2>16. Entire Agreement</h2>
+          <p>
+            These Terms, together with our <Link href="/demo/privacy">Privacy Policy</Link>,
+            constitute the entire agreement between you and us regarding your use of the Service and
+            supersede any prior agreements.
+          </p>
+
+          <hr />
+
+          <p className="text-sm text-muted-foreground">
+            By using the LibreChat Demo, you agree to these Terms of Service.
+          </p>
+        </article>
+      </main>
+      <div className="border-t border-border px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <FooterMenu />
+        </div>
+      </div>
+    </HomeLayout>
+  )
+}

--- a/scripts/generate-starters.ts
+++ b/scripts/generate-starters.ts
@@ -142,9 +142,7 @@ function findChangedPages(
 /*  LLM call — sends actual content for accuracy                             */
 /* -------------------------------------------------------------------------- */
 
-async function generateStartersForBatch(
-  pages: PageInfo[],
-): Promise<Record<string, string[]>> {
+async function generateStartersForBatch(pages: PageInfo[]): Promise<Record<string, string[]>> {
   const entries = pages
     .map(
       (p) =>
@@ -248,13 +246,11 @@ async function main() {
   }
 
   // Ensure default entry exists
-  if (!newStarters['default']) {
-    newStarters['default'] = [
-      'How do I get started with LibreChat?',
-      'What AI providers are supported?',
-      'How do I configure Docker?',
-    ]
-  }
+  newStarters['default'] ||= [
+    'How do I get started with LibreChat?',
+    'What AI providers are supported?',
+    'How do I configure Docker?',
+  ]
 
   // Build new hashes map
   const newHashes: Record<string, string> = {}


### PR DESCRIPTION
## Summary
- Adds Terms of Service page at `/demo/terms` for the LibreChat Demo (chat.librechat.ai)
- Adds Privacy Policy page at `/demo/privacy` with GDPR/DSA compliance
- Both pages use the existing site layout (HomeLayout + FooterMenu)

## Test plan
- [x] Verify `/demo/terms` renders correctly
- [x] Verify `/demo/privacy` renders correctly
- [x] Check internal links between ToS and Privacy Policy work
- [x] Verify responsive layout on mobile