### PR TITLE
Fix LibreChat Docker image removal command

### DIFF
--- a/content/docs/local/docker.mdx
+++ b/content/docs/local/docker.mdx
@@ -132,7 +132,7 @@ docker compose down
 
 ```bash filename="Remove all existing docker images"
 # Linux/Mac
-docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
+docker images -a --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -i librechat | awk '{print $1}' | sort -u | xargs -r docker rmi
 
 # Windows (PowerShell)
 docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }


### PR DESCRIPTION
The previous Linux/Mac command parsed Docker’s default human-readable image table and relied on `awk '{print $3}'`. In some Docker CLI outputs, this can pass the image size instead of the image ID to `docker rmi`, causing errors such as `invalid reference format: repository name (library/1.66GB) must be lowercase`.

This updates the command to use Docker’s formatted output and remove matching LibreChat images by image ID.