### PR TITLE
v0.8.5

### DIFF
--- a/content/changelog/config_v1.3.9.mdx
+++ b/content/changelog/config_v1.3.9.mdx
@@ -1,0 +1,25 @@
+---
+date: 2026-04-21
+title: ⚙️ Config v1.3.9
+version: "1.3.9"
+---
+
+- Fixed [`summarization.trigger`](/docs/configuration/librechat_yaml/object_structure/summarization#trigger) schema to match documented and runtime-supported types
+  - Previously only accepted `token_count` (which silently never fired at runtime)
+  - Now correctly accepts `token_ratio`, `remaining_tokens`, and `messages_to_refine` via a discriminated union
+  - `token_ratio` value constrained to 0–1, other types require positive integers
+
+- Added `thinkingDisplay` parameter for Anthropic models
+  - Controls whether reasoning content is returned in responses for Claude Opus 4.7+ (which omits thinking by default)
+  - Options: `"auto"` (default), `"summarized"`, `"omitted"`
+  - Available on `anthropic` and `bedrock` (Anthropic models) endpoints
+
+- Added `xhigh` to Anthropic effort levels
+  - `effort` field now accepts `""`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`
+
+- Added Claude Opus 4.7 to default model lists
+  - `claude-opus-4-7` for Anthropic
+  - `anthropic.claude-opus-4-7` for Bedrock
+
+- Added `text/x-markdown` MIME type alias
+  - Maps to `text/markdown` for consistent file handling

--- a/content/changelog/v0.8.5.mdx
+++ b/content/changelog/v0.8.5.mdx
@@ -36,6 +36,7 @@ version: "0.8.5"
 * 🗂️ Sidebar Icon Toggle & New Chat History Switch by [@danny-avila](https://github.com/danny-avila) in [#12642](https://github.com/danny-avila/LibreChat/pull/12642)
 * 🦉 Claude Opus 4.7 Model Support by [@danny-avila](https://github.com/danny-avila) in [#12698](https://github.com/danny-avila/LibreChat/pull/12698)
 * 🫧 Claude Opus 4.7 Reasoning Visibility by [@danny-avila](https://github.com/danny-avila) in [#12701](https://github.com/danny-avila/LibreChat/pull/12701)
+* 📅 Support `text/calendar` (iCalendar) in Code Outputs by [@upman](https://github.com/upman) in [#12758](https://github.com/danny-avila/LibreChat/pull/12758)
 
 ### 🐛 Fixes
 
@@ -56,6 +57,10 @@ version: "0.8.5"
 * 🔊 Preserve Log Metadata on Console for Warn/Error Levels by [@danny-avila](https://github.com/danny-avila) in [#12737](https://github.com/danny-avila/LibreChat/pull/12737)
 * 🤝 Load Handoff Agents for Agents API by [@danny-avila](https://github.com/danny-avila) in [#12740](https://github.com/danny-avila/LibreChat/pull/12740)
 * 🗺️ Resolve Custom-Endpoint Providers for Summarization by [@danny-avila](https://github.com/danny-avila) in [#12739](https://github.com/danny-avila/LibreChat/pull/12739)
+* 🔒 Validate MCP OAuth Protected Resource Metadata binding by [@danny-avila](https://github.com/danny-avila) in [#12755](https://github.com/danny-avila/LibreChat/pull/12755)
+* 🔐 Prefer WWW-Authenticate resource_metadata Hint for MCP OAuth by [@danny-avila](https://github.com/danny-avila) in [#12763](https://github.com/danny-avila/LibreChat/pull/12763)
+* 🔏 Prevent Browser Autofill From Silently Dropping MCP CustomUserVars on Save by [@jschmetzer](https://github.com/jschmetzer) in [#12770](https://github.com/danny-avila/LibreChat/pull/12770)
+* 🧹 Clean Up Orphaned Agent File Stubs After Deletion by [@danny-avila](https://github.com/danny-avila) in [#12781](https://github.com/danny-avila/LibreChat/pull/12781)
 
 ### 🔧 Refactoring
 
@@ -70,7 +75,7 @@ version: "0.8.5"
 
 ### 🌍 Internationalization
 
-* 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#12646](https://github.com/danny-avila/LibreChat/pull/12646)
+* 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#12646](https://github.com/danny-avila/LibreChat/pull/12646), [#12711](https://github.com/danny-avila/LibreChat/pull/12711)
 
 ## New Contributors
 
@@ -79,5 +84,7 @@ version: "0.8.5"
 * [@ivan09069](https://github.com/ivan09069) made their first contribution in [#12665](https://github.com/danny-avila/LibreChat/pull/12665)
 * [@kojinseok-del](https://github.com/kojinseok-del) made their first contribution in [#12386](https://github.com/danny-avila/LibreChat/pull/12386)
 * [@xxsLuna](https://github.com/xxsLuna) made their first contribution in [#12707](https://github.com/danny-avila/LibreChat/pull/12707)
+* [@upman](https://github.com/upman) made their first contribution in [#12758](https://github.com/danny-avila/LibreChat/pull/12758)
+* [@jschmetzer](https://github.com/jschmetzer) made their first contribution in [#12770](https://github.com/danny-avila/LibreChat/pull/12770)
 
 **Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.8.5-rc1...v0.8.5

--- a/content/changelog/v0.8.5.mdx
+++ b/content/changelog/v0.8.5.mdx
@@ -1,0 +1,83 @@
+---
+date: 2026-04-21
+title: 🚀 LibreChat v0.8.5
+description: The v0.8.5 release of LibreChat
+version: "0.8.5"
+---
+
+## What's Changed
+
+## 🏞️ Highlights
+
+- **Admin Panel Foundation**
+  - Per-principal (Roles & Groups) configuration overrides, Custom Roles & Groups, System Grants for admin-level access control
+  - Admin panel, [available for testing here](https://github.com/ClickHouse/librechat-admin-panel)
+- **Context Compaction/Summarization**
+  - Long-running agent conversations are automatically summarized to stay within context limits. Includes configurable triggers, context pruning of large tool results, and a new top-level [`summarization` config](https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/summarization). See [Config v1.3.8](/changelog/config_v1.3.8).
+- **Claude Opus 4.7 Support**
+  - Full model support with configurable reasoning visibility (`thinkingDisplay`). See [Config v1.3.9](/changelog/config_v1.3.9).
+- **UI Redesign**
+  - Redesigned sidebar with unified icon strip layout, including all panels (agent builder, prompts, etc.)
+  - Overhauled tool call UI with grouping/richer output rendering
+  - Refreshed Prompts UI
+  - Sidebar icon toggle & new chat history switch
+- **Performance & MCP Improvements**
+  - In-memory caching, Redis event sequence atomization, lazy MCP init
+  - OAuth client registration fixes and stale client recovery
+- **Pinned Model Specs**: Users can now pin favorite model specs for quick access
+
+---
+
+## Changes Since v0.8.5-rc1
+
+### ✨ Features
+
+* 🪪 Optimized Entra ID Group Sync with Auto-Creation by [@Airamhh](https://github.com/Airamhh) in [#12606](https://github.com/danny-avila/LibreChat/pull/12606)
+* 🗂️ Sidebar Icon Toggle & New Chat History Switch by [@danny-avila](https://github.com/danny-avila) in [#12642](https://github.com/danny-avila/LibreChat/pull/12642)
+* 🦉 Claude Opus 4.7 Model Support by [@danny-avila](https://github.com/danny-avila) in [#12698](https://github.com/danny-avila/LibreChat/pull/12698)
+* 🫧 Claude Opus 4.7 Reasoning Visibility by [@danny-avila](https://github.com/danny-avila) in [#12701](https://github.com/danny-avila/LibreChat/pull/12701)
+
+### 🐛 Fixes
+
+* 📑 Alias Mimetype `text/x-markdown` to `text/markdown` by [@dlew](https://github.com/dlew) in [#12608](https://github.com/danny-avila/LibreChat/pull/12608)
+* 🔬 Scope Web Search Results to Own Turn by [@danny-avila](https://github.com/danny-avila) in [#12631](https://github.com/danny-avila/LibreChat/pull/12631)
+* 🔀 Resolve Action Tools by Exact Name to Prevent Multi-Action Domain Collision by [@lrreverence](https://github.com/lrreverence) in [#12594](https://github.com/danny-avila/LibreChat/pull/12594)
+* 🔑 Clear Stale Client Registration on `invalid_client` During OAuth Token Refresh by [@danny-avila](https://github.com/danny-avila) in [#12643](https://github.com/danny-avila/LibreChat/pull/12643)
+* 🎯 Preserve Selected Artifact When Clicking Artifact Button by [@starchow](https://github.com/starchow) in [#12601](https://github.com/danny-avila/LibreChat/pull/12601)
+* 🔍 Anthropic Web Search Multi-Turn Issue and Attachment Results by [@danny-avila](https://github.com/danny-avila) in [#12651](https://github.com/danny-avila/LibreChat/pull/12651)
+* 🖼️ Hide Duplicate Image Placeholder During Image Generation by [@danny-avila](https://github.com/danny-avila) in [#12654](https://github.com/danny-avila/LibreChat/pull/12654)
+* 🧊 In-Memory Endpoint Token Config Cache Isolation by [@danny-avila](https://github.com/danny-avila) in [#12673](https://github.com/danny-avila/LibreChat/pull/12673)
+* 🔉 Normalize audio MIME types in STT format validation by [@danny-avila](https://github.com/danny-avila) in [#12674](https://github.com/danny-avila/LibreChat/pull/12674)
+* 💎 Handle `usage_metadata` in Title Transaction for Gemini Models by [@kojinseok-del](https://github.com/kojinseok-del) in [#12386](https://github.com/danny-avila/LibreChat/pull/12386)
+* 🤝 Normalize Empty Handoff Fields to Restore Default Fallback by [@xxsLuna](https://github.com/xxsLuna) in [#12707](https://github.com/danny-avila/LibreChat/pull/12707)
+* 🪐 Replace `$bitsAllSet` ACL Queries for Azure Cosmos DB Compatibility by [@danny-avila](https://github.com/danny-avila) in [#12736](https://github.com/danny-avila/LibreChat/pull/12736)
+* 📝 Preserve Raw Markdown Formatting on Upload as Text by [@danny-avila](https://github.com/danny-avila) in [#12734](https://github.com/danny-avila/LibreChat/pull/12734)
+* 📐 Align Summarization Trigger Schema with Documented and Runtime-Supported Types by [@danny-avila](https://github.com/danny-avila) in [#12735](https://github.com/danny-avila/LibreChat/pull/12735)
+* 🔊 Preserve Log Metadata on Console for Warn/Error Levels by [@danny-avila](https://github.com/danny-avila) in [#12737](https://github.com/danny-avila/LibreChat/pull/12737)
+* 🤝 Load Handoff Agents for Agents API by [@danny-avila](https://github.com/danny-avila) in [#12740](https://github.com/danny-avila/LibreChat/pull/12740)
+* 🗺️ Resolve Custom-Endpoint Providers for Summarization by [@danny-avila](https://github.com/danny-avila) in [#12739](https://github.com/danny-avila/LibreChat/pull/12739)
+
+### 🔧 Refactoring
+
+* 🧩 Agent Side Panel Layout and Consistency Fixes by [@danny-avila](https://github.com/danny-avila) in [#12676](https://github.com/danny-avila/LibreChat/pull/12676)
+* 🔼 Improve UX for Command Popovers by [@danny-avila](https://github.com/danny-avila) in [#12677](https://github.com/danny-avila/LibreChat/pull/12677)
+
+### 📦 Dependencies & Chores
+
+* 📝 Add `RAG_API_URL` to `.env.example` by [@ivan09069](https://github.com/ivan09069) in [#12665](https://github.com/danny-avila/LibreChat/pull/12665)
+* 📦 npm audit & bump `@librechat/agents` to v3.1.67 by [@danny-avila](https://github.com/danny-avila) in [#12710](https://github.com/danny-avila/LibreChat/pull/12710)
+* 📦 Update `@librechat/agents` to v3.1.68 by [@danny-avila](https://github.com/danny-avila) in [#12752](https://github.com/danny-avila/LibreChat/pull/12752)
+
+### 🌍 Internationalization
+
+* 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#12646](https://github.com/danny-avila/LibreChat/pull/12646)
+
+## New Contributors
+
+* [@lrreverence](https://github.com/lrreverence) made their first contribution in [#12594](https://github.com/danny-avila/LibreChat/pull/12594)
+* [@starchow](https://github.com/starchow) made their first contribution in [#12601](https://github.com/danny-avila/LibreChat/pull/12601)
+* [@ivan09069](https://github.com/ivan09069) made their first contribution in [#12665](https://github.com/danny-avila/LibreChat/pull/12665)
+* [@kojinseok-del](https://github.com/kojinseok-del) made their first contribution in [#12386](https://github.com/danny-avila/LibreChat/pull/12386)
+* [@xxsLuna](https://github.com/xxsLuna) made their first contribution in [#12707](https://github.com/danny-avila/LibreChat/pull/12707)
+
+**Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.8.5-rc1...v0.8.5

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -10,7 +10,7 @@ icon: Settings
 
 <OptionTable
   options={[
-    ['version', 'String', 'Specifies the version of the configuration file.', 'version: 1.3.8' ],
+    ['version', 'String', 'Specifies the version of the configuration file.', 'version: 1.3.9' ],
   ]}
 />
 

--- a/content/docs/configuration/librechat_yaml/object_structure/memory.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/memory.mdx
@@ -193,7 +193,7 @@ When using custom agent configuration, the following fields are available:
 Here's a comprehensive example showing all memory configuration options:
 
 ```yaml filename="librechat.yaml"
-version: 1.3.8
+version: 1.3.9
 cache: true
 
 memory:

--- a/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -1146,11 +1146,11 @@ preset:
 
 <OptionTable
   options={[
-    ['effort', 'String', 'Controls the Adaptive Thinking effort level for supported Anthropic models (e.g., Claude Opus 4.6). Higher effort levels allocate more thinking tokens for complex problems.', ''],
+    ['effort', 'String', 'Controls the Adaptive Thinking effort level for supported Anthropic models (e.g., Claude Opus 4.6+). Higher effort levels allocate more thinking tokens for complex problems.', ''],
   ]}
 />
 
-**Options:** `""` (unset/auto), `"low"`, `"medium"`, `"high"`, `"max"`
+**Options:** `""` (unset/auto), `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`
 
 **Default:** `""` (unset — model decides)
 
@@ -1158,6 +1158,32 @@ preset:
 ```yaml
 preset:
   effort: "high"
+```
+
+---
+
+#### thinkingDisplay
+
+> **Supported by:** `anthropic`, `bedrock` (Anthropic models)
+
+<OptionTable
+  options={[
+    ['thinkingDisplay', 'String', 'Controls whether reasoning content is returned in model responses. Claude Opus 4.7+ omits thinking content by default; this setting lets you opt in to reasoning summaries or explicitly suppress them.', ''],
+  ]}
+/>
+
+**Options:** `"auto"` (default), `"summarized"`, `"omitted"`
+
+- `"auto"` — LibreChat decides: opts in to `"summarized"` for models that omit thinking by default (Opus 4.7+), leaves the field off for older models
+- `"summarized"` — always request a post-hoc summary of the reasoning
+- `"omitted"` — always suppress reasoning content (slightly lower latency)
+
+**Default:** `"auto"`
+
+**Example:**
+```yaml
+preset:
+  thinkingDisplay: "summarized"
 ```
 
 ---

--- a/content/docs/configuration/librechat_yaml/object_structure/speech.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/speech.mdx
@@ -274,7 +274,7 @@ speechTab:
 ## Complete Example
 
 ```yaml filename="librechat.yaml"
-version: 1.3.8
+version: 1.3.9
 cache: true
 
 speech:

--- a/content/docs/configuration/librechat_yaml/object_structure/summarization.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/summarization.mdx
@@ -114,7 +114,7 @@ summarization:
 <OptionTable
   options={[
     ['type', 'String', 'The trigger strategy. Options: `"token_ratio"`, `"remaining_tokens"`, `"messages_to_refine"`.', 'type: "token_ratio"'],
-    ['value', 'Number', 'The threshold value for the chosen trigger type.', 'value: 0.8'],
+    ['value', 'Number', 'The threshold value for the chosen trigger type. For `token_ratio`: 0–1 (inclusive). For `remaining_tokens` and `messages_to_refine`: positive integer.', 'value: 0.8'],
   ]}
 />
 
@@ -123,8 +123,8 @@ summarization:
 | Type | Value | Fires When |
 |---|---|---|
 | `token_ratio` | `0.0–1.0` | The fraction of context tokens used reaches or exceeds the value |
-| `remaining_tokens` | Number | The remaining context tokens drops to or below the value |
-| `messages_to_refine` | Number | The count of messages eligible for summarization reaches or exceeds the value |
+| `remaining_tokens` | Positive integer | The remaining context tokens drops to or below the value |
+| `messages_to_refine` | Positive integer | The count of messages eligible for summarization reaches or exceeds the value |
 | _(not set)_ | — | Whenever pruning drops any messages (default behavior) |
 
 **Example:**
@@ -220,7 +220,7 @@ summarization:
 ## Complete Configuration Example
 
 ```yaml filename="librechat.yaml"
-version: 1.3.8
+version: 1.3.9
 cache: true
 
 summarization:


### PR DESCRIPTION
- Introduced new features in config v1.3.9, including:
  - Updated `summarization.trigger` schema to align with supported types.
  - Added `thinkingDisplay` parameter for Anthropic models to control reasoning content visibility.
  - Expanded `effort` field options for Anthropic models to include `xhigh`.
  - Included Claude Opus 4.7 in default model lists.
  - Added `text/x-markdown` MIME type alias for consistent file handling.
- Updated configuration documentation to reflect version changes and new options.