### PR TITLE
📝 docs: Document interface.autoSubmitFromUrl And allowedAddresses Exemption List

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/actions.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/actions.mdx
@@ -17,6 +17,9 @@ actions:
     - "librechat.ai"
     - "google.com"
     - "https://api.example.com:8443"  # With protocol and port
+  allowedAddresses:
+    - "host.docker.internal"          # Permit one private host
+    - "10.0.0.5"                      # Permit one private IP
 ```
 
 ## allowedDomains
@@ -89,3 +92,40 @@ allowedDomains:
   - "https://secure-api.example.com:443"
   - "192.168.1.50"  # Internal service (explicitly allowed)
 ```
+
+## allowedAddresses
+
+`allowedAddresses` is an **exemption list** for the SSRF private-IP block — not a domain whitelist. It is the right tool when you want to permit one or two specific private/internal hosts without restricting what your Actions can reach in the public internet.
+
+### When to use it instead of `allowedDomains`
+
+`allowedDomains` is a strict whitelist: when it is set, **only** listed entries are reachable. Adding a private IP there to permit, say, a self-hosted internal API also blocks every public action endpoint that you didn't also list.
+
+`allowedAddresses` is orthogonal: it permits specific private targets while leaving the rest of the public internet reachable through the default SSRF policy.
+
+```yaml filename="default SSRF + permitted private host"
+actions:
+  allowedAddresses:
+    - "host.docker.internal"
+    - "10.0.0.5"
+  # allowedDomains is intentionally not set — public destinations
+  # remain reachable, only listed private hosts are exempted.
+```
+
+You can also combine both: use `allowedDomains` as your strict whitelist and `allowedAddresses` to permit specific private hosts not covered by the domain rules.
+
+### Acceptable entries
+
+- **Bare hostnames**: `host.docker.internal`, `ollama.internal`, `localhost`
+- **Private IPv4 literals**: `10.0.0.5`, `127.0.0.1`, `192.168.1.10`, `169.254.169.254`
+- **Private IPv6 literals**: `::1`, `fc00::1`, `fe80::1`, `[::1]` (brackets are stripped)
+
+### Rejected entries (validated at config load)
+
+- **URLs / paths / CIDR ranges**: `http://10.0.0.5`, `10.0.0.0/24`, `/path`
+- **Host with port**: `localhost:8080`, `[::1]:8080` — list the bare hostname or IP only
+- **Public IP literals**: `8.8.8.8`, `1.1.1.1`, `2001:4860::` — the field is scoped to private IP space; public IPs are not SSRF targets and a public-IP exemption has no defensive purpose
+
+### Hostname trust
+
+A hostname entry trusts whatever IP that hostname resolves to at runtime. If the DNS for a listed hostname is rotated or hijacked to point at a different private IP, the exemption follows. Only list hostnames whose DNS you control. **Prefer literal IPs when you can.**

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -437,12 +437,14 @@ see: [Summarization Object Structure](/docs/configuration/librechat_yaml/object_
 **Subkeys:**
 <OptionTable
   options={[
-    ['allowedDomains', '', 'Specifies allowed domains for actions.', ''],
+    ['allowedDomains', 'Array of Strings', 'Strict whitelist of domains for actions. When set, only listed domains are reachable.', ''],
+    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits specific private hosts without restricting public destinations.', ''],
   ]}
 />
 
 see also: 
-- [alloweddomains](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains),
+- [allowedDomains](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains),
+- [allowedAddresses](/docs/configuration/librechat_yaml/object_structure/actions#allowedaddresses),
 - [Actions Object Structure](/docs/configuration/librechat_yaml/object_structure/actions)
 
 ## interface
@@ -469,6 +471,7 @@ see also:
     ['agents', 'Boolean or Object', 'Enables or disables all agents features for all users', ''],
     ['temporaryChat', 'Boolean', 'Enables or disables the temporary chat feature', ''],
     ['temporaryChatRetention', 'Number', 'Configures the retention period for temporary chats in hours. Min: 1, Max: 8760. Default: 720 (30 days).', ''],
+    ['autoSubmitFromUrl', 'Boolean', 'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model. When `false`, the prompt is pre-filled but not submitted.', ''],
     ['mcpServers', 'Object', 'Contains settings related to MCP server selection and access control.', ''],
     ['customWelcome', 'String', 'Custom welcome message displayed in the chat interface.', ''],
     ['runCode', 'Boolean', 'Enables or disables the "Run Code" button for Markdown Code Blocks', ''],
@@ -520,10 +523,13 @@ see: [Model Specs Object Structure](/docs/configuration/librechat_yaml/object_st
     ['azureAssistants', 'Object', 'Azure Assistants endpoint-specific configuration.', ''],
     ['agents', 'Object', 'Agents endpoint-specific configuration.', ''],
     ['all', 'Object', 'Global endpoint settings that apply to all endpoints. See Shared Endpoint Settings.', ''],
+    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits user-provided baseURLs to point at specific private hosts (e.g. self-hosted Ollama) without disabling SSRF protection for everything else.', ''],
   ]}
 />
 
 > **Note:** All endpoints support [Shared Endpoint Settings](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings) which include `streamRate`, `titleModel`, `titleMethod`, `titlePrompt`, `titlePromptTemplate`, `titleEndpoint`, and `maxToolResultChars`. These can be configured individually per endpoint or globally using the `all` key. The `all` key does not accept `baseURL`.
+
+> **Note:** `endpoints.allowedAddresses` applies to user-provided `baseURL` values (when an admin configures a custom endpoint with `apiKey: 'user_provided'` and `baseURL: 'user_provided'`). Each user-supplied baseURL is validated against the SSRF block at request time; entries listed here are exempted. See [`mcpSettings.allowedAddresses`](/docs/configuration/librechat_yaml/object_structure/mcp_settings#allowedaddresses) for the field semantics — same rules apply (private IP space only, no URLs/CIDR/ports).
 
 ## mcpSettings
 
@@ -537,14 +543,15 @@ see: [Model Specs Object Structure](/docs/configuration/librechat_yaml/object_st
 **Subkeys:**
 <OptionTable
   options={[
-    ['allowedDomains', 'Array of Strings', 'A list specifying allowed domains for MCP server connections. Required for internal/local addresses.', ''],
+    ['allowedDomains', 'Array of Strings', 'Strict whitelist of domains for MCP server connections. When set, only listed entries are reachable.', ''],
+    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits specific private hosts without flipping `allowedDomains` into strict-whitelist mode.', ''],
   ]}
 />
 
 - **Notes**:
   - This is a security feature to protect against abuse / misuse of internal addresses via MCP servers
   - By default, LibreChat restricts MCP servers from connecting to internal, local, or private network addresses
-  - MCP servers using local IP addresses or domains must be **explicitly** allowed
+  - MCP servers using local IP addresses or domains can either be added to the strict `allowedDomains` whitelist (which then becomes the only reachable set), or — to keep public destinations reachable — exempted via `allowedAddresses`
   - As with all yaml configuration changes, a LibreChat restart is required to take effect
   - Supports domains, wildcard subdomains (`*.example.com`), docker domains, and IP addresses
 
@@ -557,6 +564,9 @@ mcpSettings:
     - "*.example.com"         # All subdomains
     - "mcp-server"            # Local Docker domain
     - "172.24.1.165"          # Internal network IP
+  allowedAddresses:
+    - "host.docker.internal"  # Permit a single private host
+    - "10.0.0.5"              # Permit a single private IP
 ```
 
 see: [MCP Settings Object Structure](/docs/configuration/librechat_yaml/object_structure/mcp_settings)

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -22,6 +22,7 @@ These are fields under `interface`:
   - `agents`
   - `temporaryChat`
   - `temporaryChatRetention`
+  - `autoSubmitFromUrl`
   - `customWelcome`
   - `runCode`
   - `webSearch`
@@ -498,6 +499,34 @@ interface:
 - **168 hours**: `temporaryChatRetention: 168` (1 week)
 - **720 hours**: `temporaryChatRetention: 720` (30 days - default)
 - **8760 hours**: `temporaryChatRetention: 8760` (1 year - maximum)
+
+## autoSubmitFromUrl
+
+Controls whether a prompt supplied via URL query parameters on `/c/new` is auto-submitted to the model.
+
+When `/c/new?prompt=…&submit=true` is opened by an authenticated user, LibreChat normally pre-fills the composer with the URL-supplied prompt and submits it immediately. This is a convenience feature for crafted deeplinks and shared chat URLs.
+
+For deployments where users may receive crafted links from external sources — and where memory- or tool-enabled models could leak sensitive context if a prompt-injection payload reaches the model — operators can disable auto-submission. With the flag set to `false`, the prompt is still pre-filled in the composer but the user must press **Send** explicitly.
+
+**Key:**
+<OptionTable
+  options={[
+    ['autoSubmitFromUrl', 'Boolean', 'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model.', 'When `false`, the prompt is pre-filled in the composer but not submitted.'],
+  ]}
+/>
+
+**Default:** `true` (existing behavior is preserved unless explicitly disabled).
+
+**Notes:**
+- This setting does not affect URL-driven model spec selection or other URL-driven settings — only the auto-submission step.
+- The query parameter accepts both `prompt` and `q` as the prompt source, with `prompt` taking precedence. `submit=true` is the trigger.
+- Recommended for instances handling sensitive memory or tool data, where a 1-click prompt-injection vector should require explicit user confirmation.
+
+**Example:**
+```yaml filename="interface / autoSubmitFromUrl"
+interface:
+  autoSubmitFromUrl: false
+```
 
 ## customWelcome
 

--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_settings.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_settings.mdx
@@ -18,6 +18,9 @@ mcpSettings:
     - "mcp-server"                       # Local Docker domain
     - "172.24.1.165"                     # Internal network IP
     - "https://api.example.com:8443"     # With protocol and port
+  allowedAddresses:
+    - "host.docker.internal"             # Permit a single private host
+    - "10.0.0.5"                         # Permit a single private IP
 ```
 
 ## Configuration
@@ -27,6 +30,7 @@ mcpSettings:
 <OptionTable
   options={[
     ['allowedDomains', 'Array of Strings', 'A list specifying allowed domains for MCP server connections.', 'When configured, only listed domains are allowed. When not configured, SSRF targets are blocked but all other domains are allowed.'],
+    ['allowedAddresses', 'Array of Strings', 'An SSRF exemption list, scoped to private IP space. Hostnames or private-IP literals listed here bypass the default-deny SSRF block without restricting access to public domains.', 'Use when you want default SSRF protection AND specific internal MCP servers, without flipping `allowedDomains` into strict-whitelist mode.'],
   ]}
 />
 
@@ -108,6 +112,43 @@ mcpSettings:
   allowedDomains:
     - "172.24.1.165"    # Add the IP address or domain
 ```
+
+## allowedAddresses
+
+`allowedAddresses` is an **exemption list** for the SSRF private-IP block — not a domain whitelist. It is the right tool when you want to permit one or two specific private/internal hosts without restricting what your MCP servers can reach in the public internet.
+
+### When to use it instead of `allowedDomains`
+
+`allowedDomains` is a strict whitelist: when it is set, **only** listed entries are reachable. Adding a private IP there to permit, say, a self-hosted MCP server also blocks every public destination (`api.example.com`, `*.googleapis.com`, etc.) that you didn't also list.
+
+`allowedAddresses` is orthogonal: it permits specific private targets while leaving the rest of the public internet reachable through the default SSRF policy. Common configuration:
+
+```yaml filename="default SSRF + permitted private host"
+mcpSettings:
+  allowedAddresses:
+    - "host.docker.internal"
+    - "10.0.0.5"
+  # allowedDomains is intentionally not set — public destinations
+  # remain reachable, only listed private hosts are exempted.
+```
+
+You can also combine both: use `allowedDomains` as your strict whitelist and `allowedAddresses` to permit specific private hosts not covered by the domain rules.
+
+### Acceptable entries
+
+- **Bare hostnames**: `host.docker.internal`, `ollama.internal`, `localhost`
+- **Private IPv4 literals**: `10.0.0.5`, `127.0.0.1`, `192.168.1.10`, `169.254.169.254`
+- **Private IPv6 literals**: `::1`, `fc00::1`, `fe80::1`, `[::1]` (brackets are stripped)
+
+### Rejected entries (validated at config load)
+
+- **URLs / paths / CIDR ranges**: `http://10.0.0.5`, `10.0.0.0/24`, `/path`
+- **Host with port**: `localhost:8080`, `[::1]:8080` — list the bare hostname or IP only
+- **Public IP literals**: `8.8.8.8`, `1.1.1.1`, `2001:4860::` — the field is scoped to private IP space; public IPs are not SSRF targets and a public-IP exemption has no defensive purpose
+
+### Hostname trust
+
+A hostname entry trusts whatever IP that hostname resolves to at runtime. If the DNS for a listed hostname is rotated or hijacked to point at a different private IP, the exemption follows. Only list hostnames whose DNS you control. **Prefer literal IPs when you can.**
 
 ## References
 


### PR DESCRIPTION
## Summary

I added documentation for two new admin-facing config flags that landed in LibreChat:

- `interface.autoSubmitFromUrl` ([danny-avila/LibreChat#12929](https://github.com/danny-avila/LibreChat/pull/12929)) — toggles whether \`/c/new?prompt=…&submit=true\` auto-submits the URL-supplied prompt to the model. Default \`true\` preserves current behavior; deployments handling sensitive memory or tool data should set it to \`false\` so URL-supplied prompts only pre-fill the composer.
- \`endpoints.allowedAddresses\`, \`mcpSettings.allowedAddresses\`, and \`actions.allowedAddresses\` ([danny-avila/LibreChat#12933](https://github.com/danny-avila/LibreChat/pull/12933)) — an SSRF exemption list scoped to private IP space, orthogonal to the existing strict \`allowedDomains\` whitelist. Permits specific private/internal hosts (self-hosted Ollama, Docker host, etc.) without restricting access to public destinations.

- Documented \`interface.autoSubmitFromUrl\` in \`interface.mdx\`: full section between \`temporaryChatRetention\` and \`customWelcome\`, plus added to the field bullet list at the top.
- Documented \`mcpSettings.allowedAddresses\` in \`mcp_settings.mdx\`: new subkey row on the overview table plus a dedicated section explaining when to use it instead of \`allowedDomains\`, the validation rules (private IP space only, no URLs / paths / CIDR / \`host:port\` / public IPs), and the hostname-trust caveat.
- Documented \`actions.allowedAddresses\` in \`actions.mdx\`: mirrored treatment — overview entry and dedicated section.
- Updated \`config.mdx\`: added subkey rows to the \`actions\`, \`interface\`, \`endpoints\`, and \`mcpSettings\` overview tables; added cross-links into the per-object docs; added a clarifying note on \`endpoints.allowedAddresses\` explaining it applies to user-provided baseURLs (i.e. when an admin configures a custom endpoint with \`apiKey: 'user_provided'\` and \`baseURL: 'user_provided'\`).

## Change Type

- [x] Documentation update

## Testing

- Run the docs site locally with \`bun dev\` and navigate to the four updated pages (\`/docs/configuration/librechat_yaml/object_structure/{config,interface,actions,mcp_settings}\`) to verify the new sections render correctly, the OptionTable rows display, and the cross-link anchors (\`#allowedaddresses\`, \`#autosubmitfromurl\`) resolve.
- Verify the YAML examples are syntactically valid and the surrounding prose flows.

### **Test Configuration**:

- Bun 1.0+
- Local Next.js dev server on \`http://localhost:3333\`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes