### PR TITLE
fix: proxy Plausible analytics via first-party paths

### DIFF
--- a/app/cookie/page.tsx
+++ b/app/cookie/page.tsx
@@ -84,6 +84,18 @@ export default function CookiePolicyPage() {
             twenty-four hours and the IP address itself is never written to disk, which means the
             hash cannot be linked across days and cannot be reversed back to a person or a device.
           </p>
+          <p>
+            The Plausible script and its event endpoint are served from first-party paths on this
+            Site &mdash; <code>librechat.ai/js/</code> for the script and{' '}
+            <code>librechat.ai/api/e</code> for event ingestion &mdash; and proxied through a
+            Cloudflare Worker to our self-hosted Plausible instance at{' '}
+            <code>plausible.librechat.ai</code>. Some browser blocklists match on the word
+            &ldquo;plausible&rdquo; in a domain name and will block our self-hosted instance even
+            though it never sends data to a third party; serving the script and endpoint from{' '}
+            <code>librechat.ai</code> avoids this false positive. The proxy performs no additional
+            data collection. If you prefer to opt out, you can block <code>librechat.ai/api/e</code>{' '}
+            in your browser or disable JavaScript on this Site.
+          </p>
 
           <h3>3.2 Core Web Vitals Monitoring</h3>
           <p>
@@ -160,8 +172,9 @@ export default function CookiePolicyPage() {
               tracker-blocking features in your browser.
             </li>
             <li>
-              Installing a content-blocking extension that blocks requests to{' '}
-              <code>plausible.librechat.ai</code> and any performance-monitoring endpoint we
+              Installing a content-blocking extension or browser rule that blocks requests to the
+              first-party analytics paths <code>librechat.ai/js/</code> and{' '}
+              <code>librechat.ai/api/e</code>, as well as any performance-monitoring endpoint we
               configure.
             </li>
             <li>Disabling JavaScript, in which case no analytics or performance data is sent.</li>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -94,7 +94,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Script
           async
           id="plausible-script"
-          src="https://plausible.librechat.ai/js/pa-AxQn4zbc0KTWDDkxjlFGs.js"
+          src="/js/pa-AxQn4zbc0KTWDDkxjlFGs.js"
+          data-api="/api/e"
           strategy="afterInteractive"
         />
         {cwvEnabled && (

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -107,6 +107,19 @@ export default function PrivacyPolicyPage() {
             cannot use them to identify you, contact you, or correlate your visits to this Site with
             your activity on any other site.
           </p>
+          <p>
+            The Plausible script and event requests are served from first-party paths on{' '}
+            <code>librechat.ai</code> &mdash; specifically <code>librechat.ai/js/</code> for the
+            script and <code>librechat.ai/api/e</code> for event ingestion &mdash; and proxied
+            through a Cloudflare Worker that forwards them to our self-hosted Plausible instance at{' '}
+            <code>plausible.librechat.ai</code>. Some browser blocklists match on the word
+            &ldquo;plausible&rdquo; in a domain name and will block this self-hosted instance
+            despite the fact that it never shares data with a third party. Serving the script and
+            endpoint from <code>librechat.ai</code> directly avoids that false positive. No
+            additional data is collected as a result of this proxying; it is purely network-level
+            routing. You can opt out by blocking <code>librechat.ai/api/e</code> in your browser or
+            disabling JavaScript on this Site.
+          </p>
 
           <h3>3.2 Performance Monitoring &mdash; Core Web Vitals</h3>
           <p>
@@ -294,8 +307,9 @@ export default function PrivacyPolicyPage() {
               your browser; we will continue to honor these signals where practical.
             </li>
             <li>
-              Using a content blocker or privacy-focused browser extension to block requests to{' '}
-              <code>plausible.librechat.ai</code> and the performance ingestion endpoint.
+              Using a content blocker, browser rule, or privacy-focused extension to block requests
+              to the first-party analytics paths <code>librechat.ai/js/</code> and{' '}
+              <code>librechat.ai/api/e</code> &mdash; as well as the performance ingestion endpoint.
             </li>
             <li>Disabling JavaScript for this Site, in which case no analytics will be sent.</li>
           </ul>


### PR DESCRIPTION
## Summary
- Load the Plausible script from `/js/pa-…js` and send events to `/api/e` on `librechat.ai`, proxied through a Cloudflare Worker to the self-hosted Plausible instance at `plausible.librechat.ai`. Bypasses ad-blocker false positives that were blocking the third-party script.
- Update the Plausible sections of the privacy and cookie policies to explain the proxy and clarify that the dashboard still lives at `plausible.librechat.ai`.
- Revise the opt-out guidance in both pages to point at the first-party paths (`librechat.ai/js/`, `librechat.ai/api/e`) since the browser no longer contacts `plausible.librechat.ai` directly.

## Test plan
- [x] Load any page on the site and verify `GET /js/pa-AxQn4zbc0KTWDDkxjlFGs.js` returns 200 (proxied)
- [x] Trigger a pageview and verify `POST /api/e` returns 200 and the event lands in the Plausible dashboard
- [x] Confirm uBlock Origin / Brave Shields no longer block the requests
- [x] Spot-check `/privacy` and `/cookie` render correctly with the new wording