### PR TITLE
docs: access control & admin panel

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -36,6 +36,14 @@ These are fields under `interface`:
 - Default values are provided for most settings but can be overridden based on specific requirements or conditions.
 - Conditional logic in the application can further modify these settings based on other configurations like model specifications.
 
+<Callout type="warning" title="Deprecated: permission side-effect fields">
+Several fields below (`mcpServers`, `prompts`, `bookmarks`, `memories`, `multiConvo`, `agents`, `remoteAgents`, `temporaryChat`, `runCode`, `webSearch`, `fileSearch`, `fileCitations`, `peoplePicker`, `marketplace`) don't just toggle UI, they seed role permissions in the database at startup, and only for the built-in `USER` role.
+
+For ongoing management, use the [**LibreChat Admin Panel**](/docs/features/admin_panel), which edits the permission matrix directly on each role (including custom roles). These YAML fields remain supported for bootstrapping a fresh instance or fully file-driven deployments, but should no longer be used as the primary way to manage feature permissions.
+
+See [Access Control](/docs/features/access_control) for the full permission model.
+</Callout>
+
 ## Example
 
 ```yaml filename="interface"
@@ -84,6 +92,8 @@ interface:
 ```
 
 ## mcpServers
+
+> **Deprecated for permission management.** The `use`, `create`, `share`, and `public` sub-keys seed role permissions at startup. Prefer the [Admin Panel](/docs/features/admin_panel) for managing MCP server permissions per role/group/user. The `placeholder` and `trustCheckbox` sub-keys are unaffected.
 
 **Key:**
 <OptionTable
@@ -223,6 +233,8 @@ interface:
 
 ## prompts
 
+> **Deprecated for permission management.** Seeds the `PROMPTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel) for managing prompt permissions per role/group/user.
+
 **Key:**
 <OptionTable
   options={[
@@ -277,6 +289,8 @@ interface:
 
 ## bookmarks
 
+> **Deprecated for permission management.** Seeds the `BOOKMARKS` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
+
 **Key:**
 <OptionTable
   options={[
@@ -293,6 +307,8 @@ interface:
 ```
 
 ## memories
+
+> **Deprecated for permission management.** Seeds the `MEMORIES` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel). Note this toggle is separate from the [`memory`](/docs/configuration/librechat_yaml/object_structure/memory) behavior configuration.
 
 **Key:**
 <OptionTable
@@ -313,6 +329,8 @@ interface:
 
 ## multiConvo
 
+> **Deprecated for permission management.** Seeds the `MULTI_CONVO` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
+
 **Key:**
 <OptionTable
   options={[
@@ -331,6 +349,8 @@ interface:
 ## agents
 
 More info on [Agents](/docs/features/agents)
+
+> **Deprecated for permission management.** Seeds the `AGENTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel) for managing agent permissions per role/group/user.
 
 **Key:**
 <OptionTable
@@ -388,6 +408,8 @@ interface:
 
 Controls access to the Agents API (OpenAI-compatible and Open Responses API endpoints), which allows external applications to interact with LibreChat agents programmatically via API keys.
 
+> **Deprecated for permission management.** Seeds the `REMOTE_AGENTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
+
 **Key:**
 <OptionTable
   options={[
@@ -422,6 +444,8 @@ interface:
 ## temporaryChat
 
 Controls whether the temporary chat feature is available to users. Temporary chats are not saved to conversation history and are automatically deleted after a configurable retention period.
+
+> **Deprecated for permission management.** Seeds the `TEMPORARY_CHAT` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel). `temporaryChatRetention` below is not a permission and remains the recommended way to configure retention.
 
 **Key:**
 <OptionTable
@@ -500,6 +524,8 @@ Enables/disables the "Run Code" button for Markdown Code Blocks. More info on th
 
 **Note:** This setting does not disable the [Agents Code Interpreter Capability](/docs/features/agents#code-interpreter). To disable the Agents Capability, see the [Agents Endpoint configuration](/docs/configuration/librechat_yaml/object_structure/agents) instead.
 
+> **Deprecated for permission management.** Seeds the `RUN_CODE` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
+
 **Key:**
 <OptionTable
   options={[
@@ -520,6 +546,8 @@ interface:
 Enables/disables the web search button in the chat interface. More info on [Web Search Configuration](/docs/configuration/librechat_yaml/object_structure/web_search)
 
 **Note:** This setting does not disable the [Agents Web Search Capability](/docs/features/agents#web-search). To disable the Agents Capability, see the [Agents Endpoint configuration](/docs/configuration/librechat_yaml/object_structure/agents) instead.
+
+> **Deprecated for permission management.** Seeds the `WEB_SEARCH` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
 <OptionTable
@@ -542,6 +570,8 @@ Enables/disables the file search (for RAG API usage via tool) button in the chat
 
 **Note:** This setting does not disable the [Agents File Search Capability](/docs/features/agents#file-search). To disable the Agents Capability, see the [Agents Endpoint configuration](/docs/configuration/librechat_yaml/object_structure/agents) instead.
 
+> **Deprecated for permission management.** Seeds the `FILE_SEARCH` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
+
 **Key:**
 <OptionTable
   options={[
@@ -560,6 +590,8 @@ interface:
 ## fileCitations
 
 Controls the global availability of file citations functionality. When disabled, it effectively removes the `FILE_CITATIONS` permission for all users, preventing any file citations from being displayed when using file search, regardless of individual user permissions.
+
+> **Deprecated for permission management.** Seeds/globally gates the `FILE_CITATIONS` role permission at startup. Prefer the [Admin Panel](/docs/features/admin_panel) for managing citations permissions per role/group/user.
 
 **Note:** 
 - This setting acts as a global toggle for the `FILE_CITATIONS` permission system-wide.
@@ -585,6 +617,8 @@ interface:
 ## peoplePicker
 
 Controls which principal types (users, groups, roles) are available for selection in the people picker interface, typically used when sharing agents or managing access controls.
+
+> **Deprecated for permission management.** Seeds the `PEOPLE_PICKER` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
 <OptionTable
@@ -623,6 +657,8 @@ interface:
 ## marketplace
 
 Enables/disables access to the Agent Marketplace.
+
+> **Deprecated for permission management.** Seeds the `MARKETPLACE` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
 <OptionTable

--- a/content/docs/features/access_control.mdx
+++ b/content/docs/features/access_control.mdx
@@ -1,0 +1,231 @@
+---
+title: Access Control
+icon: ShieldCheck
+description: LibreChat's granular authorization system - control who can use, share, edit, and manage agents, prompts, MCP servers, and other resources at the user, group, role, and instance level.
+---
+
+# Granular Access Control
+
+LibreChat ships with a full authorization system on top of authentication. Access is not "all-or-nothing": every shareable entity in the app (agents, prompts, MCP servers, remote agents, files, conversations) has its own Access Control List (ACL), and every feature can be independently enabled or restricted per **user**, **group**, **role**, or **publicly**.
+
+This page explains how the pieces fit together so you can model permissions to match your organization, from a small team where everyone shares freely, to an enterprise deployment with sync'd Entra ID groups, custom roles, and delegated admins.
+
+<Callout type="info" title="Admin Panel">
+A dedicated [**LibreChat Admin Panel**](/docs/features/admin_panel) is the upcoming UI for managing users, groups, roles, custom permission profiles, and system-wide grants introduced in [v0.8.5-rc1](/changelog/v0.8.5-rc1). This page documents the underlying model, which is available today in LibreChat itself.
+</Callout>
+
+## The Access Model at a Glance
+
+LibreChat's authorization has three independent layers that compose together:
+
+| Layer | Scope | What it controls |
+| --- | --- | --- |
+| **Feature Permissions** | Per role (USER, ADMIN, custom) | Whether a principal can *use*, *create*, *share*, or *share publicly* a class of feature (agents, prompts, MCP servers, memories, web search, etc.). Configured in `librechat.yaml` or the admin panel. |
+| **Resource ACLs** | Per individual resource | Who can view, edit, delete, or re-share a specific agent, prompt, MCP server, etc. Managed by the resource owner via the in-app share dialog. |
+| **System Grants** | Platform-wide | Admin capabilities (e.g. `manage:users`, `manage:roles`, `read:usage`). Used by the admin panel. |
+
+All three are evaluated for the same four principal types:
+
+- **User**: an individual LibreChat account
+- **Group**: a collection of users (local or synced from Entra ID)
+- **Role**: a named permission profile (e.g. `USER`, `ADMIN`, or any custom role)
+- **Public**: every authenticated user on the instance
+
+## Layer 1: Feature Permissions (Role-Based)
+
+Feature-level permissions gate entire capabilities of the app for a given role. They answer questions like *"Can users in this role create agents at all?"*, *"Are they allowed to share prompts publicly?"*, *"Can they invoke the code interpreter?"*.
+
+### Built-in System Roles
+
+LibreChat ships with two system roles that are always present and cannot be deleted:
+
+- **`ADMIN`**: assigned to the first account registered on the instance. Admins can see every resource, modify any setting, access the admin panel, and configure platform-wide behavior.
+- **`USER`**: the default role assigned to every new account.
+
+Admins can be promoted manually by updating the user document in MongoDB, see [Administrator Controls](/docs/features/agents#administrator-controls).
+
+### Permission Types
+
+Each role holds a matrix of **permission types × actions**:
+
+| Permission Type | Available actions |
+| --- | --- |
+| `AGENTS` | `USE`, `CREATE`, `SHARE`, `SHARE_PUBLIC` |
+| `PROMPTS` | `USE`, `CREATE`, `SHARE`, `SHARE_PUBLIC` |
+| `MCP_SERVERS` | `USE`, `CREATE`, `SHARE`, `SHARE_PUBLIC` |
+| `REMOTE_AGENTS` | `USE`, `CREATE`, `SHARE`, `SHARE_PUBLIC` |
+| `MEMORIES` | `USE`, `CREATE`, `UPDATE`, `READ`, `OPT_OUT` |
+| `BOOKMARKS` | `USE` |
+| `MULTI_CONVO` | `USE` |
+| `TEMPORARY_CHAT` | `USE` |
+| `RUN_CODE` | `USE` |
+| `WEB_SEARCH` | `USE` |
+| `FILE_SEARCH` | `USE` |
+| `FILE_CITATIONS` | `USE` |
+| `MARKETPLACE` | `USE` |
+| `PEOPLE_PICKER` | `VIEW_USERS`, `VIEW_GROUPS`, `VIEW_ROLES` |
+
+The distinction between `SHARE` and `SHARE_PUBLIC` is important: you can allow a role to share agents with *specific* users or groups (`SHARE`) without letting them make agents visible to *everyone* on the instance (`SHARE_PUBLIC`).
+
+### Configuring Feature Permissions
+
+The recommended way to manage feature permissions is the [**LibreChat Admin Panel**](/docs/features/admin_panel), which edits the permission matrix directly on each role (including any custom roles you create). Changes take effect without redeploying LibreChat and are scoped to the exact role you want to modify, rather than the global `USER` default.
+
+<Callout type="warning" title="Legacy: `librechat.yaml` interface block">
+The [`interface` block](/docs/configuration/librechat_yaml/object_structure/interface) in `librechat.yaml` can still seed permissions for the default `USER` role at startup, and remains useful for bootstrapping a fresh instance or for fully file-driven deployments. However, it only targets the `USER` role and cannot express differences across custom roles. For ongoing permission management, prefer the admin panel.
+</Callout>
+
+### Custom Roles
+
+Beyond `USER` and `ADMIN`, administrators can create **custom roles** with their own feature-permission matrix (introduced in v0.8.5-rc1; see [#12528](https://github.com/danny-avila/LibreChat/pull/12528)). A user can hold multiple roles, and their effective permissions are the union across all held roles. Custom roles are managed from the admin panel.
+
+### Role- and Group-Scoped Configuration Overrides
+
+In addition to feature flags, v0.8.5-rc1 introduced a **DB-backed configuration override** system ([#12354](https://github.com/danny-avila/LibreChat/pull/12354)). This lets you assign a *different `librechat.yaml`-style config* to specific groups or roles. For example, a "Research" group might have access to additional endpoints, a higher recursion limit, and different agent capabilities than the default. Overrides are resolved at login and composed on top of the base configuration.
+
+## Layer 2: Resource ACLs (Per-Entity Sharing)
+
+Every shareable resource in LibreChat has its own Access Control List, independent of role-based permissions. This is how an individual user with `SHARE` permission chooses *who* gets access to *their* agent, prompt, or MCP server.
+
+### Resource Types
+
+Resource ACLs currently apply to:
+
+- **Agents** (`agent`)
+- **Prompts / Prompt Groups** (`promptGroup`)
+- **MCP Servers** (`mcpServer`)
+- **Remote Agents** (`remoteAgent`), for the [Agents API](/docs/features/agents_api)
+- **Files** (`file`), typically inherited from the resource that uses them
+- **Projects** (`project`), supports inheritance so resources shared to a project automatically inherit ACLs
+
+### Access Roles (Permission Presets)
+
+Rather than exposing raw permission bits to end users, sharing uses three named roles per resource type:
+
+| Role | Permission bits | What the grantee can do |
+| --- | --- | --- |
+| **Viewer** | `VIEW` (`0b0001`) | Use / interact with the resource |
+| **Editor** | `VIEW` + `EDIT` (`0b0011`) | View and modify the resource's settings, instructions, tools, files |
+| **Owner** | `VIEW` + `EDIT` + `DELETE` + `SHARE` (`0b1111`) | Full control: edit, delete, and re-share to others |
+
+Under the hood, permissions are stored as a bitmask (`permBits`) against each (resource, principal) pair; supersets are handled automatically, so granting Editor implies Viewer.
+
+### Granting Access from the UI
+
+1. Open the resource (agent builder, prompt form, MCP server settings, etc.)
+2. Click the **Share** button (visible when you are the owner, an admin, or have been granted `SHARE`)
+3. In the share dialog:
+   - Use the people picker to search for **users**, **groups**, or **roles** to add
+   - Pick an access role (Viewer / Editor / Owner) per principal
+   - Optionally toggle **Public access** to make the resource visible to everyone on the instance (requires the `SHARE_PUBLIC` feature permission)
+4. Save. Grantees see the resource the next time they refresh.
+
+<Callout type="warning" title="Guarding Against Data Leaks">
+Editor and Owner grantees can see everything configured on the resource, including system instructions, attached files, and tools. Any agent may also leak attached data through conversation output, so make sure your instructions are robust against prompt injection before granting edit access or making an agent public.
+</Callout>
+
+### What Grantees See
+
+- **Viewers** see the resource as a ready-to-use item in the relevant picker (e.g. the agent dropdown). They cannot open the builder, see raw instructions, or modify settings.
+- **Editors** can open the resource's configuration and modify it, but cannot delete it or re-share it.
+- **Owners** have the same UI as the original author, and can delete and re-share freely.
+- **The original author** always retains full control regardless of ACL state, and admins can manage any resource on the instance.
+
+### Project Inheritance
+
+Permissions can be inherited from a parent **project**. When an ACL entry is inherited, the `inheritedFrom` link points back to the source. This is what powers the "Global" project in LibreChat, where a resource added to the global project becomes available to all users without needing an entry per principal.
+
+## Layer 3: System Grants (Admin Capabilities)
+
+System grants are a separate grant table used for **admin-level capabilities**, answering questions like *"Can this user access the admin panel?"* or *"Can this group manage MCP servers globally?"*. They are always scoped to a principal (user, group, or role) and a capability string.
+
+The canonical capabilities include:
+
+| Capability | Purpose |
+| --- | --- |
+| `access:admin` | Access the admin panel at all |
+| `read:users` / `manage:users` | View / modify user accounts |
+| `read:groups` / `manage:groups` | View / modify groups |
+| `read:roles` / `manage:roles` | View / modify custom roles |
+| `read:configs` / `manage:configs` | View / modify system configuration |
+| `assign:configs:{user\|group\|role}` | Assign config-override profiles to principals |
+| `read:usage` | View platform usage and telemetry |
+| `read:agents` / `manage:agents` | View / moderate every agent on the instance |
+| `read:prompts` / `manage:prompts` | View / moderate every prompt |
+| `manage:mcpservers` | Manage MCP servers globally |
+
+Manage capabilities imply their corresponding read capability (e.g. holding `manage:users` automatically grants `read:users`). A `SystemRoles.ADMIN` user implicitly holds all capabilities; grants let you **delegate** a subset of admin powers to non-admin principals without making them full admins.
+
+System grants are issued and revoked via the admin panel.
+
+## Principals in Depth
+
+### Users
+
+Standard LibreChat accounts. Users can be **local** (email/password) or **federated** (OAuth2, OIDC, SAML, LDAP). Federated users can be matched to an external identity (`idOnTheSource`); for Entra ID this is the OID, which is what enables group sync.
+
+### Groups
+
+A group is a named collection of users. LibreChat supports two sources:
+
+- **Local groups**: created and managed from the admin panel or directly in the database. Members are LibreChat user IDs.
+- **Entra ID (Azure AD) groups**: synced from Microsoft Graph when a user logs in via Azure OIDC with [token reuse](/docs/configuration/authentication/OAuth2-OIDC/token-reuse) enabled. Each synced group stores its Entra Object ID as `idOnTheSource`, which keeps LibreChat in lockstep with tenant membership.
+
+Groups can appear in any ACL, in `peoplePicker` search, and as a principal target for config overrides or system grants. A single resource shared with a 500-person group is one ACL entry (not 500), and membership changes in Entra propagate automatically on the next login.
+
+### Roles
+
+Any system or custom role can be used as a principal. Sharing an agent with a role (e.g. `SupportEngineers`) gives every user currently holding that role access, without needing to enumerate individuals. Roles can be hidden from the people picker via [`interface.peoplePicker.roles`](/docs/configuration/librechat_yaml/object_structure/interface#peoplepicker) for environments where role-based sharing is an admin-only concern.
+
+### Public
+
+A special principal that matches every authenticated user. Public grants are only permitted when the granting user holds the `SHARE_PUBLIC` feature permission for that resource type.
+
+## People Picker Visibility
+
+The people picker (the search box in share dialogs) can be constrained at the instance level to hide principal types that aren't relevant for your deployment:
+
+```yaml filename="librechat.yaml"
+interface:
+  peoplePicker:
+    users: true
+    groups: true
+    roles: false
+```
+
+This only affects the *search UI*; existing ACL entries for hidden principal types continue to work and are enforced normally.
+
+## Multi-Tenancy
+
+Every record in the access system (ACL entries, access roles, groups, system grants, and custom roles) carries an optional `tenantId`. When set, visibility and resolution are tenant-scoped; when unset, records are instance-global. This allows operators to partition users, groups, and resources across tenants without leaking data between them.
+
+## Migrations from Pre-ACL Versions
+
+Versions prior to v0.8.0-rc3 used a simpler ownership model. Upgrading requires running the ACL migration so existing agents and prompts remain accessible:
+
+**Dry run (preview changes):**
+
+```bash
+npm run migrate:agent-permissions:dry-run
+npm run migrate:prompt-permissions:dry-run
+```
+
+**Execute:**
+
+```bash
+npm run migrate:agent-permissions
+npm run migrate:prompt-permissions
+```
+
+See the [agents migration guide](/docs/features/agents#migration-required-v080-rc3) for Docker variants and batch-size options.
+
+## Related Documentation
+
+- [Agents: Sharing and Permissions](/docs/features/agents#sharing-and-permissions)
+- [Interface Configuration (feature permissions)](/docs/configuration/librechat_yaml/object_structure/interface)
+- [Authentication](/docs/features/authentication)
+- [OpenID Connect Token Reuse (required for Entra ID group sync)](/docs/configuration/authentication/OAuth2-OIDC/token-reuse)
+- [Azure / Entra ID OAuth2](/docs/configuration/authentication/OAuth2-OIDC/azure)
+- [SharePoint Integration](/docs/configuration/sharepoint)
+- [Agents API (Remote Agents)](/docs/features/agents_api)
+- [LibreChat Admin Panel](/docs/features/admin_panel)

--- a/content/docs/features/admin_panel.mdx
+++ b/content/docs/features/admin_panel.mdx
@@ -1,0 +1,162 @@
+---
+title: Admin Panel
+icon: LayoutDashboard
+description: A standalone web UI for managing LibreChat users, groups, roles, configuration overrides, and system grants - without editing librechat.yaml by hand.
+---
+
+# LibreChat Admin Panel
+
+The **LibreChat Admin Panel** is a standalone browser-based management interface for LibreChat. It connects to the same database as LibreChat itself and provides a GUI for the administrative tasks that power [granular access control](/docs/features/access_control): user and group administration, role management, configuration overrides scoped to roles or groups, and system-level capability grants.
+
+<Callout type="info" title="Status: Preview">
+The admin panel is available for testing now and is the upcoming management surface that builds on the admin APIs introduced in [LibreChat v0.8.5-rc1](/changelog/v0.8.5-rc1). Source, issues, and releases live at [github.com/ClickHouse/librechat-admin-panel](https://github.com/ClickHouse/librechat-admin-panel).
+</Callout>
+
+## What It Does
+
+The admin panel is a thin client: all data lives in LibreChat's database, and every action goes through the versioned `/api/admin/*` endpoints on the LibreChat API server. It gives administrators a single place to:
+
+- **Manage configuration**: view and edit every LibreChat setting through a dynamic, schema-driven form. New fields added to the config schema appear automatically, no admin-panel release required.
+- **Apply per-principal overrides**: scope configuration overrides to specific roles or groups, with a priority-based cascade that determines the final resolved value each user sees at login.
+- **Administer users**: list, search, and view every account on the instance.
+- **Manage groups**: create and delete groups, add/remove members, and use groups as first-class principals in ACLs and overrides.
+- **Manage roles**: create custom roles beyond the built-in `USER` / `ADMIN`, edit their feature-permission matrix, and assign users to roles.
+- **Issue system grants**: delegate admin capabilities (e.g. `manage:users`, `read:usage`, `manage:mcpservers`) to specific users, groups, or roles without making them full admins.
+- **Authenticate**: log in with a local LibreChat admin account, or via OpenID SSO / SAML / supported OAuth providers when those are enabled on the LibreChat instance.
+
+For the underlying permission model (principals, resource ACLs, capabilities, and how the layers compose), see the [Access Control](/docs/features/access_control) page.
+
+## Architecture
+
+```
+┌──────────────────┐         ┌──────────────────┐         ┌──────────────┐
+│  Admin Panel     │ ───────▶│  LibreChat API   │ ───────▶│   MongoDB    │
+│  (Bun + Vite)    │  HTTPS  │  /api/admin/*    │         │  (shared DB) │
+└──────────────────┘         └──────────────────┘         └──────────────┘
+       │                             │
+       │ OAuth/OIDC/SAML redirect    │ Verifies admin access
+       └─────────────────────────────┘
+```
+
+The admin panel runs as a separate service; it does not share a process with LibreChat. Admin capabilities are verified on the LibreChat side via the `access:admin` system grant or `SystemRoles.ADMIN` role, so the panel cannot grant itself privileges it shouldn't have.
+
+The admin API surface exposed by LibreChat is:
+
+| Mount | Purpose |
+| --- | --- |
+| `POST /api/admin/login` &nbsp; `/oauth/*` | Admin-specific authentication endpoints (local + SSO) |
+| `GET /api/admin/verify` | Validates the admin session |
+| `/api/admin/users` | User listing and search |
+| `/api/admin/groups` | Group CRUD + member management |
+| `/api/admin/roles` | Custom role CRUD + permission editing + member management |
+| `/api/admin/grants` | System capability grants (assign/revoke/list) |
+| `/api/admin/config` | Base + per-principal configuration overrides |
+
+## Getting Started
+
+### Prerequisites
+
+- A running LibreChat instance on **v0.8.5-rc1 or later** (admin APIs are not available in earlier versions)
+- Network access from the admin-panel container/host to the LibreChat API
+- An admin account on LibreChat: either the first-registered user (auto-admin), a user with `role: 'ADMIN'` set in Mongo, or a principal that has been granted the `access:admin` capability
+
+### Run with Docker (recommended)
+
+Using the published image from GHCR:
+
+```bash
+# 1. Create an env file
+cp .env.example .env
+
+# 2. Edit .env and set at minimum:
+#    SESSION_SECRET=<random string, min 32 characters>
+#    VITE_API_BASE_URL=http://host.docker.internal:3080
+
+# 3. Start it
+docker compose up -d   # http://localhost:3000
+docker compose down    # stop
+```
+
+Standalone `docker run`:
+
+```bash
+docker run -p 3000:3000 \
+  --add-host=host.docker.internal:host-gateway \
+  -e SESSION_SECRET=replace-with-32-char-random-string \
+  -e VITE_API_BASE_URL=http://host.docker.internal:3080 \
+  ghcr.io/clickhouse/librechat-admin-panel:latest
+```
+
+<Callout type="warning" title="Docker Networking">
+Inside a container, `localhost` refers to the container itself, not your host. When LibreChat runs on the same host, point `VITE_API_BASE_URL` at `http://host.docker.internal:3080` (Linux: add `--add-host=host.docker.internal:host-gateway`). In production, use the public/internal DNS name of your LibreChat API.
+</Callout>
+
+### Run Locally for Development
+
+```bash
+git clone https://github.com/ClickHouse/librechat-admin-panel.git
+cd librechat-admin-panel
+cp .env.example .env    # then edit
+bun install
+bun dev                 # http://localhost:3000
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `SESSION_SECRET` | **Yes** in production | Hardcoded dev fallback when running `bun dev`; **no default** in the Docker image | Session encryption key. Must be at least 32 characters. |
+| `VITE_API_BASE_URL` | **Yes** in Docker | `http://localhost:3080` (local dev only) | Browser-facing URL of the LibreChat API server, used for OAuth redirects. |
+| `API_SERVER_URL` | No | Falls back to `VITE_API_BASE_URL` | Server-side URL for LibreChat API calls. Useful when the admin-panel server reaches LibreChat on a different URL than the browser (e.g. internal Kubernetes service vs. public hostname). |
+| `PORT` | No | `3000` | Port the admin panel listens on. |
+| `ADMIN_SSO_ONLY` | No | `false` | Hide the email/password form, forcing SSO-only login. |
+| `ADMIN_SESSION_IDLE_TIMEOUT_MS` | No | `1800000` (30 min) | Session idle timeout in milliseconds. |
+| `SESSION_COOKIE_SECURE` | No | `true` in production | Whether the session cookie requires HTTPS. |
+| `ADMIN_PANEL_METRICS_SECRET` | No | _unset_ | Bearer token required to scrape the `/metrics` Prometheus endpoint. The endpoint returns `401` when unset or mismatched. |
+
+### Cache Controls
+
+These mirror LibreChat's cache env vars. `ADMIN_PANEL_*` variants take precedence, falling back to the shared LibreChat equivalents when unset.
+
+| Variable | Purpose |
+| --- | --- |
+| `STATIC_CACHE_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_MAX_AGE` | Browser `max-age` in seconds for hashed assets in `/assets/` (default 172800 = 2 days). |
+| `STATIC_CACHE_S_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_S_MAX_AGE` | CDN `s-maxage` in seconds (default 86400 = 1 day). |
+| `INDEX_CACHE_CONTROL` / `ADMIN_PANEL_INDEX_CACHE_CONTROL` | `Cache-Control` header for the HTML index response. |
+| `INDEX_PRAGMA` / `ADMIN_PANEL_INDEX_PRAGMA` | `Pragma` header for the HTML index response. |
+| `INDEX_EXPIRES` / `ADMIN_PANEL_INDEX_EXPIRES` | `Expires` header for the HTML index response. |
+
+## Authentication
+
+The admin panel reuses LibreChat's authentication stack and does not have its own user database. Two login paths are supported:
+
+- **Local accounts**: username/password against any LibreChat user whose account passes the admin-access check.
+- **Single sign-on**: OpenID Connect, SAML, and the social OAuth providers already configured on your LibreChat instance. Set `ADMIN_SSO_ONLY=true` to hide the password form entirely.
+
+Admin access is verified server-side by LibreChat for every request. The account must either:
+
+1. Have `role: 'ADMIN'` in MongoDB, **or**
+2. Hold the `access:admin` system grant (assigned to another principal via the admin panel itself; see [System Grants](/docs/features/access_control#layer-3-system-grants-admin-capabilities)).
+
+Sessions are cookie-based, encrypted with `SESSION_SECRET`, and idle-expire per `ADMIN_SESSION_IDLE_TIMEOUT_MS`.
+
+## Configuration Management
+
+The panel renders the LibreChat config as a dynamic form driven by the config schema. This has two useful properties:
+
+- **Forward-compatible**: when LibreChat ships a new config field, the panel picks it up automatically from the schema. No admin-panel upgrade or redeploy is required.
+- **Layered overrides**: the base config (from `librechat.yaml`) can be shadowed by per-principal overrides scoped to a role or group. When a user logs in, overrides are resolved in priority order and merged on top of the base to produce the effective config that user sees.
+
+This is the surface behind LibreChat's [DB-backed per-principal configuration override system](https://github.com/danny-avila/LibreChat/pull/12354). Typical use cases:
+
+- Give a "Research" group higher `recursionLimit` and additional endpoints
+- Let a "FinanceAdmins" role manage MCP servers while regular users can only use them
+- Scope stricter `interface` permissions to external-contractor groups
+
+## Related
+
+- [Access Control](/docs/features/access_control): the permission model the admin panel is built on
+- [Interface Configuration](/docs/configuration/librechat_yaml/object_structure/interface): the feature flags the panel edits
+- [Authentication](/docs/features/authentication): user authentication on LibreChat
+- [v0.8.5-rc1 changelog](/changelog/v0.8.5-rc1): admin API foundations
+- [GitHub: ClickHouse/librechat-admin-panel](https://github.com/ClickHouse/librechat-admin-panel): source, issues, releases

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -299,6 +299,29 @@ When configuring an agent, you can attach files in different categories:
 
 ## Sharing and Permissions
 
+Agents use LibreChat's granular [access control](/docs/features/access_control) system. Each agent has its own Access Control List (ACL), and can be shared with specific **users**, **groups**, **roles**, or **publicly**, each at a chosen permission level.
+
+### Access Roles
+
+When sharing an agent, the grantee is assigned one of three roles:
+
+| Role | What the grantee can do |
+| --- | --- |
+| **Viewer** | Use the agent in conversations; cannot open the builder or see instructions, tools, or attached files |
+| **Editor** | View + modify the agent's instructions, model, tools, and files |
+| **Owner** | Full control: view, edit, delete, and re-share the agent |
+
+The original author and administrators always retain full control regardless of the ACL.
+
+### Sharing an Agent
+
+1. Open the agent in the Agent Builder
+2. Click the **Share** button in the footer (visible when you're the author, an admin, or have been granted `SHARE` permission on that specific agent)
+3. Search for users, groups, or roles in the people picker and assign each a role
+4. Optionally toggle **Public** to make the agent visible to everyone on the instance (requires the `SHARE_PUBLIC` feature permission)
+
+For full details on principals, permission bits, and how ACLs compose with role-based feature permissions, see [Access Control](/docs/features/access_control).
+
 ### Administrator Controls
 
 Administrators have access to global permission settings within the agent builder UI:
@@ -319,18 +342,22 @@ db.users.updateOne(
 
 The use of agents for all users can also be disabled via config, [more info](/docs/configuration/librechat_yaml/object_structure/interface).
 
+Feature-level permissions (who can *use*, *create*, *share*, or *share publicly* agents) are managed from the [**LibreChat Admin Panel**](/docs/features/admin_panel) on each role, including any custom roles. The [`interface.agents`](/docs/configuration/librechat_yaml/object_structure/interface#agents) block in `librechat.yaml` can still seed defaults for the built-in `USER` role at startup, but the admin panel is the recommended way to edit them going forward.
+
 ### User-Level Sharing
 
 Individual users can:
-- Share their agents with all users (if enabled)
-- Control editing permissions for shared agents
-- Manage access to their created agents
+
+- Share their agents with specific users, groups, or roles (if `SHARE` is enabled for their role)
+- Make agents visible to everyone on the instance (if `SHARE_PUBLIC` is enabled)
+- Grant each recipient a different access level (Viewer / Editor / Owner)
+- Re-share or revoke access at any time from the share dialog
 
 ### Notes
 
 - Instructions, model parameters, attached files, and tools are only exposed to the user if they have editing permissions
-  - An agent may leak any attached data, whether instructions or files, through conversation--make sure your instructions are robust against this
-- Only original authors and administrators can delete shared agents
+  - An agent may leak any attached data, whether instructions or files, through conversation, so make sure your instructions are robust against this before granting Editor/Owner access or making the agent public
+- Only original authors, administrators, and grantees with Owner permission can delete shared agents
 - Agents are private to authors unless shared
 
 ## Optional Configuration

--- a/content/docs/features/authentication.mdx
+++ b/content/docs/features/authentication.mdx
@@ -14,9 +14,11 @@ Additionally, our system can integrate social logins from various platforms such
 **For further details, refer to the configuration guides provided here: [Authentication](/docs/configuration/authentication)**
 
 <Callout type="warning" title="Important">
-- When you run the app for the first time, you need to create a new account by clicking on "Sign up" on the login page. The first account you make will be the admin account. At the moment, the only privilege of the admin user is to control [agents](docs/features/agents#administrator-controls), prompts, and [memory](/docs/features/memory) permissions, and it will be useful for the admin dashboard to manage users and other settings later.
+- When you run the app for the first time, you need to create a new account by clicking on "Sign up" on the login page. The first account you make will be the admin account and holds all administrative capabilities on the instance. See [Access Control](/docs/features/access_control) for the full authorization model covering users, groups, roles, resource ACLs, and system-level admin grants.
 - The first account created should ideally be a local account (email and password).
 </Callout>
+
+**See also:** [Access Control](/docs/features/access_control), LibreChat's granular permission system for users, groups, and roles, covering per-resource sharing of agents, prompts, MCP servers, and feature-level permissions.
 
 
 <div style={{padding: "20px", display: "flex", justifyContent: "center", alignItems: "center", flexDirection: "column"}}>

--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -276,6 +276,12 @@ LibreChat's MCP implementation is designed for highly configurable, real-world, 
 - User authentication and permissions are respected
 - Personal data and context remain private
 
+### Sharing MCP Servers
+
+MCP servers participate in LibreChat's [granular access control](/docs/features/access_control) system. In addition to servers defined in `librechat.yaml` (which are managed by admins and governed by [`interface.mcpServers`](/docs/configuration/librechat_yaml/object_structure/interface#mcpservers) feature permissions), user-created MCP servers have their own ACL and can be shared with specific **users**, **groups**, **roles**, or **publicly**, at Viewer, Editor, or Owner level.
+
+The `USE`, `CREATE`, `SHARE`, and `SHARE_PUBLIC` feature flags under `interface.mcpServers` control who is allowed to create and share MCP servers at all. See [Access Control](/docs/features/access_control) for how the permission layers compose.
+
 ### Dynamic User Context
 
 MCP servers can access user information through placeholders in **URLs and headers** (for SSE and Streamable HTTP transports):

--- a/content/docs/features/meta.json
+++ b/content/docs/features/meta.json
@@ -26,6 +26,8 @@
     "import_convos",
     "---Security---",
     "authentication",
+    "access_control",
+    "admin_panel",
     "password_reset",
     "mod_system"
   ]


### PR DESCRIPTION
- Added a new 'Access Control' page detailing LibreChat's granular authorization system, including feature permissions, resource ACLs, and system grants.
- Introduced the 'Admin Panel' documentation, outlining its functionalities for managing users, groups, roles, and configuration overrides.
- Updated existing feature documentation (agents, MCP servers) to reflect the new access control model and emphasize the use of the Admin Panel for permission management.
- Marked several YAML fields as deprecated for permission management, recommending the Admin Panel for ongoing management.