### PR TITLE
docs: update Railway deploy link to librechat-official template

### DIFF
--- a/content/docs/remote/railway.mdx
+++ b/content/docs/remote/railway.mdx
@@ -19,7 +19,7 @@ Go to the [LibreChat repository](https://github.com/danny-avila/LibreChat) on Gi
 ### **Click the "Deploy on Railway" button**
 
 <p align="left">
-    <a href="https://railway.com/deploy/b5k2mn?referralCode=HI9hWz&utm_medium=integration&utm_source=docs&utm_campaign=librechat">
+    <a href="https://railway.com/deploy/librechat-official?referralCode=HI9hWz&utm_medium=integration&utm_source=docs&utm_campaign=librechat">
         <img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40"/>
     </a>
 </p>


### PR DESCRIPTION
## Summary
- Update the Railway deploy link in `content/docs/remote/railway.mdx` from the old template ID `b5k2mn` to the new `librechat-official` slug.

## Test plan
- [x] Visit the rendered docs page and confirm the "Deploy on Railway" button resolves to the `librechat-official` template