### PR TITLE
chore: Typo in artifacts.mdx

### DIFF
--- a/content/docs/features/artifacts.mdx
+++ b/content/docs/features/artifacts.mdx
@@ -28,7 +28,7 @@ Experience the future of UI/UX design and development with LibreChat's generativ
 
 ## Content-Security-Policy
 
-You may need to need to update your web server's Content-Security-Policy to include `frame-src 'self' https://*.codesandbox.io` in order to load generated HTML apps in the Artifacts panel. This is a dependency of the [sandpack](https://sandpack.codesandbox.io/) library.
+You may need to update your web server's Content-Security-Policy to include `frame-src 'self' https://*.codesandbox.io` in order to load generated HTML apps in the Artifacts panel. This is a dependency of the [sandpack](https://sandpack.codesandbox.io/) library.
 
 ## Self-Hosting the Sandpack Bundler
 


### PR DESCRIPTION
In Content Security Policy, here 'need' typed two times.