### PR TITLE
docs: document configurable Cohere reranker API URL

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
@@ -39,6 +39,7 @@ webSearch:
   jinaApiKey: "${JINA_API_KEY}"
   jinaApiUrl: "${JINA_API_URL}"
   cohereApiKey: "${COHERE_API_KEY}"
+  cohereApiUrl: "${COHERE_API_URL}"
   rerankerType: "jina" # Options: "jina", "cohere", "none"
 
   # General Settings
@@ -416,6 +417,16 @@ webSearch:
 />
 
 **Note:** Get your API key from [Cohere Dashboard](https://dashboard.cohere.com/welcome/login)
+
+### cohereApiUrl
+
+<OptionTable
+  options={[
+    ['cohereApiUrl', 'String', 'Environment variable name for the Cohere API URL. If not set in .env, users will be prompted to provide it via UI.', '${COHERE_API_URL}'],
+  ]}
+/>
+
+**Note:** This is optional and only needed if you're using a Cohere-compatible endpoint such as Azure AI Foundry's serverless deployments. Defaults to `https://api.cohere.com/v2/rerank`.
 
 ### rerankerType
 

--- a/content/docs/features/web_search.mdx
+++ b/content/docs/features/web_search.mdx
@@ -34,6 +34,8 @@ To get started with web search, you'll need to configure API keys for a search p
    JINA_API_URL=your_jina_api_url
    # or
    COHERE_API_KEY=your_cohere_api_key
+   # Optional: Custom Cohere API URL (e.g., Azure AI Foundry serverless deployment)
+   COHERE_API_URL=your_cohere_api_url
    ```
 
 2. **User Interface** (If environment variables are not set):
@@ -134,6 +136,7 @@ Rerankers analyze the scraped content to determine the most relevant parts and r
   - API URL is optional (defaults to Jina's hosted service)
 - **Cohere**: Advanced reranking service
   - Get your API key from [Cohere Dashboard](https://dashboard.cohere.com/welcome/login)
+  - API URL is optional (defaults to Cohere's hosted service; supports Azure AI Foundry serverless Cohere endpoints)
 - **None**: Skips reranking when `rerankerType` is set to `"none"`
 
 **Planned Rerankers:**
@@ -174,9 +177,11 @@ webSearch:
   jinaApiKey: "${CUSTOM_JINA_API_KEY}"
   jinaApiUrl: "${CUSTOM_JINA_API_URL}"
   cohereApiKey: "${CUSTOM_COHERE_API_KEY}"
+  cohereApiUrl: "${CUSTOM_COHERE_API_URL}"
   # jinaApiKey: "jn-123..."                 # ❌ Wrong: Never put actual API keys here
   # jinaApiUrl: "https://..."               # ❌ Wrong: Never put actual URLs here
   # cohereApiKey: "ch-123..."               # ❌ Wrong: Never put actual API keys here
+  # cohereApiUrl: "https://..."             # ❌ Wrong: Never put actual URLs here
 
   # General Settings
   safeSearch: 1 # Options: 0 (OFF), 1 (MODERATE - default), 2 (STRICT)
@@ -208,7 +213,8 @@ If the admin hasn't configured all the necessary API keys, users will be prompte
 2. Enter API keys for the required services
 3. Configure the Firecrawl API URL if needed (optional)
 4. Configure the Jina API URL if needed (optional)
-5. Configure Tavily Search or Extract API URLs if needed (optional)
+5. Configure the Cohere API URL if needed (optional)
+6. Configure Tavily Search or Extract API URLs if needed (optional)
 
 ## Usage
 
@@ -222,6 +228,7 @@ Once configured, you can use web search in two ways:
 - Search provider and scraper configuration are required; reranking can be disabled with `rerankerType: "none"`
 - The Firecrawl API URL is optional and defaults to their hosted service
 - The Jina API URL is optional and defaults to their hosted service
+- The Cohere API URL is optional and defaults to their hosted service
 - The Tavily Search and Extract API URLs are optional and default to Tavily's hosted services
 - Safe search provides three levels of content filtering: OFF (0), MODERATE (1 - default), and STRICT (2)
 - Tavily does not inherit the global `safeSearch` setting by default; use `tavilySearchOptions.safeSearch` only if your Tavily account supports `safe_search`


### PR DESCRIPTION
## Summary

Documentation for https://github.com/danny-avila/LibreChat/pull/12969

This PR adds support for configuring a custom Cohere API URL in the web search configuration, enabling users to use Cohere-compatible endpoints such as Azure AI Foundry's serverless deployments.

## Key Changes
- Added `cohereApiUrl` configuration option to the web search settings in `librechat_yaml`
- Updated documentation to include the new `COHERE_API_URL` environment variable
- Added clarification that the Cohere API URL is optional and defaults to `https://api.cohere.com/v2/rerank`
- Updated configuration examples to show the new `cohereApiUrl` parameter
- Added notes about Azure AI Foundry serverless Cohere endpoint support
- Updated setup instructions to include the optional Cohere API URL configuration step

## Implementation Details
- The `cohereApiUrl` parameter follows the same pattern as the existing `jinaApiUrl` configuration
- It accepts an environment variable reference (e.g., `${COHERE_API_URL}`)
- Users can optionally provide the URL via the UI if not set in environment variables
- The feature is fully backward compatible - existing configurations without this parameter will continue to work with the default Cohere endpoint