### PR TITLE
🧭 docs: Add Skills, Subagents, and CloudFront Guides

### DIFF
--- a/content/changelog/config_v1.3.11.mdx
+++ b/content/changelog/config_v1.3.11.mdx
@@ -1,0 +1,19 @@
+---
+date: 2026-05-12
+title: ⚙️ Config v1.3.11
+version: '1.3.11'
+---
+
+- Added CloudFront file storage configuration
+  - Adds `"cloudfront"` as a file storage strategy for stable S3-backed CDN URLs
+  - Adds the root-level `cloudfront` object for distribution domain, signed-cookie mode, signed download URL expiry, cache invalidation, and region-aware object paths
+  - Supports signed cookies for inline image/avatar access and signed CloudFront URLs for authorized downloads
+  - See [CloudFront with S3](/docs/configuration/cdn/cloudfront) and [CloudFront Object Structure](/docs/configuration/librechat_yaml/object_structure/cloudfront)
+
+- Added Skills and Subagents to the documented default agent capabilities
+  - `skills` enables manual `$` invocation, model-invoked skills, always-apply skills, and agent skill allowlists
+  - `subagents` enables isolated child agent runs from the parent agent
+  - See [Skills](/docs/features/skills) and [Subagents](/docs/features/subagents)
+
+- Added `skills` to granular file storage strategies
+  - Allows skill-bundled files to use a dedicated storage backend

--- a/content/changelog/v0.8.6-rc1.mdx
+++ b/content/changelog/v0.8.6-rc1.mdx
@@ -9,9 +9,12 @@ version: '0.8.6-rc1'
 
 ### 🏞️ Highlights
 
-- **Agent Skills & Subagents**
-  - Agent Skills introduce reusable `SKILL.md` workflows that package instructions, bundled files, and tool access into shareable capabilities with invocation modes, import limits, and ACL sharing.
-  - Subagents let agents run other agents as tools, including self-calling for parallel work, while preserving upload/MCP context and bounding recursive expansion.
+- **Agent Skills**
+  - Agent Skills let you package reusable agent behavior into `SKILL.md` bundles: instructions, reference files, scripts, assets, and tool permissions can travel together as a capability an agent can invoke automatically, on request, or always-on.
+  - Skills can be imported, size-limited, shared through ACLs, and scoped per agent, making it easier to build repeatable workflows without baking every instruction into the agent prompt.
+- **Subagents**
+  - Subagents let agents call other agents as tools, so a primary agent can delegate specialized work, run independent passes in parallel, or even call a configured copy of itself for fan-out style problem solving.
+  - Subagent runs preserve the surrounding upload, user, and MCP context while enforcing recursion and graph limits, which keeps multi-agent execution powerful without making it unbounded.
 - **Code Execution & Artifacts**
   - Text, source-code, DOCX, CSV, XLSX, and PPTX artifacts can render inline or in the side panel with richer previews.
   - Nested artifact paths, Unicode filenames, file metadata encoding, and generated-code context filtering received several hardening passes.

--- a/content/changelog/v0.8.6-rc1.mdx
+++ b/content/changelog/v0.8.6-rc1.mdx
@@ -10,8 +10,8 @@ version: '0.8.6-rc1'
 ### 🏞️ Highlights
 
 - **Agent Skills & Subagents**
-  - Agent Skills introduce reusable `SKILL.md` workflows, invocation modes, import limits, and share-role enforcement.
-  - Subagents gain safer expansion limits, MCP/user-context propagation, resend-file preservation, clearer dialogs, and better limit logging.
+  - Agent Skills introduce reusable `SKILL.md` workflows that package instructions, bundled files, and tool access into shareable capabilities with invocation modes, import limits, and ACL sharing.
+  - Subagents let agents run other agents as tools, including self-calling for parallel work, while preserving upload/MCP context and bounding recursive expansion.
 - **Code Execution & Artifacts**
   - Text, source-code, DOCX, CSV, XLSX, and PPTX artifacts can render inline or in the side panel with richer previews.
   - Nested artifact paths, Unicode filenames, file metadata encoding, and generated-code context filtering received several hardening passes.

--- a/content/changelog/v0.8.6-rc1.mdx
+++ b/content/changelog/v0.8.6-rc1.mdx
@@ -1,0 +1,173 @@
+---
+date: 2026-05-13
+title: 🚀 LibreChat v0.8.6-rc1
+description: The v0.8.6-rc1 release of LibreChat
+version: '0.8.6-rc1'
+---
+
+## What's Changed
+
+### 🏞️ Highlights
+
+- **Agent Skills & Subagents**
+  - Agent Skills introduce reusable `SKILL.md` workflows, invocation modes, import limits, and share-role enforcement.
+  - Subagents gain safer expansion limits, MCP/user-context propagation, resend-file preservation, clearer dialogs, and better limit logging.
+- **Code Execution & Artifacts**
+  - Text, source-code, DOCX, CSV, XLSX, and PPTX artifacts can render inline or in the side panel with richer previews.
+  - Nested artifact paths, Unicode filenames, file metadata encoding, and generated-code context filtering received several hardening passes.
+- **CloudFront + S3 File Delivery**
+  - New CloudFront file strategy support includes signed cookies, signed downloads, strict signed-access enforcement, region-aware storage keys, and cookie refresh on auth refresh.
+- **Security, Auth, and MCP Hardening**
+  - MCP OAuth, OpenID/OIDC, SSRF checks, artifact routing, permission caching, avatar fetching, and HTML rendering were tightened across the stack.
+- **Providers, Search, and Model Support**
+  - Tavily search/scraping, OpenRouter prompt-cache configuration, Vertex AI multi-region endpoints, Anthropic tool-argument streaming, and GPT-5.5 token definitions are now supported.
+
+---
+
+### ✨ Features
+
+- feat: agent skills by [@danny-avila](https://github.com/danny-avila) in [#12625](https://github.com/danny-avila/LibreChat/pull/12625)
+- 📄 Auto-render Text-Based Code Execution Artifacts Inline by [@danny-avila](https://github.com/danny-avila) in [#12829](https://github.com/danny-avila/LibreChat/pull/12829)
+- 🪢 Enable Tool-Output References for Bash Tool by [@danny-avila](https://github.com/danny-avila) in [#12830](https://github.com/danny-avila/LibreChat/pull/12830)
+- 🪟 Render Code-Execution Text Artifacts as Side-Panel Artifacts by [@danny-avila](https://github.com/danny-avila) in [#12832](https://github.com/danny-avila/LibreChat/pull/12832)
+- 🪟 Render Source-Code Artifacts in the Side Panel by [@danny-avila](https://github.com/danny-avila) in [#12854](https://github.com/danny-avila/LibreChat/pull/12854)
+- 🚫 Add Support for `none` Reranker Type in Web Search Config by [@dlew](https://github.com/dlew) in [#12765](https://github.com/danny-avila/LibreChat/pull/12765)
+- 💭 Require Explicit Auto-agent Enablement for Memories by [@danny-avila](https://github.com/danny-avila) in [#12886](https://github.com/danny-avila/LibreChat/pull/12886)
+- 🪟 Add allowedAddresses Exemption List For SSRF-Guarded Targets by [@danny-avila](https://github.com/danny-avila) in [#12933](https://github.com/danny-avila/LibreChat/pull/12933)
+- 🔍 Add Tavily as Search and Scraper Provider by [@yashwanth-alapati](https://github.com/yashwanth-alapati) in [#12581](https://github.com/danny-avila/LibreChat/pull/12581)
+- 🔐 OIDC Bearer Token Authentication for Remote Agent API by [@SpectralOne](https://github.com/SpectralOne) in [#12450](https://github.com/danny-avila/LibreChat/pull/12450)
+- 📄 Rich File Artifact Previews for DOCX, CSV, XLSX, PPTX by [@danny-avila](https://github.com/danny-avila) in [#12934](https://github.com/danny-avila/LibreChat/pull/12934)
+- 🌩️ CloudFront CDN File Strategy by [@AtefBellaaj](https://github.com/AtefBellaaj) in [#12193](https://github.com/danny-avila/LibreChat/pull/12193)
+- 🧵 Enable Anthropic Tool Argument Streaming by [@danny-avila](https://github.com/danny-avila) in [#12962](https://github.com/danny-avila/LibreChat/pull/12962)
+- 🚀 Decouple File Attachment Persistence from Preview Rendering by [@danny-avila](https://github.com/danny-avila) in [#12957](https://github.com/danny-avila/LibreChat/pull/12957)
+- 🧮 Add GPT-5.5 Token Definitions by [@danny-avila](https://github.com/danny-avila) in [#12973](https://github.com/danny-avila/LibreChat/pull/12973)
+- 🧭 Add Message Navigation Strip & Redesign Scroll-to-Bottom by [@berry-13](https://github.com/berry-13) in [#12657](https://github.com/danny-avila/LibreChat/pull/12657)
+- 🔐 Add Signed CloudFront File Downloads by [@danny-avila](https://github.com/danny-avila) in [#12970](https://github.com/danny-avila/LibreChat/pull/12970)
+- 🌥️ Add Optional Region-aware S3/CloudFront Storage Keys by [@danny-avila](https://github.com/danny-avila) in [#12987](https://github.com/danny-avila/LibreChat/pull/12987)
+- 🔄 Cross-Origin Admin OAuth Refresh by [@dustinhealy](https://github.com/dustinhealy) in [#13007](https://github.com/danny-avila/LibreChat/pull/13007)
+- 🧭 Add OpenRouter Prompt Cache Setting by [@danny-avila](https://github.com/danny-avila) in [#13029](https://github.com/danny-avila/LibreChat/pull/13029)
+- 🔐 Mint Code API Auth Tokens by [@danny-avila](https://github.com/danny-avila) in [#13028](https://github.com/danny-avila/LibreChat/pull/13028)
+- 🌐 Support Vertex AI Multi-Region Endpoints by [@danny-avila](https://github.com/danny-avila) in [#13044](https://github.com/danny-avila/LibreChat/pull/13044)
+- 📦 Configure Skill Import Size Limit by [@danny-avila](https://github.com/danny-avila) in [#13073](https://github.com/danny-avila/LibreChat/pull/13073)
+- 🎭 Support OpenID Audience On Refresh Grants by [@danny-avila](https://github.com/danny-avila) in [#13077](https://github.com/danny-avila/LibreChat/pull/13077)
+- 🌩️ Strict CloudFront signed cookie enforcement via `requireSignedAccess` by [@upman](https://github.com/upman) in [#13078](https://github.com/danny-avila/LibreChat/pull/13078)
+
+### 🐛 Fixes
+
+- 🔐 Restore Tenant Context in MCP OAuth Callback by [@dustinhealy](https://github.com/dustinhealy) in [#12782](https://github.com/danny-avila/LibreChat/pull/12782)
+- 🗨️ Restore ModelSpec Preset Greeting (and iconURL Fallback) by [@danny-avila](https://github.com/danny-avila) in [#12809](https://github.com/danny-avila/LibreChat/pull/12809)
+- 🛡️ Prevent silent crash from unhandled MCP OAuth reconnect rejections by [@danny-avila](https://github.com/danny-avila) in [#12812](https://github.com/danny-avila/LibreChat/pull/12812)
+- 🌱 Inject Code-Tool Files Into Graph Sessions on First Call (+ read_file Sandbox Fallback) by [@danny-avila](https://github.com/danny-avila) in [#12831](https://github.com/danny-avila/LibreChat/pull/12831)
+- 🚫 Reject Binary Files in read_file Sandbox Fallback (No More Mojibake) by [@danny-avila](https://github.com/danny-avila) in [#12851](https://github.com/danny-avila/LibreChat/pull/12851)
+- 🔧 Replace Literal NUL Bytes in handlers.spec Test Fixture + Normalize CRLF by [@danny-avila](https://github.com/danny-avila) in [#12852](https://github.com/danny-avila/LibreChat/pull/12852)
+- 📂 Preserve Nested Folder Paths for Code-Execution Artifacts by [@danny-avila](https://github.com/danny-avila) in [#12848](https://github.com/danny-avila/LibreChat/pull/12848)
+- 🛂 Skip Inherited / Mark Skill Files Read-Only in Code-Env Pipeline by [@danny-avila](https://github.com/danny-avila) in [#12866](https://github.com/danny-avila/LibreChat/pull/12866)
+- 💎 Stop Double-Counting Cache Tokens for Gemini/OpenAI in Usage Spend by [@danny-avila](https://github.com/danny-avila) in [#12868](https://github.com/danny-avila/LibreChat/pull/12868)
+- 🛡️ Filter `user_provided` Sentinel in Tool Credential Loading by [@Falenos](https://github.com/Falenos) in [#12840](https://github.com/danny-avila/LibreChat/pull/12840)
+- 🧹 Graceful MCP OAuth Revoke Cleanup When Tokens Are Missing by [@gaurav0107](https://github.com/gaurav0107) in [#12825](https://github.com/danny-avila/LibreChat/pull/12825)
+- 🔌 Prevent Repeated Idle Check Triggers for Users With Failed MCP Connections by [@darthhexx](https://github.com/darthhexx) in [#12853](https://github.com/danny-avila/LibreChat/pull/12853)
+- 🧜‍♂️ Preserve Mermaid `foreignObject` HTML in Sanitized SVG by [@ethanlaj](https://github.com/ethanlaj) in [#12819](https://github.com/danny-avila/LibreChat/pull/12819)
+- 🩹 Treat `responseCode === 0` as Transport Failure, Not Server Error by [@derhelge](https://github.com/derhelge) in [#12834](https://github.com/danny-avila/LibreChat/pull/12834)
+- 📂 Preserve Nested Skill Paths in Code-Env Uploads by [@danny-avila](https://github.com/danny-avila) in [#12877](https://github.com/danny-avila/LibreChat/pull/12877)
+- 🩹 Polish code-execution attachment UX by [@danny-avila](https://github.com/danny-avila) in [#12870](https://github.com/danny-avila/LibreChat/pull/12870)
+- 🔌 Follow 307/308 redirects in MCP streamable HTTP transport by [@ontl](https://github.com/ontl) in [#12850](https://github.com/danny-avila/LibreChat/pull/12850)
+- 📥 Resolve Imported-Conversation Default Model From Runtime modelsConfig by [@danny-avila](https://github.com/danny-avila) in [#12885](https://github.com/danny-avila/LibreChat/pull/12885)
+- 🩹 Sync ControlCombobox popover width with trigger after layout changes by [@ethanlaj](https://github.com/ethanlaj) in [#12887](https://github.com/danny-avila/LibreChat/pull/12887)
+- 🛡️ Handle MCP Tool Cache Lookup Failures by [@danny-avila](https://github.com/danny-avila) in [#12910](https://github.com/danny-avila/LibreChat/pull/12910)
+- 📌 Stabilize Agent Prompt Cache Prefix by [@danny-avila](https://github.com/danny-avila) in [#12907](https://github.com/danny-avila/LibreChat/pull/12907)
+- 🧭 Migrate Anthropic Long Context by [@danny-avila](https://github.com/danny-avila) in [#12911](https://github.com/danny-avila/LibreChat/pull/12911)
+- 🧹 Clear MCP OAuth Tokens On Revoke by [@danny-avila](https://github.com/danny-avila) in [#12913](https://github.com/danny-avila/LibreChat/pull/12913)
+- 🛡️ Harden GitNexus Index Workflow by [@danny-avila](https://github.com/danny-avila) in [#12935](https://github.com/danny-avila/LibreChat/pull/12935)
+- 🧷 Pin GitNexus Native Dependency by [@danny-avila](https://github.com/danny-avila) in [#12937](https://github.com/danny-avila/LibreChat/pull/12937)
+- 🛡️ Harden MCP Redirect SSRF Checks by [@danny-avila](https://github.com/danny-avila) in [#12931](https://github.com/danny-avila/LibreChat/pull/12931)
+- 🧯 Harden Code Env Filepath Uploads by [@danny-avila](https://github.com/danny-avila) in [#12936](https://github.com/danny-avila/LibreChat/pull/12936)
+- 🔐 Avoid Logging Password On Login Validation Error by [@danny-avila](https://github.com/danny-avila) in [#12926](https://github.com/danny-avila/LibreChat/pull/12926)
+- 🪪 Validate Avatar URL Before Fetch by [@danny-avila](https://github.com/danny-avila) in [#12928](https://github.com/danny-avila/LibreChat/pull/12928)
+- 🚦 Make URL Auto-Submit Configurable by [@danny-avila](https://github.com/danny-avila) in [#12929](https://github.com/danny-avila/LibreChat/pull/12929)
+- 🧼 Sanitize HTML In Admin Banner And MCP Config Dialog by [@danny-avila](https://github.com/danny-avila) in [#12927](https://github.com/danny-avila/LibreChat/pull/12927)
+- 🐛 Propagate User Identity to Subagent MCP Tool Calls by [@danny-avila](https://github.com/danny-avila) in [#12950](https://github.com/danny-avila/LibreChat/pull/12950)
+- 🔐 Forward per-file entity_id through code-env priming by [@danny-avila](https://github.com/danny-avila) in [#12958](https://github.com/danny-avila/LibreChat/pull/12958)
+- 🧬 Subagent MCP requestBody Propagation (bump `@librechat/agents to 3.1.78` + cleanup) by [@danny-avila](https://github.com/danny-avila) in [#12959](https://github.com/danny-avila/LibreChat/pull/12959)
+- 🛰️ Honor Anthropic Vertex Configuration by [@danny-avila](https://github.com/danny-avila) in [#12972](https://github.com/danny-avila/LibreChat/pull/12972)
+- 🌐 Preserve Unicode Filenames by [@danny-avila](https://github.com/danny-avila) in [#12977](https://github.com/danny-avila/LibreChat/pull/12977)
+- ⏳ Preserve Temporary Chat Retention Config by [@danny-avila](https://github.com/danny-avila) in [#12985](https://github.com/danny-avila/LibreChat/pull/12985)
+- 🛂 Harden Agent File Preview Access by [@danny-avila](https://github.com/danny-avila) in [#12981](https://github.com/danny-avila/LibreChat/pull/12981)
+- 🌐 Percent-encode X-File-Metadata header for Unicode filenames by [@usnavy13](https://github.com/usnavy13) in [#12983](https://github.com/danny-avila/LibreChat/pull/12983)
+- ⏱️ Align Auto-Refill Next Date by [@danny-avila](https://github.com/danny-avila) in [#12980](https://github.com/danny-avila/LibreChat/pull/12980)
+- 🧭 Navigate Signed CDN Downloads by [@danny-avila](https://github.com/danny-avila) in [#12998](https://github.com/danny-avila/LibreChat/pull/12998)
+- 🪪 Preserve OIDC Logout ID Token Hint by [@danny-avila](https://github.com/danny-avila) in [#12999](https://github.com/danny-avila/LibreChat/pull/12999)
+- 🧭 Preserve Resend Files for Subagents by [@danny-avila](https://github.com/danny-avila) in [#13030](https://github.com/danny-avila/LibreChat/pull/13030)
+- 🛟 Persist Vertex Gemini 3 thoughtSignatures across DB round-trips by [@danny-avila](https://github.com/danny-avila) in [#13026](https://github.com/danny-avila/LibreChat/pull/13026)
+- 🛟 Summarization Provider misses `vertexai` + case-mismatched custom endpoints by [@danny-avila](https://github.com/danny-avila) in [#13025](https://github.com/danny-avila/LibreChat/pull/13025)
+- 🗂️ Remove Generated Code Files From Prompt Context by [@danny-avila](https://github.com/danny-avila) in [#13037](https://github.com/danny-avila/LibreChat/pull/13037)
+- 🛟 Allow Empty `modelSpecs.list` to Unstick Admin-Panel Saves by [@dustinhealy](https://github.com/dustinhealy) in [#13036](https://github.com/danny-avila/LibreChat/pull/13036)
+- 📜 Scope Read File Prompt For Code Agents by [@danny-avila](https://github.com/danny-avila) in [#13040](https://github.com/danny-avila/LibreChat/pull/13040)
+- 🦘 Skip OpenAI Model Fetch For User-Provided Keys by [@danny-avila](https://github.com/danny-avila) in [#13038](https://github.com/danny-avila/LibreChat/pull/13038)
+- ☁️ Enable Azure Agent Provider Uploads by [@danny-avila](https://github.com/danny-avila) in [#13045](https://github.com/danny-avila/LibreChat/pull/13045)
+- 🛡️ Gate Bash PTC Capabilities by [@danny-avila](https://github.com/danny-avila) in [#13053](https://github.com/danny-avila/LibreChat/pull/13053)
+- 🛰️ Validate Vertex Endpoint Overrides by [@danny-avila](https://github.com/danny-avila) in [#13054](https://github.com/danny-avila/LibreChat/pull/13054)
+- 🛂 Restrict OpenID JWT Bearer Reuse by [@danny-avila](https://github.com/danny-avila) in [#13052](https://github.com/danny-avila/LibreChat/pull/13052)
+- 🧯 Bound Permission Superset Cache Inputs by [@danny-avila](https://github.com/danny-avila) in [#13065](https://github.com/danny-avila/LibreChat/pull/13065)
+- 🧮 Count Rejected Skill Import Bytes by [@danny-avila](https://github.com/danny-avila) in [#13063](https://github.com/danny-avila/LibreChat/pull/13063)
+- 🧬 Bound Subagent Expansion by [@danny-avila](https://github.com/danny-avila) in [#13064](https://github.com/danny-avila/LibreChat/pull/13064)
+- 🗝️ Enforce Skill Share Role Permission by [@danny-avila](https://github.com/danny-avila) in [#13062](https://github.com/danny-avila/LibreChat/pull/13062)
+- 🪙 Pass appConfig to getBalanceConfig in set-balance script by [@Odrec](https://github.com/Odrec) in [#13070](https://github.com/danny-avila/LibreChat/pull/13070)
+- 🛡️ Harden Artifact Routing Lookups by [@danny-avila](https://github.com/danny-avila) in [#13069](https://github.com/danny-avila/LibreChat/pull/13069)
+- 🧵 Preserve Upload Context Across Multipart Routes by [@danny-avila](https://github.com/danny-avila) in [#13072](https://github.com/danny-avila/LibreChat/pull/13072)
+- 🍪 Refresh CloudFront Cookies On Auth Refresh by [@danny-avila](https://github.com/danny-avila) in [#13083](https://github.com/danny-avila/LibreChat/pull/13083)
+- 🛡️ Harden OpenID Session Token Reuse by [@danny-avila](https://github.com/danny-avila) in [#13086](https://github.com/danny-avila/LibreChat/pull/13086)
+
+### 🔧 Refactoring
+
+- 🧬 Align LibreChat With Agents LangChain Upgrade by [@danny-avila](https://github.com/danny-avila) in [#12922](https://github.com/danny-avila/LibreChat/pull/12922)
+- 🛂 Avoid Default Tavily Safe Search by [@danny-avila](https://github.com/danny-avila) in [#12939](https://github.com/danny-avila/LibreChat/pull/12939)
+- 🛡️ Restrict User Tavily Endpoint URLs by [@danny-avila](https://github.com/danny-avila) in [#12946](https://github.com/danny-avila/LibreChat/pull/12946)
+- ⚡ Bound Concurrent Office-HTML Rendering for Code Artifacts by [@danny-avila](https://github.com/danny-avila) in [#12951](https://github.com/danny-avila/LibreChat/pull/12951)
+- 🗃️ Keep Code Artifacts Manual-Open by [@danny-avila](https://github.com/danny-avila) in [#12961](https://github.com/danny-avila/LibreChat/pull/12961)
+- ⌨️ Clarify Bash Command Drafting State by [@danny-avila](https://github.com/danny-avila) in [#12963](https://github.com/danny-avila/LibreChat/pull/12963)
+- 🪟 Improve Subagent Dialog Prompt Rendering by [@danny-avila](https://github.com/danny-avila) in [#12982](https://github.com/danny-avila/LibreChat/pull/12982)
+- 🛡️ Scope `allowedAddresses` By Port by [@danny-avila](https://github.com/danny-avila) in [#13022](https://github.com/danny-avila/LibreChat/pull/13022)
+- 🧰 Use Bash PTC for Agent Tools by [@danny-avila](https://github.com/danny-avila) in [#13042](https://github.com/danny-avila/LibreChat/pull/13042)
+- 🧬 Align OpenRouter Reasoning Payloads by [@danny-avila](https://github.com/danny-avila) in [#13039](https://github.com/danny-avila/LibreChat/pull/13039)
+- 🪪 Require Remote OIDC Audience by [@danny-avila](https://github.com/danny-avila) in [#13066](https://github.com/danny-avila/LibreChat/pull/13066)
+- 🏷️ Rename Code Interpreter Labels To Run Code by [@danny-avila](https://github.com/danny-avila) in [#13071](https://github.com/danny-avila/LibreChat/pull/13071)
+- 🍪 Refresh CloudFront Media Cookies by [@danny-avila](https://github.com/danny-avila) in [#13091](https://github.com/danny-avila/LibreChat/pull/13091)
+
+### 🖥️ UI & Styling
+
+- 🖥️ Render Bash PTC Calls With Bash UI by [@danny-avila](https://github.com/danny-avila) in [#13046](https://github.com/danny-avila/LibreChat/pull/13046)
+
+### 📦 Dependencies, Chores & CI
+
+- 📦 Update TypeScript Config for TS v7 by [@danny-avila](https://github.com/danny-avila) in [#12794](https://github.com/danny-avila/LibreChat/pull/12794)
+- 🛡️ Bump `@xmldom/xmldom` to 0.8.13 via Root Override by [@danny-avila](https://github.com/danny-avila) in [#12795](https://github.com/danny-avila/LibreChat/pull/12795)
+- 📦 Update `@librechat/agents` to v3.1.74 by [@danny-avila](https://github.com/danny-avila) in [#12869](https://github.com/danny-avila/LibreChat/pull/12869)
+- 📦 npm audit fixes and Mongoose 8.23 TypeScript follow-ups by [@danny-avila](https://github.com/danny-avila) in [#12996](https://github.com/danny-avila/LibreChat/pull/12996)
+- 📦 Update `@librechat/agents` to v3.1.79 by [@danny-avila](https://github.com/danny-avila) in [#13000](https://github.com/danny-avila/LibreChat/pull/13000)
+- ⛴️ Use Bitnami Legacy MongoDB Image in Helm Chart by [@vdittgen](https://github.com/vdittgen) in [#13032](https://github.com/danny-avila/LibreChat/pull/13032)
+- 📦 Bump `@babel/preset-env` to v7.29.5 by [@danny-avila](https://github.com/danny-avila) in [#13034](https://github.com/danny-avila/LibreChat/pull/13034)
+- 🛡️ Harden Docker Dev Image Builds by [@danny-avila](https://github.com/danny-avila) in [#13041](https://github.com/danny-avila/LibreChat/pull/13041)
+- 📜 Improve Skill Handling Logs by [@danny-avila](https://github.com/danny-avila) in [#13057](https://github.com/danny-avila/LibreChat/pull/13057)
+- 🪵 Log Subagent Limit Hits by [@danny-avila](https://github.com/danny-avila) in [#13068](https://github.com/danny-avila/LibreChat/pull/13068)
+- 📦 Bump `@librechat/agents` to v3.1.85 and `mermaid` to v11.15.0 by [@danny-avila](https://github.com/danny-avila) in [#13079](https://github.com/danny-avila/LibreChat/pull/13079)
+- 🐳 Build Docker Client Package With Data Provider Dist by [@danny-avila](https://github.com/danny-avila) in [#13097](https://github.com/danny-avila/LibreChat/pull/13097)
+- 📦 Bump `@librechat/agents` to v3.1.86, npm audit, build fix by [@danny-avila](https://github.com/danny-avila) in [#13105](https://github.com/danny-avila/LibreChat/pull/13105)
+- ✨ v0.8.6-rc1 by [@danny-avila](https://github.com/danny-avila) in [#13094](https://github.com/danny-avila/LibreChat/pull/13094)
+
+### 📚 Documentation
+
+- 📚 Add Skills, Subagents, and CloudFront References by [@danny-avila](https://github.com/danny-avila) in [#13096](https://github.com/danny-avila/LibreChat/pull/13096)
+
+### 🌍 Internationalization
+
+- 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#12916](https://github.com/danny-avila/LibreChat/pull/12916), [#12964](https://github.com/danny-avila/LibreChat/pull/12964), [#13058](https://github.com/danny-avila/LibreChat/pull/13058), [#13080](https://github.com/danny-avila/LibreChat/pull/13080)
+
+## New Contributors
+
+- [@Falenos](https://github.com/Falenos) made their first contribution in [#12840](https://github.com/danny-avila/LibreChat/pull/12840)
+- [@gaurav0107](https://github.com/gaurav0107) made their first contribution in [#12825](https://github.com/danny-avila/LibreChat/pull/12825)
+- [@ontl](https://github.com/ontl) made their first contribution in [#12850](https://github.com/danny-avila/LibreChat/pull/12850)
+- [@yashwanth-alapati](https://github.com/yashwanth-alapati) made their first contribution in [#12581](https://github.com/danny-avila/LibreChat/pull/12581)
+- [@vdittgen](https://github.com/vdittgen) made their first contribution in [#13032](https://github.com/danny-avila/LibreChat/pull/13032)
+
+**Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.8.5...v0.8.6-rc1

--- a/content/docs/configuration/cdn/cloudfront.mdx
+++ b/content/docs/configuration/cdn/cloudfront.mdx
@@ -1,0 +1,274 @@
+---
+title: CloudFront with S3
+icon: Cloud
+description: Configure Amazon CloudFront as the CDN layer for LibreChat files stored in S3, including stable media links, signed cookies, and signed download URLs.
+---
+
+CloudFront lets LibreChat keep files in S3 while serving images, avatars, and downloads through stable CDN URLs. This is the recommended AWS setup when you want S3 durability without exposing users to expiring S3 presigned image URLs.
+
+## When to Use CloudFront
+
+Use CloudFront when you want:
+
+- Stable avatar and image URLs that keep rendering across the UI
+- Global edge caching in front of an S3 bucket
+- Signed cookies for private inline images and avatars
+- Backend-authorized signed URLs for downloads
+- Optional cache invalidation when files are deleted
+
+<Callout type="info" title="S3 is still required">
+  The `cloudfront` file strategy stores objects in S3 and returns CloudFront URLs. Configure the S3
+  environment variables first, then add the `cloudfront` block in `librechat.yaml`.
+</Callout>
+
+## Requirements
+
+- A private S3 bucket
+- A CloudFront distribution with the S3 bucket as an origin
+- An Origin Access Control (OAC) or equivalent origin access policy so CloudFront can read from S3
+- `AWS_REGION` and `AWS_BUCKET_NAME`
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, unless your deployment uses an AWS identity provider such as IRSA
+- `CLOUDFRONT_KEY_PAIR_ID` and `CLOUDFRONT_PRIVATE_KEY` when using signed cookies or signed download URLs
+
+## Environment Variables
+
+```bash filename=".env"
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+AWS_REGION=us-east-1
+AWS_BUCKET_NAME=your_bucket_name
+
+# Required for signed cookies and signed CloudFront download URLs
+CLOUDFRONT_KEY_PAIR_ID=K1234567890ABC
+CLOUDFRONT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+```
+
+`CLOUDFRONT_PRIVATE_KEY` must contain the full PEM private key. In `.env`, quote it and preserve newlines, or inject it from your platform secret manager.
+
+## Basic Configuration
+
+Use `fileStrategies` when you want CloudFront for images and avatars while keeping documents on S3 signed URLs:
+
+```yaml filename="librechat.yaml"
+version: 1.3.11
+
+fileStrategies:
+  avatar: 'cloudfront'
+  image: 'cloudfront'
+  document: 's3'
+
+cloudfront:
+  domain: 'https://cdn.example.com'
+  imageSigning: 'none'
+  urlExpiry: 3600
+```
+
+Use `fileStrategy` if every file type should use CloudFront:
+
+```yaml filename="librechat.yaml"
+fileStrategy: 'cloudfront'
+
+cloudfront:
+  domain: 'https://cdn.example.com'
+```
+
+## Signed Cookies
+
+Signed cookies are the secure mode for private inline images and avatars. They let LibreChat keep stable CloudFront URLs in messages and records while authorizing access with short-lived cookies.
+
+```yaml filename="librechat.yaml"
+fileStrategies:
+  avatar: 'cloudfront'
+  image: 'cloudfront'
+  document: 's3'
+
+cloudfront:
+  domain: 'https://cdn.example.com'
+  imageSigning: 'cookies'
+  cookieDomain: '.example.com'
+  cookieExpiry: 1800
+  urlExpiry: 3600
+  requireSignedAccess: true
+```
+
+### Domain Requirements
+
+For signed cookies, the LibreChat API and CloudFront hostname must share a parent domain:
+
+- API: `https://api.example.com`
+- CloudFront CNAME: `https://cdn.example.com`
+- `cookieDomain: ".example.com"`
+
+`cookieDomain` must start with a dot. The browser will not send CloudFront cookies to an unrelated domain.
+
+### What Cookies Protect
+
+LibreChat scopes signed cookies to inline media paths:
+
+- `/i/...` private uploaded or generated images, scoped to the user
+- `/a/...` avatar assets, scoped to the tenant when `tenantId` is present
+
+Documents, general uploads, and code outputs stay outside those inline media paths. Downloads are authorized by the backend and returned as signed CloudFront URLs.
+
+### Cookie Refresh
+
+When signed-cookie mode is active, LibreChat advertises a cookie refresh endpoint in startup config:
+
+```text
+POST /api/auth/cloudfront/refresh
+```
+
+Authenticated sessions refresh cookies during auth flows, token refresh, and CloudFront image retry paths. The refresh response includes the cookie lifetime and the recommended refresh timing.
+
+## Signed Downloads
+
+LibreChat uses signed CloudFront URLs for authorized downloads. The `urlExpiry` setting controls their lifetime in seconds:
+
+```yaml filename="librechat.yaml"
+cloudfront:
+  domain: 'https://cdn.example.com'
+  imageSigning: 'cookies'
+  cookieDomain: '.example.com'
+  urlExpiry: 3600
+```
+
+For direct-download filename and content-type overrides, configure the CloudFront cache/origin request policy to forward these query strings to S3:
+
+- `response-content-disposition`
+- `response-content-type`
+
+For download paths, attach a response headers policy with:
+
+- `X-Content-Type-Options: nosniff`
+- A restrictive Content Security Policy, such as `default-src 'none'`
+
+## Cache Invalidation
+
+By default, LibreChat deletes the S3 object and does not create a CloudFront invalidation. Enable invalidation when deleted files must disappear from edge cache immediately:
+
+```yaml filename="librechat.yaml"
+cloudfront:
+  domain: 'https://cdn.example.com'
+  distributionId: 'E1234ABCD'
+  invalidateOnDelete: true
+```
+
+`distributionId` is required when `invalidateOnDelete` is `true`. The AWS identity used by LibreChat also needs `cloudfront:CreateInvalidation`.
+
+## Multi-Region Object Paths
+
+`includeRegionInPath` adds the storage region to newly generated object keys:
+
+```yaml filename="librechat.yaml"
+cloudfront:
+  domain: 'https://cdn.example.com'
+  storageRegion: 'us-east-2'
+  includeRegionInPath: true
+```
+
+When enabled, new keys include region-aware path segments, for example:
+
+```text
+/i/r/us-east-2/t/tenantId/images/userId/file.png
+/a/r/us-east-2/t/tenantId/avatars/userId/avatar.png
+/r/us-east-2/t/tenantId/images/userId/file.pdf
+```
+
+This only affects newly generated keys. Existing files are not moved. LibreChat does not configure CloudFront origins, Route 53, or regional routing for you.
+
+## CloudFront Block Reference
+
+<OptionTable
+  options={[
+    [
+      'domain',
+      'string',
+      'CloudFront distribution domain or CNAME. Required.',
+      'domain: "https://cdn.example.com"',
+    ],
+    [
+      'distributionId',
+      'string',
+      'Distribution ID used for cache invalidations.',
+      'distributionId: "E1234ABCD"',
+    ],
+    [
+      'invalidateOnDelete',
+      'boolean',
+      'Create a CloudFront invalidation when a file is deleted. Default: false.',
+      'invalidateOnDelete: false',
+    ],
+    [
+      'imageSigning',
+      'string',
+      'Inline media access mode. Use `"none"` for public CloudFront access or `"cookies"` for signed cookies. `"url"` is reserved and not implemented for images.',
+      'imageSigning: "cookies"',
+    ],
+    [
+      'cookieDomain',
+      'string',
+      'Shared parent domain for signed cookies. Required when `imageSigning` is `"cookies"`.',
+      'cookieDomain: ".example.com"',
+    ],
+    [
+      'cookieExpiry',
+      'number',
+      'Signed cookie lifetime in seconds. Default: 1800. Maximum: 604800.',
+      'cookieExpiry: 1800',
+    ],
+    [
+      'urlExpiry',
+      'number',
+      'Signed download URL lifetime in seconds. Default: 3600.',
+      'urlExpiry: 3600',
+    ],
+    [
+      'storageRegion',
+      'string',
+      'Optional region label for region-aware object paths.',
+      'storageRegion: "us-east-2"',
+    ],
+    [
+      'includeRegionInPath',
+      'boolean',
+      'Include `storageRegion` in newly generated object keys. Default: false.',
+      'includeRegionInPath: false',
+    ],
+    [
+      'requireSignedAccess',
+      'boolean',
+      'Fail startup if signed-cookie CloudFront access cannot initialize. Default: false.',
+      'requireSignedAccess: true',
+    ],
+  ]}
+/>
+
+## Suggested AWS Permissions
+
+Use least-privilege IAM permissions for the S3 bucket. Add CloudFront invalidation permission only if `invalidateOnDelete` is enabled.
+
+```json filename="iam-policy.json"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::my-librechat-bucket", "arn:aws:s3:::my-librechat-bucket/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": "arn:aws:cloudfront::123456789012:distribution/E1234ABCD"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+- Startup logs `CloudFront domain is required`: add `cloudfront.domain`.
+- Startup logs `S3 must be initialized`: configure S3 environment variables first.
+- Signed cookies are not set: confirm `imageSigning: "cookies"`, `cookieDomain`, `CLOUDFRONT_KEY_PAIR_ID`, and `CLOUDFRONT_PRIVATE_KEY`.
+- Browser still cannot load images: confirm API and CDN hostnames share the configured parent domain and that cookies are allowed with `Secure` and `SameSite=None`.
+- Downloads ignore filename/content type: update the CloudFront cache/origin request policy to forward the response override query strings.

--- a/content/docs/configuration/cdn/firebase.mdx
+++ b/content/docs/configuration/cdn/firebase.mdx
@@ -4,7 +4,7 @@ icon: Flame
 description: This document provides instructions for setting up Firebase Storage as a CDN for LibreChat
 ---
 
-Firebase Storage integrates with Firebase Hosting's global CDN, allowing you to serve files stored in Firebase Storage through edge locations around the world. This makes it the only true CDN-backed file storage option in LibreChat.
+Firebase Storage integrates with Firebase Hosting's global CDN, allowing you to serve files stored in Firebase Storage through edge locations around the world. It is one of LibreChat's CDN-backed file storage options, alongside CloudFront for S3.
 
 ## Steps to Set Up Firebase
 
@@ -82,20 +82,19 @@ FIREBASE_APP_ID=1:your_app_id #appId
 ![image](https://github.com/danny-avila/LibreChat/assets/32828263/16a0f850-cdd4-4875-8342-ab67bfb59804)
 
 - Select `Rules` and delete `: if false;` on this line: `allow read, write: if false;`
+  - your updated rules should look like this:
 
-    - your updated rules should look like this:
+  ```bash
+  rules_version = '2';
 
-    ```bash
-    rules_version = '2';
-    
-    service firebase.storage {
-      match /b/{bucket}/o {
-        match /images/{userId}/{fileName} {
-          allow read, write: if true;
-        }
+  service firebase.storage {
+    match /b/{bucket}/o {
+      match /images/{userId}/{fileName} {
+        allow read, write: if true;
       }
     }
-    ```
+  }
+  ```
 
 ![image](https://github.com/danny-avila/LibreChat/assets/32828263/c190011f-c1a6-47c7-986e-8d309b5f8704)
 
@@ -108,9 +107,9 @@ FIREBASE_APP_ID=1:your_app_id #appId
 Finally, to enable the app use Firebase, you must set the following in your `librechat.yaml` config file.
 
 ```yaml
-  version: 1.3.5
-  cache: true
-  fileStrategy: "firebase"
+version: 1.3.5
+cache: true
+fileStrategy: 'firebase'
 ```
 
 For more information about the `librechat.yaml` config file, see the guide here: [Custom Endpoints & Configuration](/docs/configuration/librechat_yaml).
@@ -136,6 +135,7 @@ For more information about the `librechat.yaml` config file, see the guide here:
   }
 ]
 ```
+
 - Save the file.
 
 ---

--- a/content/docs/configuration/cdn/index.mdx
+++ b/content/docs/configuration/cdn/index.mdx
@@ -5,18 +5,27 @@ description: File storage and CDN setup instructions
 ---
 
 <Callout type="info" title="Note">
-  LibreChat supports multiple file storage backends and one CDN option. Amazon S3 and Azure Blob Storage are object/file storage solutions, while Firebase is the only true CDN option with global edge delivery. Choose the one that best meets your deployment requirements.
+  LibreChat supports local storage, object storage backends, and CDN-backed delivery. Use S3 for
+  durable object storage, then add CloudFront when you need stable media links, edge caching, signed
+  cookies, or signed download URLs.
 </Callout>
 
 ## File Storage
 
 ### Amazon S3
+
 - [Amazon S3](/docs/configuration/cdn/s3)
 
 ### Azure Blob Storage
+
 - [Azure Blob Storage](/docs/configuration/cdn/azure)
 
 ## CDN
 
+### CloudFront
+
+- [CloudFront with S3](/docs/configuration/cdn/cloudfront)
+
 ### Firebase
+
 - [Firebase CDN](/docs/configuration/cdn/firebase)

--- a/content/docs/configuration/cdn/meta.json
+++ b/content/docs/configuration/cdn/meta.json
@@ -1,9 +1,5 @@
 {
   "title": "File Storage & CDN",
   "icon": "HardDrive",
-  "pages": [
-    "s3",
-    "azure",
-    "firebase"
-  ]
+  "pages": ["s3", "cloudfront", "azure", "firebase"]
 }

--- a/content/docs/configuration/cdn/s3.mdx
+++ b/content/docs/configuration/cdn/s3.mdx
@@ -45,6 +45,7 @@ If you are deploying LibreChat on Kubernetes (e.g. on EKS), you can use IRSA to 
    }
    ```
 2. **Create a Policy** that grants necessary S3 permissions (example below):
+
 ```json
 {
   "Version": "2012-10-17",
@@ -66,16 +67,19 @@ If you are deploying LibreChat on Kubernetes (e.g. on EKS), you can use IRSA to 
     }
   ]
 }
-   ```
+```
+
 3. **Annotate your Kubernetes ServiceAccount:**  
-Ensure your LibreChat pods use a service account annotated for IRSA. This way, the AWS SDK in your application (using our updated S3 initialization code) will automatically use the temporary credentials provided by IRSA without needing the environment variables for AWS credentials.
+   Ensure your LibreChat pods use a service account annotated for IRSA. This way, the AWS SDK in your application (using our updated S3 initialization code) will automatically use the temporary credentials provided by IRSA without needing the environment variables for AWS credentials.
 
 ## 2. Create an S3 Bucket
 
 1. **Open the S3 Console:**
+
 - Go to the [Amazon S3 console](https://s3.console.aws.amazon.com/s3/).
 
 2. **Create a New Bucket:**
+
 - Click **"Create bucket"**.
 - **Bucket Name:** Enter a unique name (e.g., `mylibrechatbucket`).
 - **Region:** Select the AWS region closest to your users (for example, `us-east-1` or `eu-west-1`).
@@ -108,46 +112,50 @@ If you are using **IRSA** on Kubernetes, you do **not** need to set `AWS_ACCESS_
 Update your LibreChat configuration file (`librechat.yaml`) to specify that the application should use Amazon S3 for file handling:
 
 ```yaml filename="librechat.yaml"
-version: 1.3.5
+version: 1.3.11
 cache: true
-fileStrategy: "s3"
+fileStrategy: 's3'
 ```
 
-<Callout type="warning" title="S3 presigned URLs expire — images and avatars will break">
+<Callout type="warning" title="S3 presigned URLs expire for visual assets">
   S3 does not serve files through a CDN. LibreChat accesses S3 files via **presigned URLs**, which are temporary signed tokens with a configurable expiry (`S3_URL_EXPIRY_SECONDS`). AWS caps presigned URL lifetime at 7 days for IAM user credentials, and just a few hours when using temporary credentials (STS/IAM roles such as IRSA). Once a URL expires, the image or avatar it references will appear broken in the UI until the page is refreshed and a new URL is generated.
 
-  The refresh logic in LibreChat is not applied consistently — for example, the agent list endpoint returns stored (potentially stale) URLs, while the single-agent endpoint refreshes them. This causes visible broken avatar images in the model selector and chat UI. See the [related discussion](https://github.com/danny-avila/LibreChat/discussions/10280#discussioncomment-14803903) for full context.
+The refresh logic in LibreChat is not applied consistently for every visual surface. For example, list-style endpoints can return stored URLs while detail endpoints refresh them. This can cause visible broken avatar images in the model selector and chat UI. See the [related discussion](https://github.com/danny-avila/LibreChat/discussions/10280#discussioncomment-14803903) for full context.
 
-  **S3 is well-suited for document storage** (PDFs, text files, code) where short-lived presigned download URLs are appropriate. For images and avatars that need to render persistently across the UI, use [Firebase](/docs/configuration/cdn/firebase) or configure `fileStrategies` to route only those types to a CDN-backed strategy:
+**S3 is well-suited for document storage** (PDFs, text files, code) where short-lived presigned download URLs are appropriate. For images and avatars that need to render persistently across the UI, use [CloudFront with S3](/docs/configuration/cdn/cloudfront), [Firebase](/docs/configuration/cdn/firebase), or configure `fileStrategies` to route only those types to a CDN-backed strategy:
 
-  ```yaml filename="librechat.yaml"
-  fileStrategies:
-    avatar: "firebase"
-    image: "firebase"
-    document: "s3"
-  ```
+```yaml filename="librechat.yaml"
+fileStrategies:
+  avatar: 'cloudfront'
+  image: 'cloudfront'
+  document: 's3'
+```
 
-  CloudFront (Amazon's CDN for S3, which eliminates presigned URLs entirely) is planned and in active development.
 </Callout>
 
 ## Summary
 
 1. **Create an AWS Account & IAM User (or configure IRSA):**
+
 - For traditional deployments, create an IAM user with programmatic access and obtain your access keys.
 - For Kubernetes deployments (e.g., on EKS), set up IRSA so that your pods automatically obtain temporary credentials.
 
 2. **Create an S3 Bucket:**
+
 - Use the Amazon S3 console to create a bucket, choosing a unique name and region.
 
 3. **Update Environment Variables:**
+
 - For non-IRSA: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `AWS_BUCKET_NAME` in your `.env` file.
 - For IRSA: set only `AWS_REGION` and `AWS_BUCKET_NAME`; ensure your pod’s service account is correctly annotated.
 
 4. **Configure LibreChat:**
-- Set `fileStrategy` to `"s3"` in your `librechat.yaml` configuration file.
+
+- Set `fileStrategy` to `"s3"` in your `librechat.yaml` configuration file, or use `fileStrategies` to keep documents in S3 while sending images and avatars through CloudFront.
 
 With these steps, your LibreChat application will use Amazon S3 to handle file uploads, downloads, and deletions. Additionally, with IRSA support, your application can run securely on Kubernetes without embedding long-term AWS credentials.
 
 <Callout type="info" title="Note">
-  Always ensure your AWS credentials remain secure. Do not commit them to a public repository. Adjust IAM policies to follow the principle of least privilege as needed.
+  Always ensure your AWS credentials remain secure. Do not commit them to a public repository.
+  Adjust IAM policies to follow the principle of least privilege as needed.
 </Callout>

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -15,15 +15,15 @@ Alternatively, you can create a new file named `docker-compose.override.yml` in 
 For more info see:
 
 - Our quick guide:
-    - **[Docker Override](/docs/configuration/docker_override)**
+  - **[Docker Override](/docs/configuration/docker_override)**
 
 - The official docker documentation:
-    - **[docker docs - understanding-multiple-compose-files](https://docs.docker.com/compose/multiple-compose-files/extends/#understanding-multiple-compose-files)**
-    - **[docker docs - merge-compose-files](https://docs.docker.com/compose/multiple-compose-files/merge/#merge-compose-files)**
-    - **[docker docs - specifying-multiple-compose-files](https://docs.docker.com/compose/reference/#specifying-multiple-compose-files)**
+  - **[docker docs - understanding-multiple-compose-files](https://docs.docker.com/compose/multiple-compose-files/extends/#understanding-multiple-compose-files)**
+  - **[docker docs - merge-compose-files](https://docs.docker.com/compose/multiple-compose-files/merge/#merge-compose-files)**
+  - **[docker docs - specifying-multiple-compose-files](https://docs.docker.com/compose/reference/#specifying-multiple-compose-files)**
 
 - You can also view an example of an override file for LibreChat in your LibreChat folder and on GitHub:
-    - **[docker-compose.override.example](https://github.com/danny-avila/LibreChat/blob/main/docker-compose.override.yml.example)**
+  - **[docker-compose.override.example](https://github.com/danny-avila/LibreChat/blob/main/docker-compose.override.yml.example)**
 
 ---
 
@@ -34,7 +34,6 @@ For more info see:
 - The server listens on a specific port.
 - The `PORT` environment variable sets the port where the server listens. By default, it is set to `3080`.
 
-
 <OptionTable
   options={[
     ['HOST', 'string', 'Specifies the host.', 'HOST=localhost'],
@@ -43,6 +42,7 @@ For more info see:
 />
 
 ### Trust proxy
+
 Use the address that is at most n number of hops away from the Express application.
 req.socket.remoteAddress is the first hop, and the rest are looked for in the X-Forwarded-For header from right to left.
 A value of 0 means that the first untrusted address would be req.socket.remoteAddress, i.e. there is no reverse proxy.
@@ -51,9 +51,7 @@ The `TRUST_PROXY` environment variable default is set to `1`.
 Refer to [Express.js - trust proxy](https://expressjs.com/en/guide/behind-proxies.html) for more information about this.
 
 <OptionTable
-  options={[
-    ['TRUST_PROXY', 'number', 'Specifies the number of hops.', 'TRUST_PROXY=1'],
-  ]}
+  options={[['TRUST_PROXY', 'number', 'Specifies the number of hops.', 'TRUST_PROXY=1']]}
 />
 
 ### Credentials Configuration
@@ -62,24 +60,54 @@ To securely store credentials, you need a fixed key and IV. You can set them her
 
 <OptionTable
   options={[
-    ['CREDS_KEY', 'string', '32-byte key (64 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_KEY=f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0'],
-    ['CREDS_IV', 'string', '16-byte IV (32 characters in hex) for securely storing credentials. Required for app startup.', 'CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb'],
+    [
+      'CREDS_KEY',
+      'string',
+      '32-byte key (64 characters in hex) for securely storing credentials. Required for app startup.',
+      'CREDS_KEY=f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0',
+    ],
+    [
+      'CREDS_IV',
+      'string',
+      '16-byte IV (32 characters in hex) for securely storing credentials. Required for app startup.',
+      'CREDS_IV=e2341419ec3dd3d19b13a1a87fafcbfb',
+    ],
   ]}
 />
 
 <Callout type="warning" title="Warning">
-**Warning:** If you don't set `CREDS_KEY` and `CREDS_IV`, the app will crash on startup.
-- You can use this [Key Generator](/toolkit/creds_generator) to generate them quickly.
+  **Warning:** If you don't set `CREDS_KEY` and `CREDS_IV`, the app will crash on startup. - You can
+  use this [Key Generator](/toolkit/creds_generator) to generate them quickly.
 </Callout>
 
 ### Static File Handling
 
 <OptionTable
   options={[
-    ['STATIC_CACHE_MAX_AGE', 'string', 'Cache-Control max-age in seconds','STATIC_CACHE_MAX_AGE=172800'],
-    ['STATIC_CACHE_S_MAX_AGE', 'string', 'Cache-Control s-maxage in seconds for shared caches (CDNs and proxies)','STATIC_CACHE_S_MAX_AGE="86400"'],
-    ['DISABLE_COMPRESSION', 'boolean', 'Disables compression for static files.','DISABLE_COMPRESSION=false'],
-    ['ENABLE_IMAGE_OUTPUT_GZIP_SCAN', 'boolean', 'Enables serving gzipped versions of uploaded images if present in the same folder.','ENABLE_IMAGE_OUTPUT_GZIP_SCAN=true'],
+    [
+      'STATIC_CACHE_MAX_AGE',
+      'string',
+      'Cache-Control max-age in seconds',
+      'STATIC_CACHE_MAX_AGE=172800',
+    ],
+    [
+      'STATIC_CACHE_S_MAX_AGE',
+      'string',
+      'Cache-Control s-maxage in seconds for shared caches (CDNs and proxies)',
+      'STATIC_CACHE_S_MAX_AGE="86400"',
+    ],
+    [
+      'DISABLE_COMPRESSION',
+      'boolean',
+      'Disables compression for static files.',
+      'DISABLE_COMPRESSION=false',
+    ],
+    [
+      'ENABLE_IMAGE_OUTPUT_GZIP_SCAN',
+      'boolean',
+      'Enables serving gzipped versions of uploaded images if present in the same folder.',
+      'ENABLE_IMAGE_OUTPUT_GZIP_SCAN=true',
+    ],
   ]}
 />
 
@@ -87,22 +115,28 @@ To securely store credentials, you need a fixed key and IV. You can set them her
 
 Sets the [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) headers for static files. These configurations only trigger when the `NODE_ENV` is set to `production`.
 
-* Uncomment `STATIC_CACHE_MAX_AGE` to change the local `max-age` for static files. By default this is set to 2 days (172800 seconds).
-* Uncomment `STATIC_CACHE_S_MAX_AGE` to set the `s-maxage` for shared caches (CDNs and proxies). By default this is set to 1 day (86400 seconds).
-* Uncomment `DISABLE_COMPRESSION` to disable compression for static files. By default, compression is enabled.
-* Uncomment `ENABLE_IMAGE_OUTPUT_GZIP_SCAN` to enable scanning and serving of gzipped version of images if they have been pre-compressed in the same folder, with the same name and a .gz extension. By default, gzip scan for uploaded images is disabled.
+- Uncomment `STATIC_CACHE_MAX_AGE` to change the local `max-age` for static files. By default this is set to 2 days (172800 seconds).
+- Uncomment `STATIC_CACHE_S_MAX_AGE` to set the `s-maxage` for shared caches (CDNs and proxies). By default this is set to 1 day (86400 seconds).
+- Uncomment `DISABLE_COMPRESSION` to disable compression for static files. By default, compression is enabled.
+- Uncomment `ENABLE_IMAGE_OUTPUT_GZIP_SCAN` to enable scanning and serving of gzipped version of images if they have been pre-compressed in the same folder, with the same name and a .gz extension. By default, gzip scan for uploaded images is disabled.
 
 <Callout type="warning" title="Warning">
-- This only affects static files served by the API server and is not applicable to _Firebase_, _NGINX_, or any other configurations.
+  - This only affects static files served by the API server and is not applicable to _Firebase_,
+  _NGINX_, or any other configurations.
 </Callout>
 
 ### Index HTML Cache Control
 
 <OptionTable
   options={[
-    ['INDEX_CACHE_CONTROL', 'string', 'Cache-Control header for index.html','INDEX_CACHE_CONTROL=no-cache, no-store, must-revalidate'],
-    ['INDEX_PRAGMA', 'string', 'Pragma header for index.html','INDEX_PRAGMA=no-cache'],
-    ['INDEX_EXPIRES', 'string', 'Expires header for index.html','INDEX_EXPIRES=0'],
+    [
+      'INDEX_CACHE_CONTROL',
+      'string',
+      'Cache-Control header for index.html',
+      'INDEX_CACHE_CONTROL=no-cache, no-store, must-revalidate',
+    ],
+    ['INDEX_PRAGMA', 'string', 'Pragma header for index.html', 'INDEX_PRAGMA=no-cache'],
+    ['INDEX_EXPIRES', 'string', 'Expires header for index.html', 'INDEX_EXPIRES=0'],
   ]}
 />
 
@@ -111,31 +145,63 @@ Sets the [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Heade
 Controls caching headers specifically for the index.html response. By default, these settings prevent caching to ensure users always get the latest version of the application.
 
 <Callout type="note" title="Note">
-Unlike static assets which are cached for performance, the index.html file's cache headers are configured separately to ensure users always get the latest application shell.
+  Unlike static assets which are cached for performance, the index.html file's cache headers are
+  configured separately to ensure users always get the latest application shell.
 </Callout>
 
 ### MongoDB Database
 
 <OptionTable
   options={[
-    ['MONGO_URI', 'string', 'Specifies the MongoDB URI.','MONGO_URI=mongodb://127.0.0.1:27017/LibreChat'],
+    [
+      'MONGO_URI',
+      'string',
+      'Specifies the MongoDB URI.',
+      'MONGO_URI=mongodb://127.0.0.1:27017/LibreChat',
+    ],
   ]}
 />
 
 Change this to your MongoDB URI if different. You should add `LibreChat` or your own `APP_TITLE` as the database name in the URI.
 
 If you are using an online database, the URI format is `mongodb+srv://<username>:<password>@<host>/<database>?<options>`. Your `MONGO_URI` should look like this:
-* `mongodb+srv://username:password@host.mongodb.net/LibreChat?retryWrites=true` (`retryWrites` is the only option you need when using the online database.)
+
+- `mongodb+srv://username:password@host.mongodb.net/LibreChat?retryWrites=true` (`retryWrites` is the only option you need when using the online database.)
 
 #### MongoDB Connection Pool Configuration
 
 <OptionTable
   options={[
-    ['MONGO_MAX_POOL_SIZE', 'number', 'The maximum number of connections in the connection pool.', '# MONGO_MAX_POOL_SIZE='],
-    ['MONGO_MIN_POOL_SIZE', 'number', 'The minimum number of connections in the connection pool.', '# MONGO_MIN_POOL_SIZE='],
-    ['MONGO_MAX_CONNECTING', 'number', 'The maximum number of connections that may be in the process of being established concurrently by the connection pool.', '# MONGO_MAX_CONNECTING='],
-    ['MONGO_MAX_IDLE_TIME_MS', 'number', 'The maximum number of milliseconds that a connection can remain idle in the pool before being removed and closed.', '# MONGO_MAX_IDLE_TIME_MS='],
-    ['MONGO_WAIT_QUEUE_TIMEOUT_MS', 'number', 'The maximum time in milliseconds that a thread can wait for a connection to become available.', '# MONGO_WAIT_QUEUE_TIMEOUT_MS='],
+    [
+      'MONGO_MAX_POOL_SIZE',
+      'number',
+      'The maximum number of connections in the connection pool.',
+      '# MONGO_MAX_POOL_SIZE=',
+    ],
+    [
+      'MONGO_MIN_POOL_SIZE',
+      'number',
+      'The minimum number of connections in the connection pool.',
+      '# MONGO_MIN_POOL_SIZE=',
+    ],
+    [
+      'MONGO_MAX_CONNECTING',
+      'number',
+      'The maximum number of connections that may be in the process of being established concurrently by the connection pool.',
+      '# MONGO_MAX_CONNECTING=',
+    ],
+    [
+      'MONGO_MAX_IDLE_TIME_MS',
+      'number',
+      'The maximum number of milliseconds that a connection can remain idle in the pool before being removed and closed.',
+      '# MONGO_MAX_IDLE_TIME_MS=',
+    ],
+    [
+      'MONGO_WAIT_QUEUE_TIMEOUT_MS',
+      'number',
+      'The maximum time in milliseconds that a thread can wait for a connection to become available.',
+      '# MONGO_WAIT_QUEUE_TIMEOUT_MS=',
+    ],
   ]}
 />
 
@@ -143,25 +209,36 @@ If you are using an online database, the URI format is `mongodb+srv://<username>
 
 <OptionTable
   options={[
-    ['MONGO_AUTO_INDEX', 'boolean', 'Set to false to disable automatic index creation for all models associated with this connection. When omitted, uses Mongoose default behavior.', '# MONGO_AUTO_INDEX='],
-    ['MONGO_AUTO_CREATE', 'boolean', 'Set to false to disable Mongoose automatically calling createCollection() on every model created on this connection. When omitted, uses Mongoose default behavior.', '# MONGO_AUTO_CREATE='],
+    [
+      'MONGO_AUTO_INDEX',
+      'boolean',
+      'Set to false to disable automatic index creation for all models associated with this connection. When omitted, uses Mongoose default behavior.',
+      '# MONGO_AUTO_INDEX=',
+    ],
+    [
+      'MONGO_AUTO_CREATE',
+      'boolean',
+      'Set to false to disable Mongoose automatically calling createCollection() on every model created on this connection. When omitted, uses Mongoose default behavior.',
+      '# MONGO_AUTO_CREATE=',
+    ],
   ]}
 />
 
 Alternatively you can use `documentDb` that emulates `mongoDb` but it:
 
-* does not support `retryWrites` - use `retryWrites=false`
-* requires TLS connection, hence use parameters `tls=true` to enable TLS and `tlsCAFile=/path-to-ca/bundle.pem` to point to the AWS provided CA bundle file
+- does not support `retryWrites` - use `retryWrites=false`
+- requires TLS connection, hence use parameters `tls=true` to enable TLS and `tlsCAFile=/path-to-ca/bundle.pem` to point to the AWS provided CA bundle file
 
 The URI for `documentDb` will look like:
-* `mongodb+srv://username:password@domain/dbname?retryWrites=false&tls=true&tlsCAFile=/path-to-ca/bundle.pem`
+
+- `mongodb+srv://username:password@domain/dbname?retryWrites=false&tls=true&tlsCAFile=/path-to-ca/bundle.pem`
 
 See also:
 
-* [MongoDB Atlas](/docs/configuration/mongodb/mongodb_atlas) for instructions on how to create an online MongoDB Atlas database (useful for use without Docker)
-* [MongoDB Community Server](/docs/configuration/mongodb/mongodb_community) for instructions on how to create a local MongoDB database (without Docker)
-* [MongoDB Authentication](/docs/configuration/mongodb/mongodb_auth) To enable explicit authentication for MongoDB in Docker.
-* [Manage your database with Mongo Express](/blog/2023-11-30_mongoexpress) for securely accessing your Docker MongoDB database
+- [MongoDB Atlas](/docs/configuration/mongodb/mongodb_atlas) for instructions on how to create an online MongoDB Atlas database (useful for use without Docker)
+- [MongoDB Community Server](/docs/configuration/mongodb/mongodb_community) for instructions on how to create a local MongoDB database (without Docker)
+- [MongoDB Authentication](/docs/configuration/mongodb/mongodb_auth) To enable explicit authentication for MongoDB in Docker.
+- [Manage your database with Mongo Express](/blog/2023-11-30_mongoexpress) for securely accessing your Docker MongoDB database
 
 ### Application Domains
 
@@ -169,12 +246,23 @@ To configure LibreChat for local use or custom domain deployment, set the follow
 
 <OptionTable
   options={[
-    ['DOMAIN_CLIENT', 'string', 'Specifies the client-side domain.', 'DOMAIN_CLIENT=http://localhost:3080'],
-    ['DOMAIN_SERVER', 'string', 'Specifies the server-side domain.', 'DOMAIN_SERVER=http://localhost:3080'],
+    [
+      'DOMAIN_CLIENT',
+      'string',
+      'Specifies the client-side domain.',
+      'DOMAIN_CLIENT=http://localhost:3080',
+    ],
+    [
+      'DOMAIN_SERVER',
+      'string',
+      'Specifies the server-side domain.',
+      'DOMAIN_SERVER=http://localhost:3080',
+    ],
   ]}
 />
 
 When deploying LibreChat to a custom domain, replace `http://localhost:3080` with your deployed URL
+
 - e.g. `https://librechat.example.com`.
 
 ### Prevent Public Search Engines Indexing
@@ -183,7 +271,12 @@ By default, your website will not be indexed by public search engines (e.g. Goog
 
 <OptionTable
   options={[
-    ['NO_INDEX', 'boolean', 'Prevents public search engines from indexing your website.', 'NO_INDEX=true'],
+    [
+      'NO_INDEX',
+      'boolean',
+      'Prevents public search engines from indexing your website.',
+      'NO_INDEX=true',
+    ],
   ]}
 />
 
@@ -195,33 +288,65 @@ LibreChat has built-in central logging, see [Logging System](/docs/configuration
 
 #### Log Files
 
-* Debug logging is enabled by default and crucial for development.
-* To report issues, reproduce the error and submit logs from `./api/logs/debug-%DATE%.log` at: **[LibreChat GitHub Issues](https://github.com/danny-avila/LibreChat/issues)**
-* Error logs are stored in the same location.
+- Debug logging is enabled by default and crucial for development.
+- To report issues, reproduce the error and submit logs from `./api/logs/debug-%DATE%.log` at: **[LibreChat GitHub Issues](https://github.com/danny-avila/LibreChat/issues)**
+- Error logs are stored in the same location.
 
 #### Environment Variables
 
 <OptionTable
   options={[
-    ['DEBUG_LOGGING', 'boolean', 'Keep debug logs active.','DEBUG_LOGGING=true'],
-    ['DEBUG_CONSOLE', 'boolean', 'Enable verbose console/stdout logs in the same format as file debug logs.', 'DEBUG_CONSOLE=false'],
-    ['CONSOLE_JSON', 'boolean', 'Enable verbose JSON console/stdout logs suitable for cloud deployments like GCP/AWS.', 'CONSOLE_JSON=false'],
-    ['CONSOLE_JSON_STRING_LENGTH', 'number', 'Configure the truncation size for console/stdout logs, defaults to 255', 'CONSOLE_JSON_STRING_LENGTH=1000'],
-    ['LIBRECHAT_LOG_DIR', 'string', 'Custom directory for log files. Defaults to /app/logs (Docker) or api/logs (local dev).', '# LIBRECHAT_LOG_DIR=/custom/log/path'],
-    ['MEM_DIAG', 'boolean', 'Enable memory diagnostics — logs heap/RSS snapshots every 60 seconds. Auto-enabled when running with --inspect.', '# MEM_DIAG=true'],
-    ['AGENT_DEBUG_LOGGING', 'boolean', 'Enables verbose debug logging in the agent controller (token counts, context pruning diagnostics).', '# AGENT_DEBUG_LOGGING=true'],
+    ['DEBUG_LOGGING', 'boolean', 'Keep debug logs active.', 'DEBUG_LOGGING=true'],
+    [
+      'DEBUG_CONSOLE',
+      'boolean',
+      'Enable verbose console/stdout logs in the same format as file debug logs.',
+      'DEBUG_CONSOLE=false',
+    ],
+    [
+      'CONSOLE_JSON',
+      'boolean',
+      'Enable verbose JSON console/stdout logs suitable for cloud deployments like GCP/AWS.',
+      'CONSOLE_JSON=false',
+    ],
+    [
+      'CONSOLE_JSON_STRING_LENGTH',
+      'number',
+      'Configure the truncation size for string values in JSON console/stdout logs. Default: 255.',
+      '# CONSOLE_JSON_STRING_LENGTH=255',
+    ],
+    [
+      'LIBRECHAT_LOG_DIR',
+      'string',
+      'Custom directory for log files. Defaults to /app/logs (Docker) or api/logs (local dev).',
+      '# LIBRECHAT_LOG_DIR=/custom/log/path',
+    ],
+    [
+      'MEM_DIAG',
+      'boolean',
+      'Enable memory diagnostics — logs heap/RSS snapshots every 60 seconds. Auto-enabled when running with --inspect.',
+      '# MEM_DIAG=true',
+    ],
+    [
+      'AGENT_DEBUG_LOGGING',
+      'boolean',
+      'Enables verbose debug logging in the agent controller (token counts, context pruning diagnostics).',
+      '# AGENT_DEBUG_LOGGING=true',
+    ],
   ]}
 />
 
 Note:
-* `DEBUG_LOGGING` can be used with either `DEBUG_CONSOLE` or `CONSOLE_JSON` but not both.
-* `DEBUG_CONSOLE` and `CONSOLE_JSON` are mutually exclusive.
-* `CONSOLE_JSON`: When handling console logs in cloud deployments (such as GCP or AWS), enabling this will dump the logs with a UTC timestamp and format them as JSON.
-  * See: [feat: Add CONSOLE_JSON](https://github.com/danny-avila/LibreChat/pull/2146)
+
+- `DEBUG_LOGGING` can be used with either `DEBUG_CONSOLE` or `CONSOLE_JSON` but not both.
+- `DEBUG_CONSOLE` and `CONSOLE_JSON` are mutually exclusive.
+- `CONSOLE_JSON`: When handling console logs in cloud deployments (such as GCP or AWS), enabling this will dump the logs with a UTC timestamp and format them as JSON.
+  - See: [feat: Add CONSOLE_JSON](https://github.com/danny-avila/LibreChat/pull/2146)
 
 Note: `DEBUG_CONSOLE` is not recommended, as the outputs can be quite verbose, and so it's disabled by default.
 
 ### Permission
+
 > UID and GID are numbers assigned by Linux to each user and group on the system. If you have permission problems, set here the UID and GID of the user running the Docker Compose command. The applications in the container will run with these UID/GID.
 
 <OptionTable
@@ -232,6 +357,7 @@ Note: `DEBUG_CONSOLE` is not recommended, as the outputs can be quite verbose, a
 />
 
 ### Configuration Path - `librechat.yaml`
+
 Specify an alternative location for the LibreChat configuration file.
 You may specify an **absolute path**, a **relative path**, or a **URL**. The filename in the path is flexible and does not have to be `librechat.yaml`; any valid configuration file will work.
 
@@ -239,7 +365,12 @@ You may specify an **absolute path**, a **relative path**, or a **URL**. The fil
 
 <OptionTable
   options={[
-    ['CONFIG_PATH', 'string', 'An alternative location for the LibreChat configuration file.', '# CONFIG_PATH=https://raw.githubusercontent.com/danny-avila/LibreChat/main/librechat.example.yaml'],
+    [
+      'CONFIG_PATH',
+      'string',
+      'An alternative location for the LibreChat configuration file.',
+      '# CONFIG_PATH=https://raw.githubusercontent.com/danny-avila/LibreChat/main/librechat.example.yaml',
+    ],
   ]}
 />
 
@@ -249,12 +380,19 @@ By default, LibreChat will exit with an error (exit code 1) if the `librechat.ya
 
 <OptionTable
   options={[
-    ['CONFIG_BYPASS_VALIDATION', 'boolean', 'When set to `true`, the server will log a warning and continue starting with default configuration even if `librechat.yaml` has validation errors. This preserves the legacy behavior.', '# CONFIG_BYPASS_VALIDATION=true'],
+    [
+      'CONFIG_BYPASS_VALIDATION',
+      'boolean',
+      'When set to `true`, the server will log a warning and continue starting with default configuration even if `librechat.yaml` has validation errors. This preserves the legacy behavior.',
+      '# CONFIG_BYPASS_VALIDATION=true',
+    ],
   ]}
 />
 
 <Callout type="warning" title="Warning">
-Using `CONFIG_BYPASS_VALIDATION=true` is not recommended for production environments. It is intended as a temporary workaround while debugging configuration issues. Always fix validation errors in your configuration file.
+  Using `CONFIG_BYPASS_VALIDATION=true` is not recommended for production environments. It is
+  intended as a temporary workaround while debugging configuration issues. Always fix validation
+  errors in your configuration file.
 </Callout>
 
 ### Uncaught Exception Handling
@@ -263,29 +401,43 @@ By default, LibreChat will exit the process when an uncaught exception occurs, w
 
 <OptionTable
   options={[
-    ['CONTINUE_ON_UNCAUGHT_EXCEPTION', 'boolean', 'When set to `true`, the app will continue running after encountering uncaught exceptions instead of exiting the process.', '# CONTINUE_ON_UNCAUGHT_EXCEPTION=false'],
+    [
+      'CONTINUE_ON_UNCAUGHT_EXCEPTION',
+      'boolean',
+      'When set to `true`, the app will continue running after encountering uncaught exceptions instead of exiting the process.',
+      '# CONTINUE_ON_UNCAUGHT_EXCEPTION=false',
+    ],
   ]}
 />
 
 <Callout type="warning" title="Warning">
-Not recommended for production unless necessary. Uncaught exceptions may leave the application in an unpredictable state.
+  Not recommended for production unless necessary. Uncaught exceptions may leave the application in
+  an unpredictable state.
 </Callout>
 
 ## Endpoints
+
 In this section, you can configure the endpoints and models selection, their API keys, and the proxy and reverse proxy settings for the endpoints that support it.
 
 ### General Config
+
 Uncomment `ENDPOINTS` to customize the available endpoints in LibreChat.
 
 <OptionTable
   options={[
-    ['ENDPOINTS', 'string', 'Comma-separated list of available endpoints.', '# ENDPOINTS=openAI,agents,assistants,gptPlugins,azureOpenAI,google,anthropic,bingAI,custom'],
+    [
+      'ENDPOINTS',
+      'string',
+      'Comma-separated list of available endpoints.',
+      '# ENDPOINTS=openAI,agents,assistants,gptPlugins,azureOpenAI,google,anthropic,bingAI,custom',
+    ],
     ['PROXY', 'string', 'Proxy setting for all endpoints.', 'PROXY='],
     ['TITLE_CONVO', 'boolean', 'Enable titling for all endpoints.', 'TITLE_CONVO=true'],
   ]}
 />
 
 ### Known Endpoints - `librechat.yaml`
+
 - see also: [Custom Endpoints & Configuration](/docs/configuration/librechat_yaml)
 
 <OptionTable
@@ -314,35 +466,102 @@ For detailed configuration and customization options, see: [Web Search Configura
 
 <OptionTable
   options={[
-    ['SERPER_API_KEY', 'string', 'API key for Serper search provider. Get your key from https://serper.dev/api-key', '# SERPER_API_KEY='],
-    ['TAVILY_API_KEY', 'string', 'API key for Tavily search and scraper provider. Get your key from https://app.tavily.com/home', '# TAVILY_API_KEY='],
-    ['TAVILY_SEARCH_URL', 'string', 'Custom Tavily Search API URL (optional). Only needed for custom or proxy Tavily-compatible search endpoints.', '# TAVILY_SEARCH_URL='],
-    ['TAVILY_EXTRACT_URL', 'string', 'Custom Tavily Extract API URL (optional). Only needed for custom or proxy Tavily-compatible extract endpoints.', '# TAVILY_EXTRACT_URL='],
-    ['FIRECRAWL_API_KEY', 'string', 'API key for Firecrawl scraper service. Get your key from https://docs.firecrawl.dev/introduction#api-key', '# FIRECRAWL_API_KEY='],
-    ['FIRECRAWL_API_URL', 'string', 'Custom Firecrawl API URL (optional). Only needed for custom Firecrawl instances.', '# FIRECRAWL_API_URL='],
+    [
+      'SERPER_API_KEY',
+      'string',
+      'API key for Serper search provider. Get your key from https://serper.dev/api-key',
+      '# SERPER_API_KEY=',
+    ],
+    [
+      'TAVILY_API_KEY',
+      'string',
+      'API key for Tavily search and scraper provider. Get your key from https://app.tavily.com/home',
+      '# TAVILY_API_KEY=',
+    ],
+    [
+      'TAVILY_SEARCH_URL',
+      'string',
+      'Custom Tavily Search API URL (optional). Only needed for custom or proxy Tavily-compatible search endpoints.',
+      '# TAVILY_SEARCH_URL=',
+    ],
+    [
+      'TAVILY_EXTRACT_URL',
+      'string',
+      'Custom Tavily Extract API URL (optional). Only needed for custom or proxy Tavily-compatible extract endpoints.',
+      '# TAVILY_EXTRACT_URL=',
+    ],
+    [
+      'FIRECRAWL_API_KEY',
+      'string',
+      'API key for Firecrawl scraper service. Get your key from https://docs.firecrawl.dev/introduction#api-key',
+      '# FIRECRAWL_API_KEY=',
+    ],
+    [
+      'FIRECRAWL_API_URL',
+      'string',
+      'Custom Firecrawl API URL (optional). Only needed for custom Firecrawl instances.',
+      '# FIRECRAWL_API_URL=',
+    ],
     ['FIRECRAWL_VERSION', 'string', 'Firecrawl API version (v0 or v1).', '# FIRECRAWL_VERSION=v1'],
-    ['JINA_API_KEY', 'string', 'API key for Jina reranker service. Get your key from https://jina.ai/api-dashboard/', '# JINA_API_KEY='],
-    ['JINA_API_URL', 'string', 'Custom Jina API URL (optional). Only needed for custom Jina instances.', '# JINA_API_URL='],
-    ['COHERE_API_KEY', 'string', 'API key for Cohere reranker service. Get your key from https://dashboard.cohere.com/welcome/login', '# COHERE_API_KEY='],
+    [
+      'JINA_API_KEY',
+      'string',
+      'API key for Jina reranker service. Get your key from https://jina.ai/api-dashboard/',
+      '# JINA_API_KEY=',
+    ],
+    [
+      'JINA_API_URL',
+      'string',
+      'Custom Jina API URL (optional). Only needed for custom Jina instances.',
+      '# JINA_API_URL=',
+    ],
+    [
+      'COHERE_API_KEY',
+      'string',
+      'API key for Cohere reranker service. Get your key from https://dashboard.cohere.com/welcome/login',
+      '# COHERE_API_KEY=',
+    ],
   ]}
 />
 
 **Note**: These variable names can be customized in your `librechat.yaml` configuration file. For example, you could use `CUSTOM_SERPER_KEY` instead of `SERPER_API_KEY` by configuring it in the web search settings. See the [Web Search Configuration](/docs/configuration/librechat_yaml/object_structure/web_search) documentation for details on customizing variable names.
 
 ### Anthropic
+
 see: [Anthropic Endpoint](/docs/configuration/pre_configured_ai/anthropic)
+
 - You can request an access key from https://platform.claude.com/
 - Leave `ANTHROPIC_API_KEY=` blank to disable this endpoint
 - Set `ANTHROPIC_API_KEY=` to "user_provided" to allow users to provide their own API key from the WebUI
 - If you have access to a reverse proxy for `Anthropic`, you can set it with `ANTHROPIC_REVERSE_PROXY=`
-    - leave blank or comment it out to use default base url
+  - leave blank or comment it out to use default base url
 
 <OptionTable
   options={[
-    ['ANTHROPIC_API_KEY', 'string', 'Anthropic API key or "user_provided" to allow users to provide their own API key.', 'Defaults to an empty string.'],
-    ['ANTHROPIC_MODELS', 'string', 'Comma-separated list of Anthropic models to use.', '# ANTHROPIC_MODELS=claude-3-opus-20240229,claude-3-sonnet-20240229,claude-3-haiku-20240307,claude-2.1,claude-2,claude-1.2,claude-1,claude-1-100k,claude-instant-1,claude-instant-1-100k'],
-    ['ANTHROPIC_REVERSE_PROXY', 'string', 'Reverse proxy for Anthropic.', '# ANTHROPIC_REVERSE_PROXY='],
-    ['ANTHROPIC_TITLE_MODEL', 'string', 'DEPRECATED: Model to use for titling with Anthropic.', '# ANTHROPIC_TITLE_MODEL=claude-3-haiku-20240307'],
+    [
+      'ANTHROPIC_API_KEY',
+      'string',
+      'Anthropic API key or "user_provided" to allow users to provide their own API key.',
+      'Defaults to an empty string.',
+    ],
+    [
+      'ANTHROPIC_MODELS',
+      'string',
+      'Comma-separated list of Anthropic models to use.',
+      '# ANTHROPIC_MODELS=claude-3-opus-20240229,claude-3-sonnet-20240229,claude-3-haiku-20240307,claude-2.1,claude-2,claude-1.2,claude-1,claude-1-100k,claude-instant-1,claude-instant-1-100k',
+    ],
+    [
+      'ANTHROPIC_REVERSE_PROXY',
+      'string',
+      'Reverse proxy for Anthropic.',
+      '# ANTHROPIC_REVERSE_PROXY=',
+    ],
+    [
+      'ANTHROPIC_TITLE_MODEL',
+      'string',
+      'DEPRECATED: Model to use for titling with Anthropic.',
+      '# ANTHROPIC_TITLE_MODEL=claude-3-haiku-20240307',
+    ],
   ]}
 />
 
@@ -356,8 +575,18 @@ You can also use Anthropic Claude models through Google Cloud Vertex AI. For det
 
 <OptionTable
   options={[
-    ['ANTHROPIC_USE_VERTEX', 'boolean', 'Set to true to use Anthropic models through Google Vertex AI instead of direct API.', 'ANTHROPIC_USE_VERTEX=true'],
-    ['ANTHROPIC_VERTEX_REGION', 'string', 'The Google Cloud region for Vertex AI. Default: us-east5.', 'ANTHROPIC_VERTEX_REGION=us-east5'],
+    [
+      'ANTHROPIC_USE_VERTEX',
+      'boolean',
+      'Set to true to use Anthropic models through Google Vertex AI instead of direct API.',
+      'ANTHROPIC_USE_VERTEX=true',
+    ],
+    [
+      'ANTHROPIC_VERTEX_REGION',
+      'string',
+      'The Google Cloud region for Vertex AI. Default: us-east5.',
+      'ANTHROPIC_VERTEX_REGION=us-east5',
+    ],
   ]}
 />
 
@@ -369,23 +598,59 @@ See: [AWS Bedrock Setup](/docs/configuration/pre_configured_ai/bedrock)
 
 <OptionTable
   options={[
-    ['BEDROCK_AWS_DEFAULT_REGION', 'string', 'A default AWS region must be provided for Bedrock.', 'BEDROCK_AWS_DEFAULT_REGION=us-east-1'],
-    ['BEDROCK_AWS_ACCESS_KEY_ID', 'string', 'AWS access key ID for Bedrock. Optional if using default AWS credentials chain.', '# BEDROCK_AWS_ACCESS_KEY_ID=your_access_key_id'],
-    ['BEDROCK_AWS_SECRET_ACCESS_KEY', 'string', 'AWS secret access key for Bedrock. Optional if using default AWS credentials chain.', '# BEDROCK_AWS_SECRET_ACCESS_KEY=your_secret_access_key'],
-    ['BEDROCK_AWS_SESSION_TOKEN', 'string', 'AWS session token for temporary credentials. Optional.', '# BEDROCK_AWS_SESSION_TOKEN=your_session_token'],
-    ['BEDROCK_AWS_MODELS', 'string', 'Comma-separated list of Bedrock model IDs. If omitted, all known supported models are included.', '# BEDROCK_AWS_MODELS=anthropic.claude-3-5-sonnet-20240620-v1:0,meta.llama3-1-8b-instruct-v1:0'],
+    [
+      'BEDROCK_AWS_DEFAULT_REGION',
+      'string',
+      'A default AWS region must be provided for Bedrock.',
+      'BEDROCK_AWS_DEFAULT_REGION=us-east-1',
+    ],
+    [
+      'BEDROCK_AWS_ACCESS_KEY_ID',
+      'string',
+      'AWS access key ID for Bedrock. Optional if using default AWS credentials chain.',
+      '# BEDROCK_AWS_ACCESS_KEY_ID=your_access_key_id',
+    ],
+    [
+      'BEDROCK_AWS_SECRET_ACCESS_KEY',
+      'string',
+      'AWS secret access key for Bedrock. Optional if using default AWS credentials chain.',
+      '# BEDROCK_AWS_SECRET_ACCESS_KEY=your_secret_access_key',
+    ],
+    [
+      'BEDROCK_AWS_SESSION_TOKEN',
+      'string',
+      'AWS session token for temporary credentials. Optional.',
+      '# BEDROCK_AWS_SESSION_TOKEN=your_session_token',
+    ],
+    [
+      'BEDROCK_AWS_MODELS',
+      'string',
+      'Comma-separated list of Bedrock model IDs. If omitted, all known supported models are included.',
+      '# BEDROCK_AWS_MODELS=anthropic.claude-3-5-sonnet-20240620-v1:0,meta.llama3-1-8b-instruct-v1:0',
+    ],
   ]}
 />
 
 > **Note:** You can omit the access keys to use the default AWS credentials chain (environment variables, SSO credentials, shared credentials files, or EC2/ECS Instance Metadata Service). See [AWS Bedrock Setup](/docs/configuration/pre_configured_ai/bedrock) for more details.
 
 ### BingAI
+
 Bing, also used for Sydney, jailbreak, and Bing Image Creator
 
 <OptionTable
   options={[
-    ['BINGAI_TOKEN', 'string', 'Bing access token. Leave blank to disable. Can be set to "user_provided" to allow users to provide their own token from the WebUI.', 'BINGAI_TOKEN=user_provided'],
-    ['BINGAI_HOST', 'string', 'Bing host URL. Leave commented out to use default server.', '# BINGAI_HOST=https://cn.bing.com'],
+    [
+      'BINGAI_TOKEN',
+      'string',
+      'Bing access token. Leave blank to disable. Can be set to "user_provided" to allow users to provide their own token from the WebUI.',
+      'BINGAI_TOKEN=user_provided',
+    ],
+    [
+      'BINGAI_HOST',
+      'string',
+      'Bing host URL. Leave commented out to use default server.',
+      '# BINGAI_HOST=https://cn.bing.com',
+    ],
   ]}
 />
 
@@ -397,21 +662,91 @@ Follow these instructions to setup the [Google Endpoint](/docs/configuration/pre
 
 <OptionTable
   options={[
-    ['GOOGLE_KEY', 'string', 'Google API key. Set to "user_provided" to allow users to provide their own API key from the WebUI.', 'GOOGLE_KEY=user_provided'],
-    ['GOOGLE_SERVICE_KEY_FILE', 'string', 'Path to Google service account JSON key file, URL to fetch it from, or stringified JSON. Used for Vertex AI authentication (e.g., OCR features).', 'GOOGLE_SERVICE_KEY_FILE=/path/to/auth.json'],
+    [
+      'GOOGLE_KEY',
+      'string',
+      'Google API key. Set to "user_provided" to allow users to provide their own API key from the WebUI.',
+      'GOOGLE_KEY=user_provided',
+    ],
+    [
+      'GOOGLE_SERVICE_KEY_FILE',
+      'string',
+      'Path to Google service account JSON key file, URL to fetch it from, or stringified JSON. Used for Vertex AI authentication (e.g., OCR features).',
+      'GOOGLE_SERVICE_KEY_FILE=/path/to/auth.json',
+    ],
     ['GOOGLE_REVERSE_PROXY', 'string', 'Google reverse proxy URL.', 'GOOGLE_REVERSE_PROXY='],
-    ['GOOGLE_AUTH_HEADER', 'boolean', 'Use Authorization header instead of X-goog-api-key. Some reverse proxies require this.', '# GOOGLE_AUTH_HEADER=true'],
-    ['GOOGLE_MODELS', 'string', 'Available Gemini API Google models, separated by commas.', 'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite'],
-    ['GOOGLE_MODELS', 'string', 'Available Vertex AI Google models, separated by commas.', 'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001'],
-    ['GOOGLE_TITLE_MODEL', 'string', 'DEPRECATED: The model used for titling with Google.', 'GOOGLE_TITLE_MODEL=gemini-pro'],
-    ['GOOGLE_LOC', 'string', 'Specifies the Google Cloud location for processing API requests', 'GOOGLE_LOC=us-central1'],
-    ['GOOGLE_CLOUD_LOCATION', 'string', 'Alternative region for Gemini Image Generation (e.g., global).', '# GOOGLE_CLOUD_LOCATION=global'],
-    ['GOOGLE_EXCLUDE_SAFETY_SETTINGS', 'string', 'Completely omit the safety settings that are included by default, which will use provider defaults', 'GOOGLE_EXCLUDE_SAFETY_SETTINGS=true'],
-    ['GOOGLE_SAFETY_SEXUALLY_EXPLICIT', 'string', 'Safety setting for sexually explicit content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', 'GOOGLE_SAFETY_SEXUALLY_EXPLICIT=BLOCK_ONLY_HIGH'],
-    ['GOOGLE_SAFETY_HATE_SPEECH', 'string', 'Safety setting for hate speech content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', 'GOOGLE_SAFETY_HATE_SPEECH=BLOCK_ONLY_HIGH'],
-    ['GOOGLE_SAFETY_HARASSMENT', 'string', 'Safety setting for harassment content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', 'GOOGLE_SAFETY_HARASSMENT=BLOCK_ONLY_HIGH'],
-    ['GOOGLE_SAFETY_DANGEROUS_CONTENT', 'string', 'Safety setting for dangerous content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', 'GOOGLE_SAFETY_DANGEROUS_CONTENT=BLOCK_ONLY_HIGH'],
-    ['GOOGLE_SAFETY_CIVIC_INTEGRITY', 'string', 'Safety setting for civic integrity content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.', '# GOOGLE_SAFETY_CIVIC_INTEGRITY=BLOCK_ONLY_HIGH'],
+    [
+      'GOOGLE_AUTH_HEADER',
+      'boolean',
+      'Use Authorization header instead of X-goog-api-key. Some reverse proxies require this.',
+      '# GOOGLE_AUTH_HEADER=true',
+    ],
+    [
+      'GOOGLE_MODELS',
+      'string',
+      'Available Gemini API Google models, separated by commas.',
+      'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite',
+    ],
+    [
+      'GOOGLE_MODELS',
+      'string',
+      'Available Vertex AI Google models, separated by commas.',
+      'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001',
+    ],
+    [
+      'GOOGLE_TITLE_MODEL',
+      'string',
+      'DEPRECATED: The model used for titling with Google.',
+      'GOOGLE_TITLE_MODEL=gemini-pro',
+    ],
+    [
+      'GOOGLE_LOC',
+      'string',
+      'Specifies the Google Cloud location for processing API requests',
+      'GOOGLE_LOC=us-central1',
+    ],
+    [
+      'GOOGLE_CLOUD_LOCATION',
+      'string',
+      'Alternative region for Gemini Image Generation (e.g., global).',
+      '# GOOGLE_CLOUD_LOCATION=global',
+    ],
+    [
+      'GOOGLE_EXCLUDE_SAFETY_SETTINGS',
+      'string',
+      'Completely omit the safety settings that are included by default, which will use provider defaults',
+      'GOOGLE_EXCLUDE_SAFETY_SETTINGS=true',
+    ],
+    [
+      'GOOGLE_SAFETY_SEXUALLY_EXPLICIT',
+      'string',
+      'Safety setting for sexually explicit content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.',
+      'GOOGLE_SAFETY_SEXUALLY_EXPLICIT=BLOCK_ONLY_HIGH',
+    ],
+    [
+      'GOOGLE_SAFETY_HATE_SPEECH',
+      'string',
+      'Safety setting for hate speech content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.',
+      'GOOGLE_SAFETY_HATE_SPEECH=BLOCK_ONLY_HIGH',
+    ],
+    [
+      'GOOGLE_SAFETY_HARASSMENT',
+      'string',
+      'Safety setting for harassment content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.',
+      'GOOGLE_SAFETY_HARASSMENT=BLOCK_ONLY_HIGH',
+    ],
+    [
+      'GOOGLE_SAFETY_DANGEROUS_CONTENT',
+      'string',
+      'Safety setting for dangerous content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.',
+      'GOOGLE_SAFETY_DANGEROUS_CONTENT=BLOCK_ONLY_HIGH',
+    ],
+    [
+      'GOOGLE_SAFETY_CIVIC_INTEGRITY',
+      'string',
+      'Safety setting for civic integrity content. Options are BLOCK_ALL, BLOCK_ONLY_HIGH, WARN_ONLY, and OFF.',
+      '# GOOGLE_SAFETY_CIVIC_INTEGRITY=BLOCK_ONLY_HIGH',
+    ],
   ]}
 />
 
@@ -420,9 +755,10 @@ Customize the available models, separated by commas, **without spaces**. The fir
 - `GOOGLE_TITLE_MODEL` is now deprecated and will be removed in future versions. Use the [`titleModel` Endpoint Setting](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings#titlemodel) instead in the `librechat.yaml` config instead.
 
 **Note:** For the Vertex AI `GOOGLE_SAFETY` variables, you do not have access to the `BLOCK_NONE` setting by default. To use this restricted `HarmBlockThreshold` setting, you will need to either:
+
 - (a) Get access through an allowlist via your Google account team
 - (b) Switch your account type to monthly invoiced billing following this instruction:
-    https://cloud.google.com/billing/docs/how-to/invoiced-billing
+  https://cloud.google.com/billing/docs/how-to/invoiced-billing
 
 #### Gemini Image Generation
 
@@ -430,8 +766,18 @@ Gemini Image Generation is a tool for Agents that supports both the Gemini API a
 
 <OptionTable
   options={[
-    ['GEMINI_API_KEY', 'string', 'Dedicated Gemini API key for image generation. Falls back to GOOGLE_KEY if not set.', '# GEMINI_API_KEY=your_gemini_api_key'],
-    ['GEMINI_IMAGE_MODEL', 'string', 'Gemini model for image generation. Default: gemini-2.5-flash-image.', '# GEMINI_IMAGE_MODEL=gemini-2.5-flash-image'],
+    [
+      'GEMINI_API_KEY',
+      'string',
+      'Dedicated Gemini API key for image generation. Falls back to GOOGLE_KEY if not set.',
+      '# GEMINI_API_KEY=your_gemini_api_key',
+    ],
+    [
+      'GEMINI_IMAGE_MODEL',
+      'string',
+      'Gemini model for image generation. Default: gemini-2.5-flash-image.',
+      '# GEMINI_IMAGE_MODEL=gemini-2.5-flash-image',
+    ],
   ]}
 />
 
@@ -443,15 +789,55 @@ See: [OpenAI Setup](/docs/configuration/pre_configured_ai/openai)
 
 <OptionTable
   options={[
-    ['OPENAI_API_KEY', 'string', 'Your OpenAI API key. Leave blank to disable this endpoint or set to "user_provided" to allow users to provide their own API key from the WebUI.', 'OPENAI_API_KEY=user_provided'],
-    ['OPENAI_MODELS', 'string', 'Customize the available models, separated by commas, without spaces. The first will be default. Leave commented out to use internal settings.', '# OPENAI_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k'],
+    [
+      'OPENAI_API_KEY',
+      'string',
+      'Your OpenAI API key. Leave blank to disable this endpoint or set to "user_provided" to allow users to provide their own API key from the WebUI.',
+      'OPENAI_API_KEY=user_provided',
+    ],
+    [
+      'OPENAI_MODELS',
+      'string',
+      'Customize the available models, separated by commas, without spaces. The first will be default. Leave commented out to use internal settings.',
+      '# OPENAI_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k',
+    ],
     ['DEBUG_OPENAI', 'boolean', 'Enable debug mode for the OpenAI endpoint.', 'DEBUG_OPENAI=false'],
-    ['OPENAI_SUMMARIZE', 'boolean', 'Enable message summarization. False by default', '# OPENAI_SUMMARIZE=true'],
-    ['OPENAI_SUMMARY_MODEL', 'string', 'The model used for OpenAI summarization.', '# OPENAI_SUMMARY_MODEL=gpt-3.5-turbo'],
-    ['OPENAI_FORCE_PROMPT', 'boolean', 'Force the API to be called with a prompt payload instead of a messages payload.', '# OPENAI_FORCE_PROMPT=false'],
-    ['OPENAI_ORGANIZATION', 'string', 'Specify which organization to use for each API request to OpenAI. Optional', '# OPENAI_ORGANIZATION='],
-    ['OPENAI_REVERSE_PROXY', 'string', 'DEPRECATED: Reverse proxy settings for OpenAI.', '# OPENAI_REVERSE_PROXY='],
-    ['OPENAI_TITLE_MODEL', 'string', 'DEPRECATED: The model used for OpenAI titling.', '# OPENAI_TITLE_MODEL=gpt-3.5-turbo'],
+    [
+      'OPENAI_SUMMARIZE',
+      'boolean',
+      'Enable message summarization. False by default',
+      '# OPENAI_SUMMARIZE=true',
+    ],
+    [
+      'OPENAI_SUMMARY_MODEL',
+      'string',
+      'The model used for OpenAI summarization.',
+      '# OPENAI_SUMMARY_MODEL=gpt-3.5-turbo',
+    ],
+    [
+      'OPENAI_FORCE_PROMPT',
+      'boolean',
+      'Force the API to be called with a prompt payload instead of a messages payload.',
+      '# OPENAI_FORCE_PROMPT=false',
+    ],
+    [
+      'OPENAI_ORGANIZATION',
+      'string',
+      'Specify which organization to use for each API request to OpenAI. Optional',
+      '# OPENAI_ORGANIZATION=',
+    ],
+    [
+      'OPENAI_REVERSE_PROXY',
+      'string',
+      'DEPRECATED: Reverse proxy settings for OpenAI.',
+      '# OPENAI_REVERSE_PROXY=',
+    ],
+    [
+      'OPENAI_TITLE_MODEL',
+      'string',
+      'DEPRECATED: The model used for OpenAI titling.',
+      '# OPENAI_TITLE_MODEL=gpt-3.5-turbo',
+    ],
   ]}
 />
 
@@ -464,9 +850,24 @@ See: [Assistants Setup](/docs/configuration/pre_configured_ai/assistants)
 
 <OptionTable
   options={[
-    ['ASSISTANTS_API_KEY', 'string', 'Your OpenAI API key for Assistants API. Leave blank to disable this endpoint or set to "user_provided" to allow users to provide their own API key from the WebUI.', 'ASSISTANTS_API_KEY=user_provided'],
-    ['ASSISTANTS_MODELS', 'string', 'Customize the available models, separated by commas, without spaces. The first will be default. Leave blank to use internal settings.', '# ASSISTANTS_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-16k-0613,gpt-3.5-turbo-16k,gpt-3.5-turbo,gpt-4,gpt-4-0314,gpt-4-32k-0314,gpt-4-0613,gpt-3.5-turbo-0613,gpt-3.5-turbo-1106,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview'],
-    ['ASSISTANTS_BASE_URL', 'string', 'Alternate base URL for Assistants API.', '# ASSISTANTS_BASE_URL='],
+    [
+      'ASSISTANTS_API_KEY',
+      'string',
+      'Your OpenAI API key for Assistants API. Leave blank to disable this endpoint or set to "user_provided" to allow users to provide their own API key from the WebUI.',
+      'ASSISTANTS_API_KEY=user_provided',
+    ],
+    [
+      'ASSISTANTS_MODELS',
+      'string',
+      'Customize the available models, separated by commas, without spaces. The first will be default. Leave blank to use internal settings.',
+      '# ASSISTANTS_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-16k-0613,gpt-3.5-turbo-16k,gpt-3.5-turbo,gpt-4,gpt-4-0314,gpt-4-32k-0314,gpt-4-0613,gpt-3.5-turbo-0613,gpt-3.5-turbo-1106,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview',
+    ],
+    [
+      'ASSISTANTS_BASE_URL',
+      'string',
+      'Alternate base URL for Assistants API.',
+      '# ASSISTANTS_BASE_URL=',
+    ],
   ]}
 />
 
@@ -478,10 +879,7 @@ Get your API key here: **[https://tavily.com/#api](https://tavily.com/#api)**
 
 **Environment Variables:**
 
-<OptionTable
-  options={[    ['TAVILY_API_KEY', 'string', 'Tavily API key.','TAVILY_API_KEY='],
-  ]}
-/>
+<OptionTable options={[['TAVILY_API_KEY', 'string', 'Tavily API key.', 'TAVILY_API_KEY=']]} />
 
 ### Traversaal
 
@@ -492,9 +890,7 @@ Get API key here: **https://api.traversaal.ai/dashboard**
 **Environment Variables:**
 
 <OptionTable
-  options={[
-    ['TRAVERSAAL_API_KEY', 'string', 'Traversaal API key.','TRAVERSAAL_API_KEY='],
-  ]}
+  options={[['TRAVERSAAL_API_KEY', 'string', 'Traversaal API key.', 'TRAVERSAAL_API_KEY=']]}
 />
 
 ### WolframAlpha
@@ -503,15 +899,12 @@ See detailed instructions here: **[Wolfram Alpha](/docs/configuration/tools/wolf
 
 **Environment Variables:**
 
-<OptionTable
-  options={[
-    ['WOLFRAM_APP_ID', 'string', 'Wolfram Alpha App ID.','WOLFRAM_APP_ID='],
-  ]}
-/>
+<OptionTable options={[['WOLFRAM_APP_ID', 'string', 'Wolfram Alpha App ID.', 'WOLFRAM_APP_ID=']]} />
 
 ### Zapier
 
 **Description:** - You need a Zapier account. Get your API key from here: **[Zapier](https://nla.zapier.com/credentials/)**
+
 - Create allowed actions - Follow step 3 in this getting start guide from Zapier
 
 **Note:** Zapier is known to be finicky with certain actions. Writing email drafts is probably the best use of it.
@@ -519,9 +912,7 @@ See detailed instructions here: **[Wolfram Alpha](/docs/configuration/tools/wolf
 **Environment Variables:**
 
 <OptionTable
-  options={[
-    ['ZAPIER_NLA_API_KEY', 'string', 'Zapier NLA API key.','ZAPIER_NLA_API_KEY='],
-  ]}
+  options={[['ZAPIER_NLA_API_KEY', 'string', 'Zapier NLA API key.', 'ZAPIER_NLA_API_KEY=']]}
 />
 
 ### OpenWeather
@@ -530,7 +921,12 @@ See detailed instructions here: **[OpenWeather](/docs/configuration/tools/openwe
 
 <OptionTable
   options={[
-    ['OPENWEATHER_API_KEY', 'string', 'OpenWeather API key for the One Call API 3.0.','OPENWEATHER_API_KEY='],
+    [
+      'OPENWEATHER_API_KEY',
+      'string',
+      'OpenWeather API key for the One Call API 3.0.',
+      'OPENWEATHER_API_KEY=',
+    ],
   ]}
 />
 
@@ -540,8 +936,18 @@ The Code Interpreter API provides a secure environment for executing code and ma
 
 <OptionTable
   options={[
-    ['LIBRECHAT_CODE_API_KEY', 'string', 'API key for the Code Interpreter service. When set globally, provides access to all users.', 'LIBRECHAT_CODE_API_KEY=your-api-key'],
-    ['LIBRECHAT_CODE_BASEURL', 'string', 'Custom base URL for the Code Interpreter API (Enterprise plans only).', '# LIBRECHAT_CODE_BASEURL=https://your-custom-domain.com'],
+    [
+      'LIBRECHAT_CODE_API_KEY',
+      'string',
+      'API key for the Code Interpreter service. When set globally, provides access to all users.',
+      'LIBRECHAT_CODE_API_KEY=your-api-key',
+    ],
+    [
+      'LIBRECHAT_CODE_BASEURL',
+      'string',
+      'Custom base URL for the Code Interpreter API (Enterprise plans only).',
+      '# LIBRECHAT_CODE_BASEURL=https://your-custom-domain.com',
+    ],
   ]}
 />
 
@@ -555,7 +961,12 @@ For more info, including pre-made container images for self-hosting with metric 
 
 <OptionTable
   options={[
-    ['SANDPACK_BUNDLER_URL', 'string', 'Specifies a custom bundler URL for Sandpack, used by Artifacts','SANDPACK_BUNDLER_URL=your-bundler-url'],
+    [
+      'SANDPACK_BUNDLER_URL',
+      'string',
+      'Specifies a custom bundler URL for Sandpack, used by Artifacts',
+      'SANDPACK_BUNDLER_URL=your-bundler-url',
+    ],
   ]}
 />
 
@@ -564,9 +975,7 @@ For more info, including pre-made container images for self-hosting with metric 
 Enables search in messages and conversations:
 
 <OptionTable
-  options={[
-    ['SEARCH', 'boolean', 'Enables search in messages and conversations.','SEARCH=true'],
-  ]}
+  options={[['SEARCH', 'boolean', 'Enables search in messages and conversations.', 'SEARCH=true']]}
 />
 
 > Note: If you're not using docker, it requires the installation of the free self-hosted Meilisearch or a paid remote plan
@@ -575,7 +984,12 @@ To disable anonymized telemetry analytics for MeiliSearch for absolute privacy, 
 
 <OptionTable
   options={[
-    ['MEILI_NO_ANALYTICS', 'boolean', 'Disables anonymized telemetry analytics for MeiliSearch.','MEILI_NO_ANALYTICS=true'],
+    [
+      'MEILI_NO_ANALYTICS',
+      'boolean',
+      'Disables anonymized telemetry analytics for MeiliSearch.',
+      'MEILI_NO_ANALYTICS=true',
+    ],
   ]}
 />
 
@@ -583,7 +997,12 @@ For the API server to connect to the search server. Replace '0.0.0.0' with 'meil
 
 <OptionTable
   options={[
-    ['MEILI_HOST', 'string', 'The API server connection to the search server.','MEILI_HOST=http://0.0.0.0:7700'],
+    [
+      'MEILI_HOST',
+      'string',
+      'The API server connection to the search server.',
+      'MEILI_HOST=http://0.0.0.0:7700',
+    ],
   ]}
 />
 
@@ -591,7 +1010,12 @@ This master key must be at least 16 bytes, composed of valid UTF-8 characters. M
 
 <OptionTable
   options={[
-    ['MEILI_MASTER_KEY', 'string', 'The master key for MeiliSearch.','MEILI_MASTER_KEY=DrhYf7zENyR6AlUCKmnz0eYASOQdl6zxH7s7MKFSfFCt'],
+    [
+      'MEILI_MASTER_KEY',
+      'string',
+      'The master key for MeiliSearch.',
+      'MEILI_MASTER_KEY=DrhYf7zENyR6AlUCKmnz0eYASOQdl6zxH7s7MKFSfFCt',
+    ],
   ]}
 />
 
@@ -599,7 +1023,12 @@ To prevent LibreChat from attempting a database indexing sync with Meilisearch, 
 
 <OptionTable
   options={[
-    ['MEILI_NO_SYNC', 'string', 'Toggle for disabling Mellisearch index sync','MEILI_NO_SYNC=true'],
+    [
+      'MEILI_NO_SYNC',
+      'string',
+      'Toggle for disabling Mellisearch index sync',
+      'MEILI_NO_SYNC=true',
+    ],
   ]}
 />
 
@@ -609,12 +1038,42 @@ Configure Retrieval-Augmented Generation for document indexing and context-aware
 
 <OptionTable
   options={[
-    ['RAG_API_URL', 'string', 'URL of the RAG API service.', 'RAG_API_URL=http://host.docker.internal:8000'],
-    ['RAG_OPENAI_API_KEY', 'string', 'OpenAI API key for RAG embeddings. Overrides OPENAI_API_KEY for RAG.', '# RAG_OPENAI_API_KEY=sk-your-openai-api-key'],
-    ['RAG_OPENAI_BASEURL', 'string', 'Custom OpenAI base URL for RAG embeddings.', '# RAG_OPENAI_BASEURL='],
-    ['RAG_USE_FULL_CONTEXT', 'boolean', 'Fetch entire file context instead of top 4 results. Default: false.', '# RAG_USE_FULL_CONTEXT=true'],
-    ['EMBEDDINGS_PROVIDER', 'string', 'Embeddings provider: openai, azure, huggingface, huggingfacetei, or ollama. Default: openai.', '# EMBEDDINGS_PROVIDER=openai'],
-    ['EMBEDDINGS_MODEL', 'string', 'Embeddings model to use. Default depends on provider.', '# EMBEDDINGS_MODEL=text-embedding-3-small'],
+    [
+      'RAG_API_URL',
+      'string',
+      'URL of the RAG API service.',
+      'RAG_API_URL=http://host.docker.internal:8000',
+    ],
+    [
+      'RAG_OPENAI_API_KEY',
+      'string',
+      'OpenAI API key for RAG embeddings. Overrides OPENAI_API_KEY for RAG.',
+      '# RAG_OPENAI_API_KEY=sk-your-openai-api-key',
+    ],
+    [
+      'RAG_OPENAI_BASEURL',
+      'string',
+      'Custom OpenAI base URL for RAG embeddings.',
+      '# RAG_OPENAI_BASEURL=',
+    ],
+    [
+      'RAG_USE_FULL_CONTEXT',
+      'boolean',
+      'Fetch entire file context instead of top 4 results. Default: false.',
+      '# RAG_USE_FULL_CONTEXT=true',
+    ],
+    [
+      'EMBEDDINGS_PROVIDER',
+      'string',
+      'Embeddings provider: openai, azure, huggingface, huggingfacetei, or ollama. Default: openai.',
+      '# EMBEDDINGS_PROVIDER=openai',
+    ],
+    [
+      'EMBEDDINGS_MODEL',
+      'string',
+      'Embeddings model to use. Default depends on provider.',
+      '# EMBEDDINGS_MODEL=text-embedding-3-small',
+    ],
   ]}
 />
 
@@ -626,8 +1085,18 @@ Configure Speech-to-Text (STT) and Text-to-Speech (TTS) services. See: **[Speech
 
 <OptionTable
   options={[
-    ['STT_API_KEY', 'string', 'API key for Speech-to-Text service (e.g., OpenAI Whisper).', '# STT_API_KEY='],
-    ['TTS_API_KEY', 'string', 'API key for Text-to-Speech service (e.g., OpenAI TTS).', '# TTS_API_KEY='],
+    [
+      'STT_API_KEY',
+      'string',
+      'API key for Speech-to-Text service (e.g., OpenAI Whisper).',
+      '# STT_API_KEY=',
+    ],
+    [
+      'TTS_API_KEY',
+      'string',
+      'API key for Text-to-Speech service (e.g., OpenAI TTS).',
+      '# TTS_API_KEY=',
+    ],
   ]}
 />
 
@@ -639,39 +1108,78 @@ Configure shared conversation links functionality.
 
 <OptionTable
   options={[
-    ['ALLOW_SHARED_LINKS', 'boolean', 'Enable or disable shared conversation links. Default: true.', 'ALLOW_SHARED_LINKS=true'],
-    ['ALLOW_SHARED_LINKS_PUBLIC', 'boolean', 'Allow shared links to be publicly accessible without authentication. Default: false.', 'ALLOW_SHARED_LINKS_PUBLIC=false'],
+    [
+      'ALLOW_SHARED_LINKS',
+      'boolean',
+      'Enable or disable shared conversation links. Default: true.',
+      'ALLOW_SHARED_LINKS=true',
+    ],
+    [
+      'ALLOW_SHARED_LINKS_PUBLIC',
+      'boolean',
+      'Allow shared links to be publicly accessible without authentication. Default: false.',
+      'ALLOW_SHARED_LINKS_PUBLIC=false',
+    ],
   ]}
 />
 
 ## User System
+
 This section contains the configuration for:
 
-  - [Automated Moderation](#moderation)
-  - [Balance/Token Usage](#balance)
-  - [Registration and Social Logins](#registration-and-login)
-  - [Email Password Reset](#email-password-reset)
+- [Automated Moderation](#moderation)
+- [Balance/Token Usage](#balance)
+- [Registration and Social Logins](#registration-and-login)
+- [Email Password Reset](#email-password-reset)
 
 ### Moderation
+
 The Automated Moderation System uses a scoring mechanism to track user violations. As users commit actions like excessive logins, registrations, or messaging, they accumulate violation scores. Upon reaching a set threshold, the user and their IP are temporarily banned. This system ensures platform security by monitoring and penalizing rapid or suspicious activities.
 
 see: **[Automated Moderation](/docs/configuration/mod_system)**
 
 #### Basic Moderation Settings
+
 <OptionTable
   options={[
-    ['OPENAI_MODERATION', 'boolean', 'Whether or not to enable OpenAI moderation on the **OpenAI** and **Plugins** endpoints.','OPENAI_MODERATION=false'],
-    ['OPENAI_MODERATION_API_KEY', 'string', 'Your OpenAI API key.','OPENAI_MODERATION_API_KEY='],
-    ['OPENAI_MODERATION_REVERSE_PROXY', 'string', 'Note: Commented out by default, this is not working with all reverse proxys.','# OPENAI_MODERATION_REVERSE_PROXY='],
+    [
+      'OPENAI_MODERATION',
+      'boolean',
+      'Whether or not to enable OpenAI moderation on the **OpenAI** and **Plugins** endpoints.',
+      'OPENAI_MODERATION=false',
+    ],
+    ['OPENAI_MODERATION_API_KEY', 'string', 'Your OpenAI API key.', 'OPENAI_MODERATION_API_KEY='],
+    [
+      'OPENAI_MODERATION_REVERSE_PROXY',
+      'string',
+      'Note: Commented out by default, this is not working with all reverse proxys.',
+      '# OPENAI_MODERATION_REVERSE_PROXY=',
+    ],
   ]}
 />
 
 #### Banning Settings
+
 <OptionTable
   options={[
-    ['BAN_VIOLATIONS', 'boolean', 'Whether or not to enable banning users for violations (they will still be logged).','BAN_VIOLATIONS=true'],
-    ['BAN_DURATION', 'integer', 'How long the user and associated IP are banned for (in milliseconds).','BAN_DURATION=1000 * 60 * 60 * 2'],
-    ['BAN_INTERVAL', 'integer', 'The user will be banned every time their score reaches/crosses over the interval threshold.','BAN_INTERVAL=20'],
+    [
+      'BAN_VIOLATIONS',
+      'boolean',
+      'Whether or not to enable banning users for violations (they will still be logged).',
+      'BAN_VIOLATIONS=true',
+    ],
+    [
+      'BAN_DURATION',
+      'integer',
+      'How long the user and associated IP are banned for (in milliseconds).',
+      'BAN_DURATION=1000 * 60 * 60 * 2',
+    ],
+    [
+      'BAN_INTERVAL',
+      'integer',
+      'The user will be banned every time their score reaches/crosses over the interval threshold.',
+      'BAN_INTERVAL=20',
+    ],
   ]}
 />
 
@@ -681,43 +1189,143 @@ Prevents brute force attacks and spam registrations by limiting login attempts a
 
 <OptionTable
   options={[
-    ['LOGIN_MAX', 'integer', 'The max amount of logins allowed per IP per LOGIN_WINDOW.','LOGIN_MAX=7'],
-    ['LOGIN_WINDOW', 'integer', 'In minutes, determines the window of time for LOGIN_MAX logins.','LOGIN_WINDOW=5'],
-    ['REGISTER_MAX', 'integer', 'The max amount of registrations allowed per IP per REGISTER_WINDOW.','REGISTER_MAX=5'],
-    ['REGISTER_WINDOW', 'integer', 'In minutes, determines the window of time for REGISTER_MAX registrations.','REGISTER_WINDOW=60'],
+    [
+      'LOGIN_MAX',
+      'integer',
+      'The max amount of logins allowed per IP per LOGIN_WINDOW.',
+      'LOGIN_MAX=7',
+    ],
+    [
+      'LOGIN_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for LOGIN_MAX logins.',
+      'LOGIN_WINDOW=5',
+    ],
+    [
+      'REGISTER_MAX',
+      'integer',
+      'The max amount of registrations allowed per IP per REGISTER_WINDOW.',
+      'REGISTER_MAX=5',
+    ],
+    [
+      'REGISTER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for REGISTER_MAX registrations.',
+      'REGISTER_WINDOW=60',
+    ],
   ]}
 />
 
 #### Score for each violation
+
 <OptionTable
   options={[
-    ['LOGIN_VIOLATION_SCORE', 'integer', 'Score for login violations.','LOGIN_VIOLATION_SCORE=1'],
-    ['REGISTRATION_VIOLATION_SCORE', 'integer', 'Score for registration violations.','REGISTRATION_VIOLATION_SCORE=1'],
-    ['CONCURRENT_VIOLATION_SCORE', 'integer', 'Score for concurrent violations.','CONCURRENT_VIOLATION_SCORE=1'],
-    ['MESSAGE_VIOLATION_SCORE', 'integer', 'Score for message violations.','MESSAGE_VIOLATION_SCORE=1'],
-    ['NON_BROWSER_VIOLATION_SCORE', 'integer', 'Score for non-browser violations.','NON_BROWSER_VIOLATION_SCORE=20'],
-    ['ILLEGAL_MODEL_REQ_SCORE', 'integer', 'Score for illegal model requests.','ILLEGAL_MODEL_REQ_SCORE=5'],
-    ['IMPORT_VIOLATION_SCORE', 'integer', 'Score for import conversation violations.','IMPORT_VIOLATION_SCORE=1'],
-    ['FORK_VIOLATION_SCORE', 'integer', 'Score for conversation fork violations.','FORK_VIOLATION_SCORE=1'],
-    ['TTS_VIOLATION_SCORE', 'integer', 'Score for text-to-speech violations.','TTS_VIOLATION_SCORE=0'],
-    ['STT_VIOLATION_SCORE', 'integer', 'Score for speech-to-text violations.','STT_VIOLATION_SCORE=0'],
-    ['FILE_UPLOAD_VIOLATION_SCORE', 'integer', 'Score for file upload violations.','FILE_UPLOAD_VIOLATION_SCORE=0'],
-    ['RESET_PASSWORD_VIOLATION_SCORE', 'integer', 'Score for password reset violations.','RESET_PASSWORD_VIOLATION_SCORE=0'],
-    ['VERIFY_EMAIL_VIOLATION_SCORE', 'integer', 'Score for email verification violations.','VERIFY_EMAIL_VIOLATION_SCORE=0'],
-    ['TOOL_CALL_VIOLATION_SCORE', 'integer', 'Score for tool call violations.','TOOL_CALL_VIOLATION_SCORE=0'],
-    ['CONVO_ACCESS_VIOLATION_SCORE', 'integer', 'Score for conversation access violations.','CONVO_ACCESS_VIOLATION_SCORE=0'],
+    ['LOGIN_VIOLATION_SCORE', 'integer', 'Score for login violations.', 'LOGIN_VIOLATION_SCORE=1'],
+    [
+      'REGISTRATION_VIOLATION_SCORE',
+      'integer',
+      'Score for registration violations.',
+      'REGISTRATION_VIOLATION_SCORE=1',
+    ],
+    [
+      'CONCURRENT_VIOLATION_SCORE',
+      'integer',
+      'Score for concurrent violations.',
+      'CONCURRENT_VIOLATION_SCORE=1',
+    ],
+    [
+      'MESSAGE_VIOLATION_SCORE',
+      'integer',
+      'Score for message violations.',
+      'MESSAGE_VIOLATION_SCORE=1',
+    ],
+    [
+      'NON_BROWSER_VIOLATION_SCORE',
+      'integer',
+      'Score for non-browser violations.',
+      'NON_BROWSER_VIOLATION_SCORE=20',
+    ],
+    [
+      'ILLEGAL_MODEL_REQ_SCORE',
+      'integer',
+      'Score for illegal model requests.',
+      'ILLEGAL_MODEL_REQ_SCORE=5',
+    ],
+    [
+      'IMPORT_VIOLATION_SCORE',
+      'integer',
+      'Score for import conversation violations.',
+      'IMPORT_VIOLATION_SCORE=1',
+    ],
+    [
+      'FORK_VIOLATION_SCORE',
+      'integer',
+      'Score for conversation fork violations.',
+      'FORK_VIOLATION_SCORE=1',
+    ],
+    [
+      'TTS_VIOLATION_SCORE',
+      'integer',
+      'Score for text-to-speech violations.',
+      'TTS_VIOLATION_SCORE=0',
+    ],
+    [
+      'STT_VIOLATION_SCORE',
+      'integer',
+      'Score for speech-to-text violations.',
+      'STT_VIOLATION_SCORE=0',
+    ],
+    [
+      'FILE_UPLOAD_VIOLATION_SCORE',
+      'integer',
+      'Score for file upload violations.',
+      'FILE_UPLOAD_VIOLATION_SCORE=0',
+    ],
+    [
+      'RESET_PASSWORD_VIOLATION_SCORE',
+      'integer',
+      'Score for password reset violations.',
+      'RESET_PASSWORD_VIOLATION_SCORE=0',
+    ],
+    [
+      'VERIFY_EMAIL_VIOLATION_SCORE',
+      'integer',
+      'Score for email verification violations.',
+      'VERIFY_EMAIL_VIOLATION_SCORE=0',
+    ],
+    [
+      'TOOL_CALL_VIOLATION_SCORE',
+      'integer',
+      'Score for tool call violations.',
+      'TOOL_CALL_VIOLATION_SCORE=0',
+    ],
+    [
+      'CONVO_ACCESS_VIOLATION_SCORE',
+      'integer',
+      'Score for conversation access violations.',
+      'CONVO_ACCESS_VIOLATION_SCORE=0',
+    ],
   ]}
 />
 
 > Note: Non-browser access and Illegal model requests are almost always nefarious as it means a 3rd party is attempting to access the server through an automated script.
 
-
 #### Message rate limiting (per user & IP)
 
 <OptionTable
   options={[
-    ['LIMIT_CONCURRENT_MESSAGES', 'boolean', 'Whether to limit the amount of messages a user can send per request.','LIMIT_CONCURRENT_MESSAGES=true'],
-    ['CONCURRENT_MESSAGE_MAX', 'integer', 'The max amount of messages a user can send per request.','CONCURRENT_MESSAGE_MAX=2'],
+    [
+      'LIMIT_CONCURRENT_MESSAGES',
+      'boolean',
+      'Whether to limit the amount of messages a user can send per request.',
+      'LIMIT_CONCURRENT_MESSAGES=true',
+    ],
+    [
+      'CONCURRENT_MESSAGE_MAX',
+      'integer',
+      'The max amount of messages a user can send per request.',
+      'CONCURRENT_MESSAGE_MAX=2',
+    ],
   ]}
 />
 
@@ -729,9 +1337,24 @@ Prevents brute force attacks and spam registrations by limiting login attempts a
 
 <OptionTable
   options={[
-    ['LIMIT_MESSAGE_IP', 'boolean', 'Whether to limit the amount of messages an IP can send per `MESSAGE_IP_WINDOW`.','LIMIT_MESSAGE_IP=true'],
-    ['MESSAGE_IP_MAX', 'integer', 'The max amount of messages an IP can send per `MESSAGE_IP_WINDOW`.','MESSAGE_IP_MAX=40'],
-    ['MESSAGE_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `MESSAGE_IP_MAX` messages.','MESSAGE_IP_WINDOW=1'],
+    [
+      'LIMIT_MESSAGE_IP',
+      'boolean',
+      'Whether to limit the amount of messages an IP can send per `MESSAGE_IP_WINDOW`.',
+      'LIMIT_MESSAGE_IP=true',
+    ],
+    [
+      'MESSAGE_IP_MAX',
+      'integer',
+      'The max amount of messages an IP can send per `MESSAGE_IP_WINDOW`.',
+      'MESSAGE_IP_MAX=40',
+    ],
+    [
+      'MESSAGE_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `MESSAGE_IP_MAX` messages.',
+      'MESSAGE_IP_WINDOW=1',
+    ],
   ]}
 />
 
@@ -739,9 +1362,24 @@ Prevents brute force attacks and spam registrations by limiting login attempts a
 
 <OptionTable
   options={[
-    ['LIMIT_MESSAGE_USER', 'boolean', 'Whether to limit the amount of messages an user can send per `MESSAGE_USER_WINDOW`.','LIMIT_MESSAGE_USER=false'],
-    ['MESSAGE_USER_MAX', 'integer', 'The max amount of messages an user can send per `MESSAGE_USER_WINDOW`.','MESSAGE_USER_MAX=40'],
-    ['MESSAGE_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `MESSAGE_USER_MAX` messages.','MESSAGE_USER_WINDOW=1'],
+    [
+      'LIMIT_MESSAGE_USER',
+      'boolean',
+      'Whether to limit the amount of messages an user can send per `MESSAGE_USER_WINDOW`.',
+      'LIMIT_MESSAGE_USER=false',
+    ],
+    [
+      'MESSAGE_USER_MAX',
+      'integer',
+      'The max amount of messages an user can send per `MESSAGE_USER_WINDOW`.',
+      'MESSAGE_USER_MAX=40',
+    ],
+    [
+      'MESSAGE_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `MESSAGE_USER_MAX` messages.',
+      'MESSAGE_USER_WINDOW=1',
+    ],
   ]}
 />
 
@@ -755,9 +1393,24 @@ Limits how often users can import conversations to prevent abuse.
 
 <OptionTable
   options={[
-    ['LIMIT_IMPORT_IP', 'boolean', 'Whether to limit the amount of conversation imports an IP can perform per `IMPORT_IP_WINDOW`.','LIMIT_IMPORT_IP=true'],
-    ['IMPORT_IP_MAX', 'integer', 'The max amount of conversation imports an IP can perform per `IMPORT_IP_WINDOW`.','IMPORT_IP_MAX=100'],
-    ['IMPORT_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `IMPORT_IP_MAX` imports.','IMPORT_IP_WINDOW=1'],
+    [
+      'LIMIT_IMPORT_IP',
+      'boolean',
+      'Whether to limit the amount of conversation imports an IP can perform per `IMPORT_IP_WINDOW`.',
+      'LIMIT_IMPORT_IP=true',
+    ],
+    [
+      'IMPORT_IP_MAX',
+      'integer',
+      'The max amount of conversation imports an IP can perform per `IMPORT_IP_WINDOW`.',
+      'IMPORT_IP_MAX=100',
+    ],
+    [
+      'IMPORT_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `IMPORT_IP_MAX` imports.',
+      'IMPORT_IP_WINDOW=1',
+    ],
   ]}
 />
 
@@ -765,9 +1418,24 @@ Limits how often users can import conversations to prevent abuse.
 
 <OptionTable
   options={[
-    ['LIMIT_IMPORT_USER', 'boolean', 'Whether to limit the amount of conversation imports a user can perform per `IMPORT_USER_WINDOW`.','LIMIT_IMPORT_USER=false'],
-    ['IMPORT_USER_MAX', 'integer', 'The max amount of conversation imports a user can perform per `IMPORT_USER_WINDOW`.','IMPORT_USER_MAX=50'],
-    ['IMPORT_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `IMPORT_USER_MAX` imports.','IMPORT_USER_WINDOW=1'],
+    [
+      'LIMIT_IMPORT_USER',
+      'boolean',
+      'Whether to limit the amount of conversation imports a user can perform per `IMPORT_USER_WINDOW`.',
+      'LIMIT_IMPORT_USER=false',
+    ],
+    [
+      'IMPORT_USER_MAX',
+      'integer',
+      'The max amount of conversation imports a user can perform per `IMPORT_USER_WINDOW`.',
+      'IMPORT_USER_MAX=50',
+    ],
+    [
+      'IMPORT_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `IMPORT_USER_MAX` imports.',
+      'IMPORT_USER_WINDOW=1',
+    ],
   ]}
 />
 
@@ -781,9 +1449,24 @@ Limits how often users can fork conversations to prevent abuse.
 
 <OptionTable
   options={[
-    ['LIMIT_FORK_IP', 'boolean', 'Whether to limit the amount of conversation forks an IP can create per `FORK_IP_WINDOW`.','LIMIT_FORK_IP=true'],
-    ['FORK_IP_MAX', 'integer', 'The max amount of conversation forks an IP can create per `FORK_IP_WINDOW`.','FORK_IP_MAX=30'],
-    ['FORK_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `FORK_IP_MAX` forks.','FORK_IP_WINDOW=1'],
+    [
+      'LIMIT_FORK_IP',
+      'boolean',
+      'Whether to limit the amount of conversation forks an IP can create per `FORK_IP_WINDOW`.',
+      'LIMIT_FORK_IP=true',
+    ],
+    [
+      'FORK_IP_MAX',
+      'integer',
+      'The max amount of conversation forks an IP can create per `FORK_IP_WINDOW`.',
+      'FORK_IP_MAX=30',
+    ],
+    [
+      'FORK_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `FORK_IP_MAX` forks.',
+      'FORK_IP_WINDOW=1',
+    ],
   ]}
 />
 
@@ -791,9 +1474,24 @@ Limits how often users can fork conversations to prevent abuse.
 
 <OptionTable
   options={[
-    ['LIMIT_FORK_USER', 'boolean', 'Whether to limit the amount of conversation forks a user can create per `FORK_USER_WINDOW`.','LIMIT_FORK_USER=false'],
-    ['FORK_USER_MAX', 'integer', 'The max amount of conversation forks a user can create per `FORK_USER_WINDOW`.','FORK_USER_MAX=7'],
-    ['FORK_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `FORK_USER_MAX` forks.','FORK_USER_WINDOW=1'],
+    [
+      'LIMIT_FORK_USER',
+      'boolean',
+      'Whether to limit the amount of conversation forks a user can create per `FORK_USER_WINDOW`.',
+      'LIMIT_FORK_USER=false',
+    ],
+    [
+      'FORK_USER_MAX',
+      'integer',
+      'The max amount of conversation forks a user can create per `FORK_USER_WINDOW`.',
+      'FORK_USER_MAX=7',
+    ],
+    [
+      'FORK_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `FORK_USER_MAX` forks.',
+      'FORK_USER_WINDOW=1',
+    ],
   ]}
 />
 
@@ -807,8 +1505,18 @@ Limits how often users can upload files to prevent abuse.
 
 <OptionTable
   options={[
-    ['FILE_UPLOAD_IP_MAX', 'integer', 'Max file uploads per IP per `FILE_UPLOAD_IP_WINDOW`. Default: 100.','# FILE_UPLOAD_IP_MAX=100'],
-    ['FILE_UPLOAD_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `FILE_UPLOAD_IP_MAX`. Default: 15.','# FILE_UPLOAD_IP_WINDOW=15'],
+    [
+      'FILE_UPLOAD_IP_MAX',
+      'integer',
+      'Max file uploads per IP per `FILE_UPLOAD_IP_WINDOW`. Default: 100.',
+      '# FILE_UPLOAD_IP_MAX=100',
+    ],
+    [
+      'FILE_UPLOAD_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `FILE_UPLOAD_IP_MAX`. Default: 15.',
+      '# FILE_UPLOAD_IP_WINDOW=15',
+    ],
   ]}
 />
 
@@ -816,8 +1524,18 @@ Limits how often users can upload files to prevent abuse.
 
 <OptionTable
   options={[
-    ['FILE_UPLOAD_USER_MAX', 'integer', 'Max file uploads per user per `FILE_UPLOAD_USER_WINDOW`. Default: 50.','# FILE_UPLOAD_USER_MAX=50'],
-    ['FILE_UPLOAD_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `FILE_UPLOAD_USER_MAX`. Default: 15.','# FILE_UPLOAD_USER_WINDOW=15'],
+    [
+      'FILE_UPLOAD_USER_MAX',
+      'integer',
+      'Max file uploads per user per `FILE_UPLOAD_USER_WINDOW`. Default: 50.',
+      '# FILE_UPLOAD_USER_MAX=50',
+    ],
+    [
+      'FILE_UPLOAD_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `FILE_UPLOAD_USER_MAX`. Default: 15.',
+      '# FILE_UPLOAD_USER_WINDOW=15',
+    ],
   ]}
 />
 
@@ -831,8 +1549,18 @@ Limits how often users can use Text-to-Speech to prevent abuse.
 
 <OptionTable
   options={[
-    ['TTS_IP_MAX', 'integer', 'Max TTS requests per IP per `TTS_IP_WINDOW`. Default: 100.','# TTS_IP_MAX=100'],
-    ['TTS_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `TTS_IP_MAX`. Default: 1.','# TTS_IP_WINDOW=1'],
+    [
+      'TTS_IP_MAX',
+      'integer',
+      'Max TTS requests per IP per `TTS_IP_WINDOW`. Default: 100.',
+      '# TTS_IP_MAX=100',
+    ],
+    [
+      'TTS_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `TTS_IP_MAX`. Default: 1.',
+      '# TTS_IP_WINDOW=1',
+    ],
   ]}
 />
 
@@ -840,8 +1568,18 @@ Limits how often users can use Text-to-Speech to prevent abuse.
 
 <OptionTable
   options={[
-    ['TTS_USER_MAX', 'integer', 'Max TTS requests per user per `TTS_USER_WINDOW`. Default: 50.','# TTS_USER_MAX=50'],
-    ['TTS_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `TTS_USER_MAX`. Default: 1.','# TTS_USER_WINDOW=1'],
+    [
+      'TTS_USER_MAX',
+      'integer',
+      'Max TTS requests per user per `TTS_USER_WINDOW`. Default: 50.',
+      '# TTS_USER_MAX=50',
+    ],
+    [
+      'TTS_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `TTS_USER_MAX`. Default: 1.',
+      '# TTS_USER_WINDOW=1',
+    ],
   ]}
 />
 
@@ -855,8 +1593,18 @@ Limits how often users can use Speech-to-Text to prevent abuse.
 
 <OptionTable
   options={[
-    ['STT_IP_MAX', 'integer', 'Max STT requests per IP per `STT_IP_WINDOW`. Default: 100.','# STT_IP_MAX=100'],
-    ['STT_IP_WINDOW', 'integer', 'In minutes, determines the window of time for `STT_IP_MAX`. Default: 1.','# STT_IP_WINDOW=1'],
+    [
+      'STT_IP_MAX',
+      'integer',
+      'Max STT requests per IP per `STT_IP_WINDOW`. Default: 100.',
+      '# STT_IP_MAX=100',
+    ],
+    [
+      'STT_IP_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `STT_IP_MAX`. Default: 1.',
+      '# STT_IP_WINDOW=1',
+    ],
   ]}
 />
 
@@ -864,8 +1612,18 @@ Limits how often users can use Speech-to-Text to prevent abuse.
 
 <OptionTable
   options={[
-    ['STT_USER_MAX', 'integer', 'Max STT requests per user per `STT_USER_WINDOW`. Default: 50.','# STT_USER_MAX=50'],
-    ['STT_USER_WINDOW', 'integer', 'In minutes, determines the window of time for `STT_USER_MAX`. Default: 1.','# STT_USER_WINDOW=1'],
+    [
+      'STT_USER_MAX',
+      'integer',
+      'Max STT requests per user per `STT_USER_WINDOW`. Default: 50.',
+      '# STT_USER_MAX=50',
+    ],
+    [
+      'STT_USER_WINDOW',
+      'integer',
+      'In minutes, determines the window of time for `STT_USER_MAX`. Default: 1.',
+      '# STT_USER_WINDOW=1',
+    ],
   ]}
 />
 
@@ -877,22 +1635,32 @@ see: **[Token Usage](/docs/configuration/token_usage)**
 
 <OptionTable
   options={[
-    ['CHECK_BALANCE', 'boolean', 'Enable token credit balances for the OpenAI/Plugins endpoints.','CHECK_BALANCE=false'],
-    ['START_BALANCE', 'integer', 'If the value is set, tokens will be credited to the user\'s balance after registration.', 'START_BALANCE=20000']
+    [
+      'CHECK_BALANCE',
+      'boolean',
+      'Enable token credit balances for the OpenAI/Plugins endpoints.',
+      'CHECK_BALANCE=false',
+    ],
+    [
+      'START_BALANCE',
+      'integer',
+      "If the value is set, tokens will be credited to the user's balance after registration.",
+      'START_BALANCE=20000',
+    ],
   ]}
 />
 
 #### Managing Balances
 
 - Run `npm run add-balance` to manually add balances.
-    - You can also specify the email and token credit amount to add, e.g.: `npm run add-balance example@example.com 1000`
+  - You can also specify the email and token credit amount to add, e.g.: `npm run add-balance example@example.com 1000`
 - Run `npm run set-balance` to manually set balances, similar to `add-balance`.
 - Run `npm run list-balances` to list the balance of every user.
 
 > **Note:** 1000 credits = $0.001 (1 mill USD)
 
-
 ### Registration and Login
+
 see: **[Authentication System](/docs/configuration/authentication)**
 
 <div style={{display: "flex", justifyContent: "center", alignItems: "center", flexDirection: "column"}}>
@@ -906,21 +1674,64 @@ see: **[Authentication System](/docs/configuration/authentication)**
 </div>
 
 <Callout type="info" title="Configuration File Clarification">
-All authentication settings in this section should be configured in your `.env` file, not in the `librechat.yaml` file or `docker-compose.override.yml`. The `docker-compose.override.yml` file is only used to mount volumes and set environment variables for Docker, while the `librechat.yaml` file is used for custom endpoints and other application settings.
+  All authentication settings in this section should be configured in your `.env` file, not in the
+  `librechat.yaml` file or `docker-compose.override.yml`. The `docker-compose.override.yml` file is
+  only used to mount volumes and set environment variables for Docker, while the `librechat.yaml`
+  file is used for custom endpoints and other application settings.
 </Callout>
 
 - General Settings:
 
 <OptionTable
   options={[
-    ['ALLOW_EMAIL_LOGIN', 'boolean', 'Enable or disable ONLY email login.','ALLOW_EMAIL_LOGIN=true'],
-    ['ALLOW_REGISTRATION', 'boolean', 'Enable or disable Email registration of new users.','ALLOW_REGISTRATION=true'],
-    ['ALLOW_SOCIAL_LOGIN', 'boolean', 'Allow users to connect to LibreChat with various social networks.','ALLOW_SOCIAL_LOGIN=false'],
-    ['ALLOW_SOCIAL_REGISTRATION', 'boolean', 'Enable or disable registration of new users using various social networks.','ALLOW_SOCIAL_REGISTRATION=false'],
-    ['ALLOW_PASSWORD_RESET', 'boolean', 'Enable or disable the ability for users to reset their password by themselves','ALLOW_PASSWORD_RESET=false'],
-    ['ALLOW_ACCOUNT_DELETION', 'boolean', 'Enable or disable the ability for users to delete their account by themselves. Enabled by default if omitted/commented out','ALLOW_ACCOUNT_DELETION=true'],
-    ['ALLOW_UNVERIFIED_EMAIL_LOGIN', 'boolean', 'Set to true to allow users to log in without verifying their email address. If set to false, users will be required to verify their email before logging in.', 'ALLOW_UNVERIFIED_EMAIL_LOGIN=true'],
-    ['MIN_PASSWORD_LENGTH', 'number', 'Minimum password length for user authentication. When using LDAP authentication, you may want to set this to 1 to bypass local password validation, as LDAP servers handle their own password policies.', 'MIN_PASSWORD_LENGTH=8'],
+    [
+      'ALLOW_EMAIL_LOGIN',
+      'boolean',
+      'Enable or disable ONLY email login.',
+      'ALLOW_EMAIL_LOGIN=true',
+    ],
+    [
+      'ALLOW_REGISTRATION',
+      'boolean',
+      'Enable or disable Email registration of new users.',
+      'ALLOW_REGISTRATION=true',
+    ],
+    [
+      'ALLOW_SOCIAL_LOGIN',
+      'boolean',
+      'Allow users to connect to LibreChat with various social networks.',
+      'ALLOW_SOCIAL_LOGIN=false',
+    ],
+    [
+      'ALLOW_SOCIAL_REGISTRATION',
+      'boolean',
+      'Enable or disable registration of new users using various social networks.',
+      'ALLOW_SOCIAL_REGISTRATION=false',
+    ],
+    [
+      'ALLOW_PASSWORD_RESET',
+      'boolean',
+      'Enable or disable the ability for users to reset their password by themselves',
+      'ALLOW_PASSWORD_RESET=false',
+    ],
+    [
+      'ALLOW_ACCOUNT_DELETION',
+      'boolean',
+      'Enable or disable the ability for users to delete their account by themselves. Enabled by default if omitted/commented out',
+      'ALLOW_ACCOUNT_DELETION=true',
+    ],
+    [
+      'ALLOW_UNVERIFIED_EMAIL_LOGIN',
+      'boolean',
+      'Set to true to allow users to log in without verifying their email address. If set to false, users will be required to verify their email before logging in.',
+      'ALLOW_UNVERIFIED_EMAIL_LOGIN=true',
+    ],
+    [
+      'MIN_PASSWORD_LENGTH',
+      'number',
+      'Minimum password length for user authentication. When using LDAP authentication, you may want to set this to 1 to bypass local password validation, as LDAP servers handle their own password policies.',
+      'MIN_PASSWORD_LENGTH=8',
+    ],
   ]}
 />
 
@@ -931,8 +1742,18 @@ All authentication settings in this section should be configured in your `.env` 
 
 <OptionTable
   options={[
-    ['SESSION_EXPIRY', 'integer (milliseconds)', 'Session expiry time.','SESSION_EXPIRY=1000 * 60 * 15'],
-    ['REFRESH_TOKEN_EXPIRY', 'integer (milliseconds)', 'Refresh token expiry time.','REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7'],
+    [
+      'SESSION_EXPIRY',
+      'integer (milliseconds)',
+      'Session expiry time.',
+      'SESSION_EXPIRY=1000 * 60 * 15',
+    ],
+    [
+      'REFRESH_TOKEN_EXPIRY',
+      'integer (milliseconds)',
+      'Refresh token expiry time.',
+      'REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7',
+    ],
   ]}
 />
 
@@ -945,12 +1766,23 @@ Use this replit to generate some quickly: **[JWT Keys](/toolkit/creds_generator)
 
 <OptionTable
   options={[
-    ['JWT_SECRET', 'string (hex)', 'JWT secret key.','JWT_SECRET=16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef'],
-    ['JWT_REFRESH_SECRET', 'string (hex)', 'JWT refresh secret key.','JWT_REFRESH_SECRET=eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418'],
+    [
+      'JWT_SECRET',
+      'string (hex)',
+      'JWT secret key.',
+      'JWT_SECRET=16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef',
+    ],
+    [
+      'JWT_REFRESH_SECRET',
+      'string (hex)',
+      'JWT refresh secret key.',
+      'JWT_REFRESH_SECRET=eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418',
+    ],
   ]}
 />
 
 ### Social Logins
+
 For more details: [OAuth2-OIDC](/docs/configuration/authentication/OAuth2-OIDC)
 
 #### Apple Authentication
@@ -959,14 +1791,33 @@ For more information: **[Apple Authentication](/docs/configuration/authenticatio
 
 <OptionTable
   options={[
-    ['APPLE_CLIENT_ID', 'string', 'Your Apple Services ID (e.g., com.yourdomain.librechat.services).', 'APPLE_CLIENT_ID=com.yourdomain.librechat.services'],
+    [
+      'APPLE_CLIENT_ID',
+      'string',
+      'Your Apple Services ID (e.g., com.yourdomain.librechat.services).',
+      'APPLE_CLIENT_ID=com.yourdomain.librechat.services',
+    ],
     ['APPLE_TEAM_ID', 'string', 'Your Apple Developer Team ID.', 'APPLE_TEAM_ID=YOUR_TEAM_ID'],
-    ['APPLE_KEY_ID', 'string', 'Your Apple Key ID from the downloaded key.', 'APPLE_KEY_ID=YOUR_KEY_ID'],
-    ['APPLE_PRIVATE_KEY_PATH', 'string', 'Absolute path to your downloaded .p8 file.', 'APPLE_PRIVATE_KEY_PATH=/path/to/AuthKey.p8'],
-    ['APPLE_CALLBACK_URL', 'string', 'The callback URL for Apple authentication.', 'APPLE_CALLBACK_URL=/oauth/apple/callback'],
+    [
+      'APPLE_KEY_ID',
+      'string',
+      'Your Apple Key ID from the downloaded key.',
+      'APPLE_KEY_ID=YOUR_KEY_ID',
+    ],
+    [
+      'APPLE_PRIVATE_KEY_PATH',
+      'string',
+      'Absolute path to your downloaded .p8 file.',
+      'APPLE_PRIVATE_KEY_PATH=/path/to/AuthKey.p8',
+    ],
+    [
+      'APPLE_CALLBACK_URL',
+      'string',
+      'The callback URL for Apple authentication.',
+      'APPLE_CALLBACK_URL=/oauth/apple/callback',
+    ],
   ]}
 />
-
 
 #### Discord Authentication
 
@@ -974,9 +1825,14 @@ For more information: **[Discord](/docs/configuration/authentication/OAuth2-OIDC
 
 <OptionTable
   options={[
-    ['DISCORD_CLIENT_ID', 'string', 'Your Discord client ID.','DISCORD_CLIENT_ID='],
-    ['DISCORD_CLIENT_SECRET', 'string', 'Your Discord client secret.','DISCORD_CLIENT_SECRET='],
-    ['DISCORD_CALLBACK_URL', 'string', 'The callback URL for Discord authentication.','DISCORD_CALLBACK_URL=/oauth/discord/callback'],
+    ['DISCORD_CLIENT_ID', 'string', 'Your Discord client ID.', 'DISCORD_CLIENT_ID='],
+    ['DISCORD_CLIENT_SECRET', 'string', 'Your Discord client secret.', 'DISCORD_CLIENT_SECRET='],
+    [
+      'DISCORD_CALLBACK_URL',
+      'string',
+      'The callback URL for Discord authentication.',
+      'DISCORD_CALLBACK_URL=/oauth/discord/callback',
+    ],
   ]}
 />
 
@@ -986,9 +1842,14 @@ For more information: **[Facebook Authentication](/docs/configuration/authentica
 
 <OptionTable
   options={[
-    ['FACEBOOK_CLIENT_ID', 'string', 'Your Facebook client ID.','FACEBOOK_CLIENT_ID='],
-    ['FACEBOOK_CLIENT_SECRET', 'string', 'Your Facebook client secret.','FACEBOOK_CLIENT_SECRET='],
-    ['FACEBOOK_CALLBACK_URL', 'string', 'The callback URL for Facebook authentication.','FACEBOOK_CALLBACK_URL=/oauth/facebook/callback'],
+    ['FACEBOOK_CLIENT_ID', 'string', 'Your Facebook client ID.', 'FACEBOOK_CLIENT_ID='],
+    ['FACEBOOK_CLIENT_SECRET', 'string', 'Your Facebook client secret.', 'FACEBOOK_CLIENT_SECRET='],
+    [
+      'FACEBOOK_CALLBACK_URL',
+      'string',
+      'The callback URL for Facebook authentication.',
+      'FACEBOOK_CALLBACK_URL=/oauth/facebook/callback',
+    ],
   ]}
 />
 
@@ -998,11 +1859,26 @@ For more information: **[GitHub Authentication](/docs/configuration/authenticati
 
 <OptionTable
   options={[
-    ['GITHUB_CLIENT_ID', 'string', 'Your GitHub client ID.','GITHUB_CLIENT_ID='],
-    ['GITHUB_CLIENT_SECRET', 'string', 'Your GitHub client secret.','GITHUB_CLIENT_SECRET='],
-    ['GITHUB_CALLBACK_URL', 'string', 'The callback URL for GitHub authentication.','GITHUB_CALLBACK_URL=/oauth/github/callback'],
-    ['GITHUB_ENTERPRISE_BASE_URL', 'string', 'Optional: The base URL for your GitHub Enterprise instance.', 'GITHUB_ENTERPRISE_BASE_URL='],
-    ['GITHUB_ENTERPRISE_USER_AGENT', 'string', 'Optional: The user agent for GitHub Enterprise requests.', 'GITHUB_ENTERPRISE_USER_AGENT='],
+    ['GITHUB_CLIENT_ID', 'string', 'Your GitHub client ID.', 'GITHUB_CLIENT_ID='],
+    ['GITHUB_CLIENT_SECRET', 'string', 'Your GitHub client secret.', 'GITHUB_CLIENT_SECRET='],
+    [
+      'GITHUB_CALLBACK_URL',
+      'string',
+      'The callback URL for GitHub authentication.',
+      'GITHUB_CALLBACK_URL=/oauth/github/callback',
+    ],
+    [
+      'GITHUB_ENTERPRISE_BASE_URL',
+      'string',
+      'Optional: The base URL for your GitHub Enterprise instance.',
+      'GITHUB_ENTERPRISE_BASE_URL=',
+    ],
+    [
+      'GITHUB_ENTERPRISE_USER_AGENT',
+      'string',
+      'Optional: The user agent for GitHub Enterprise requests.',
+      'GITHUB_ENTERPRISE_USER_AGENT=',
+    ],
   ]}
 />
 
@@ -1012,69 +1888,220 @@ For more information: **[Google Authentication](/docs/configuration/authenticati
 
 <OptionTable
   options={[
-    ['GOOGLE_CLIENT_ID', 'string', 'Your Google client ID.','GOOGLE_CLIENT_ID='],
-    ['GOOGLE_CLIENT_SECRET', 'string', 'Your Google client secret.','GOOGLE_CLIENT_SECRET='],
-    ['GOOGLE_CALLBACK_URL', 'string', 'The callback URL for Google authentication.','GOOGLE_CALLBACK_URL=/oauth/google/callback'],
+    ['GOOGLE_CLIENT_ID', 'string', 'Your Google client ID.', 'GOOGLE_CLIENT_ID='],
+    ['GOOGLE_CLIENT_SECRET', 'string', 'Your Google client secret.', 'GOOGLE_CLIENT_SECRET='],
+    [
+      'GOOGLE_CALLBACK_URL',
+      'string',
+      'The callback URL for Google authentication.',
+      'GOOGLE_CALLBACK_URL=/oauth/google/callback',
+    ],
   ]}
 />
 
 #### OpenID Connect
 
 For more information:
-  - [Auth0](/docs/configuration/authentication/OAuth2-OIDC/auth0)
-  - [AWS Cognito](/docs/configuration/authentication/OAuth2-OIDC/aws)
-  - [Azure Entra/AD](/docs/configuration/authentication/OAuth2-OIDC/azure)
-  - [Keycloak](/docs/configuration/authentication/OAuth2-OIDC/keycloak)
+
+- [Auth0](/docs/configuration/authentication/OAuth2-OIDC/auth0)
+- [AWS Cognito](/docs/configuration/authentication/OAuth2-OIDC/aws)
+- [Azure Entra/AD](/docs/configuration/authentication/OAuth2-OIDC/azure)
+- [Keycloak](/docs/configuration/authentication/OAuth2-OIDC/keycloak)
 
 <OptionTable
   options={[
-    ['OPENID_CLIENT_ID', 'string', 'Your OpenID client ID.','OPENID_CLIENT_ID='],
-    ['OPENID_CLIENT_SECRET', 'string', 'Your OpenID client secret.','OPENID_CLIENT_SECRET='],
-    ['OPENID_ISSUER', 'string', 'The OpenID issuer URL.','OPENID_ISSUER='],
-    ['OPENID_SESSION_SECRET', 'string', 'The secret for OpenID session storage.','OPENID_SESSION_SECRET='],
+    ['OPENID_CLIENT_ID', 'string', 'Your OpenID client ID.', 'OPENID_CLIENT_ID='],
+    ['OPENID_CLIENT_SECRET', 'string', 'Your OpenID client secret.', 'OPENID_CLIENT_SECRET='],
+    ['OPENID_ISSUER', 'string', 'The OpenID issuer URL.', 'OPENID_ISSUER='],
+    [
+      'OPENID_SESSION_SECRET',
+      'string',
+      'The secret for OpenID session storage.',
+      'OPENID_SESSION_SECRET=',
+    ],
     ['OPENID_SCOPE', 'string', 'The OpenID scope.', 'OPENID_SCOPE="openid profile email"'],
-    ['OPENID_CALLBACK_URL', 'string', 'The callback URL for OpenID authentication.','OPENID_CALLBACK_URL=/oauth/openid/callback'],
-    ['OPENID_AUDIENCE', 'string', 'The audience parameter for authorization requests. Required for Auth0 when using OPENID_REUSE_TOKENS=true to receive JWT access tokens instead of opaque tokens.','OPENID_AUDIENCE=https://api.librechat.com'],
-    ['OPENID_REQUIRED_ROLE', 'string', 'The required role(s) for validation. Supports a single role or multiple comma-separated roles. When multiple roles are specified, the user needs ANY of the specified roles (OR logic).','OPENID_REQUIRED_ROLE=admin or OPENID_REQUIRED_ROLE=role1,role2,admin'],
-    ['OPENID_REQUIRED_ROLE_TOKEN_KIND', 'string', 'The token kind for required role validation.','OPENID_REQUIRED_ROLE_TOKEN_KIND='],
-    ['OPENID_REQUIRED_ROLE_PARAMETER_PATH', 'string', 'The parameter path for required role validation.','OPENID_REQUIRED_ROLE_PARAMETER_PATH='],
-    ['OPENID_ADMIN_ROLE', 'string', 'The role the user should have in order to be an admin in LibreChat.','OPENID_ADMIN_ROLE='],
-    ['OPENID_ADMIN_ROLE_TOKEN_KIND', 'string', 'The source of the information for admin role verification. Possible values are: access, id or userinfo.','OPENID_ADMIN_ROLE_TOKEN_KIND='],
-    ['OPENID_ADMIN_ROLE_PARAMETER_PATH', 'string', 'The parameter path for required role validation.','OPENID_ADMIN_ROLE_PARAMETER_PATH='],
-    ['OPENID_BUTTON_LABEL', 'string', 'The label for the OpenID login button.','OPENID_BUTTON_LABEL='],
-    ['OPENID_IMAGE_URL', 'string', 'The URL of the OpenID login button image.','OPENID_IMAGE_URL='],
-    ['OPENID_USE_END_SESSION_ENDPOINT', 'string', 'Whether to use the Issuer End Session Endpoint as a Logout Redirect','OPENID_USE_END_SESSION_ENDPOINT=TRUE'],
-    ['OPENID_AUTO_REDIRECT', 'boolean', 'Whether to automatically redirect to the OpenID provider.','OPENID_AUTO_REDIRECT=true'],
-    ['OPENID_USE_PKCE', 'boolean', 'Use PKCE (Proof Key for Code Exchange) for OpenID authentication.','# OPENID_USE_PKCE=true'],
-    ['OPENID_POST_LOGOUT_REDIRECT_URI', 'string', 'Redirect URI after OpenID logout. Defaults to ${DOMAIN_CLIENT}/login.','# OPENID_POST_LOGOUT_REDIRECT_URI='],
-    ['OPENID_CLOCK_TOLERANCE', 'number', 'Clock tolerance in seconds for token validation. Default: 300.','# OPENID_CLOCK_TOLERANCE=300'],
-    ['OPENID_GENERATE_NONCE', 'boolean', 'Force the OpenID client to generate a nonce parameter. Required by some identity providers like AWS Cognito (especially with federation) and Authentik.','OPENID_GENERATE_NONCE=true'],
-    ['DEBUG_OPENID_REQUESTS', 'boolean', 'Enable detailed logging of OpenID request headers. When disabled (default), only request URLs are logged at debug level. When enabled, request headers are also logged (with sensitive data masked) for deeper debugging of authentication issues.','DEBUG_OPENID_REQUESTS=false'],
-    ['OPENID_USERNAME_CLAIM', 'string', 'The user info property from the OpenID provider to store as the user\'s username.','OPENID_USERNAME_CLAIM='],
-    ['OPENID_NAME_CLAIM', 'string', 'The user info property from the OpenID provider to store as the user\'s display name.','OPENID_NAME_CLAIM='],
-    ['OPENID_EMAIL_CLAIM', 'string', 'The user info claim to use as the email/identifier for user matching (e.g., "upn" for Entra ID). When not set, defaults to: email → preferred_username → upn.','OPENID_EMAIL_CLAIM='],
+    [
+      'OPENID_CALLBACK_URL',
+      'string',
+      'The callback URL for OpenID authentication.',
+      'OPENID_CALLBACK_URL=/oauth/openid/callback',
+    ],
+    [
+      'OPENID_AUDIENCE',
+      'string',
+      'The audience parameter for authorization requests. Required for Auth0 when using OPENID_REUSE_TOKENS=true to receive JWT access tokens instead of opaque tokens.',
+      'OPENID_AUDIENCE=https://api.librechat.com',
+    ],
+    [
+      'OPENID_REQUIRED_ROLE',
+      'string',
+      'The required role(s) for validation. Supports a single role or multiple comma-separated roles. When multiple roles are specified, the user needs ANY of the specified roles (OR logic).',
+      'OPENID_REQUIRED_ROLE=admin or OPENID_REQUIRED_ROLE=role1,role2,admin',
+    ],
+    [
+      'OPENID_REQUIRED_ROLE_TOKEN_KIND',
+      'string',
+      'The token kind for required role validation.',
+      'OPENID_REQUIRED_ROLE_TOKEN_KIND=',
+    ],
+    [
+      'OPENID_REQUIRED_ROLE_PARAMETER_PATH',
+      'string',
+      'The parameter path for required role validation.',
+      'OPENID_REQUIRED_ROLE_PARAMETER_PATH=',
+    ],
+    [
+      'OPENID_ADMIN_ROLE',
+      'string',
+      'The role the user should have in order to be an admin in LibreChat.',
+      'OPENID_ADMIN_ROLE=',
+    ],
+    [
+      'OPENID_ADMIN_ROLE_TOKEN_KIND',
+      'string',
+      'The source of the information for admin role verification. Possible values are: access, id or userinfo.',
+      'OPENID_ADMIN_ROLE_TOKEN_KIND=',
+    ],
+    [
+      'OPENID_ADMIN_ROLE_PARAMETER_PATH',
+      'string',
+      'The parameter path for required role validation.',
+      'OPENID_ADMIN_ROLE_PARAMETER_PATH=',
+    ],
+    [
+      'OPENID_BUTTON_LABEL',
+      'string',
+      'The label for the OpenID login button.',
+      'OPENID_BUTTON_LABEL=',
+    ],
+    [
+      'OPENID_IMAGE_URL',
+      'string',
+      'The URL of the OpenID login button image.',
+      'OPENID_IMAGE_URL=',
+    ],
+    [
+      'OPENID_USE_END_SESSION_ENDPOINT',
+      'string',
+      'Whether to use the Issuer End Session Endpoint as a Logout Redirect',
+      'OPENID_USE_END_SESSION_ENDPOINT=TRUE',
+    ],
+    [
+      'OPENID_AUTO_REDIRECT',
+      'boolean',
+      'Whether to automatically redirect to the OpenID provider.',
+      'OPENID_AUTO_REDIRECT=true',
+    ],
+    [
+      'OPENID_USE_PKCE',
+      'boolean',
+      'Use PKCE (Proof Key for Code Exchange) for OpenID authentication.',
+      '# OPENID_USE_PKCE=true',
+    ],
+    [
+      'OPENID_POST_LOGOUT_REDIRECT_URI',
+      'string',
+      'Redirect URI after OpenID logout. Defaults to ${DOMAIN_CLIENT}/login.',
+      '# OPENID_POST_LOGOUT_REDIRECT_URI=',
+    ],
+    [
+      'OPENID_CLOCK_TOLERANCE',
+      'number',
+      'Clock tolerance in seconds for token validation. Default: 300.',
+      '# OPENID_CLOCK_TOLERANCE=300',
+    ],
+    [
+      'OPENID_GENERATE_NONCE',
+      'boolean',
+      'Force the OpenID client to generate a nonce parameter. Required by some identity providers like AWS Cognito (especially with federation) and Authentik.',
+      'OPENID_GENERATE_NONCE=true',
+    ],
+    [
+      'DEBUG_OPENID_REQUESTS',
+      'boolean',
+      'Enable detailed logging of OpenID request headers. When disabled (default), only request URLs are logged at debug level. When enabled, request headers are also logged (with sensitive data masked) for deeper debugging of authentication issues.',
+      'DEBUG_OPENID_REQUESTS=false',
+    ],
+    [
+      'OPENID_USERNAME_CLAIM',
+      'string',
+      "The user info property from the OpenID provider to store as the user's username.",
+      'OPENID_USERNAME_CLAIM=',
+    ],
+    [
+      'OPENID_NAME_CLAIM',
+      'string',
+      "The user info property from the OpenID provider to store as the user's display name.",
+      'OPENID_NAME_CLAIM=',
+    ],
+    [
+      'OPENID_EMAIL_CLAIM',
+      'string',
+      'The user info claim to use as the email/identifier for user matching (e.g., "upn" for Entra ID). When not set, defaults to: email → preferred_username → upn.',
+      'OPENID_EMAIL_CLAIM=',
+    ],
   ]}
 />
-                                                                                                                               
 ##### OpenID Connect Token Reuse
 
 LibreChat supports reusing access and refresh tokens issued by your OpenID Connect provider (like Azure Entra ID or Auth0) to manage user authentication state. When this feature is active, the refresh token passed to the user as a cookie is issued by your OpenID provider instead of LibreChat.
 
 <OptionTable
   options={[
-    ['OPENID_REUSE_TOKENS', 'boolean', 'Enable reuse of OpenID provider tokens for session management.', 'OPENID_REUSE_TOKENS=false'],
-    ['OPENID_SCOPE', 'string', 'Space-separated list of OpenID scopes. Must include offline_access for token reuse.', 'OPENID_SCOPE=api://librechat/.default openid profile email offline_access'],
-    ['OPENID_AUDIENCE', 'string', 'The audience parameter for authorization requests. Required for Auth0 when OPENID_REUSE_TOKENS=true. See the note in the main OpenID section above.', 'OPENID_AUDIENCE=https://api.librechat.com'],
-    ['OPENID_JWKS_URL_CACHE_ENABLED', 'boolean', 'Enable caching of signing key verification results.', 'OPENID_JWKS_URL_CACHE_ENABLED=true'],
-    ['OPENID_JWKS_URL_CACHE_TIME', 'number', 'Cache duration in milliseconds (default: 600000 ms / 10 minutes).', 'OPENID_JWKS_URL_CACHE_TIME=600000'],
-    ['OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED', 'boolean', 'Enable on-behalf-of flow for user info.', 'OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED=true'],
-    ['OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE', 'string', 'Scope for user info in on-behalf-of flow.', 'OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE=user.read'],
-    ['OPENID_USE_END_SESSION_ENDPOINT', 'boolean', 'Enable use of the end session endpoint for logout.', 'OPENID_USE_END_SESSION_ENDPOINT=true'],
+    [
+      'OPENID_REUSE_TOKENS',
+      'boolean',
+      'Enable reuse of OpenID provider tokens for session management.',
+      'OPENID_REUSE_TOKENS=false',
+    ],
+    [
+      'OPENID_SCOPE',
+      'string',
+      'Space-separated list of OpenID scopes. Must include offline_access for token reuse.',
+      'OPENID_SCOPE=api://librechat/.default openid profile email offline_access',
+    ],
+    [
+      'OPENID_AUDIENCE',
+      'string',
+      'The audience parameter for authorization requests. Required for Auth0 when OPENID_REUSE_TOKENS=true. See the note in the main OpenID section above.',
+      'OPENID_AUDIENCE=https://api.librechat.com',
+    ],
+    [
+      'OPENID_JWKS_URL_CACHE_ENABLED',
+      'boolean',
+      'Enable caching of signing key verification results.',
+      'OPENID_JWKS_URL_CACHE_ENABLED=true',
+    ],
+    [
+      'OPENID_JWKS_URL_CACHE_TIME',
+      'number',
+      'Cache duration in milliseconds (default: 600000 ms / 10 minutes).',
+      'OPENID_JWKS_URL_CACHE_TIME=600000',
+    ],
+    [
+      'OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED',
+      'boolean',
+      'Enable on-behalf-of flow for user info.',
+      'OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED=true',
+    ],
+    [
+      'OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE',
+      'string',
+      'Scope for user info in on-behalf-of flow.',
+      'OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE=user.read',
+    ],
+    [
+      'OPENID_USE_END_SESSION_ENDPOINT',
+      'boolean',
+      'Enable use of the end session endpoint for logout.',
+      'OPENID_USE_END_SESSION_ENDPOINT=true',
+    ],
   ]}
 />
 
 <Callout type="note" title="Note">
-For detailed configuration steps and prerequisites, see [Re-use OpenID Tokens for Login Session](/docs/configuration/authentication/OAuth2-OIDC/token-reuse).
+  For detailed configuration steps and prerequisites, see [Re-use OpenID Tokens for Login
+  Session](/docs/configuration/authentication/OAuth2-OIDC/token-reuse).
 </Callout>
 
 ##### Microsoft Graph API / Entra ID Integration
@@ -1083,17 +2110,32 @@ When using Azure Entra ID (formerly Azure AD) as your OpenID provider, you can e
 
 <OptionTable
   options={[
-    ['USE_ENTRA_ID_FOR_PEOPLE_SEARCH', 'boolean', 'Enable Entra ID people search integration in permissions/sharing system. When enabled, the people picker will search both local database and Entra ID.', 'USE_ENTRA_ID_FOR_PEOPLE_SEARCH=false'],
-    ['ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS', 'boolean', 'When enabled, Entra ID group owners will be considered as members of the group.', 'ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS=false'],
-    ['OPENID_GRAPH_SCOPES', 'string', 'Microsoft Graph API scopes needed for people/group search. Default scopes provide access to user profiles and group memberships.', 'OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All,User.ReadBasic.All'],
+    [
+      'USE_ENTRA_ID_FOR_PEOPLE_SEARCH',
+      'boolean',
+      'Enable Entra ID people search integration in permissions/sharing system. When enabled, the people picker will search both local database and Entra ID.',
+      'USE_ENTRA_ID_FOR_PEOPLE_SEARCH=false',
+    ],
+    [
+      'ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS',
+      'boolean',
+      'When enabled, Entra ID group owners will be considered as members of the group.',
+      'ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS=false',
+    ],
+    [
+      'OPENID_GRAPH_SCOPES',
+      'string',
+      'Microsoft Graph API scopes needed for people/group search. Default scopes provide access to user profiles and group memberships.',
+      'OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All,User.ReadBasic.All',
+    ],
   ]}
 />
 
 <Callout type="warning" title="Important Prerequisites">
-- You must have Azure Entra ID configured as your OpenID provider
-- **OpenID token reuse MUST be enabled** (`OPENID_REUSE_TOKENS=true`) - this feature will not work without it
-- Your Azure app registration must have the appropriate Microsoft Graph API permissions
-- For group search functionality, admin consent may be required for certain Graph API scopes
+  - You must have Azure Entra ID configured as your OpenID provider - **OpenID token reuse MUST be
+  enabled** (`OPENID_REUSE_TOKENS=true`) - this feature will not work without it - Your Azure app
+  registration must have the appropriate Microsoft Graph API permissions - For group search
+  functionality, admin consent may be required for certain Graph API scopes
 </Callout>
 
 ##### SharePoint Integration
@@ -1102,10 +2144,30 @@ LibreChat supports direct integration with SharePoint Online and OneDrive for Bu
 
 <OptionTable
   options={[
-    ['ENABLE_SHAREPOINT_FILEPICKER', 'boolean', 'Enable SharePoint file picker in chat and agent panels. When enabled, adds "From SharePoint" option in file attachment menu.', 'ENABLE_SHAREPOINT_FILEPICKER=true'],
-    ['SHAREPOINT_BASE_URL', 'string', 'SharePoint tenant base URL. Required when SharePoint integration is enabled.', 'SHAREPOINT_BASE_URL=https://yourtenant.sharepoint.com'],
-    ['SHAREPOINT_PICKER_SHAREPOINT_SCOPE', 'string', 'SharePoint-specific OAuth scope for the file picker. Used for authentication when opening the SharePoint file picker interface.', 'SHAREPOINT_PICKER_SHAREPOINT_SCOPE=https://yourtenant.sharepoint.com/AllSites.Read'],
-    ['SHAREPOINT_PICKER_GRAPH_SCOPE', 'string', 'Microsoft Graph API scope for file downloads. Used for downloading files from SharePoint after selection.', 'SHAREPOINT_PICKER_GRAPH_SCOPE=Files.Read.All'],
+    [
+      'ENABLE_SHAREPOINT_FILEPICKER',
+      'boolean',
+      'Enable SharePoint file picker in chat and agent panels. When enabled, adds "From SharePoint" option in file attachment menu.',
+      'ENABLE_SHAREPOINT_FILEPICKER=true',
+    ],
+    [
+      'SHAREPOINT_BASE_URL',
+      'string',
+      'SharePoint tenant base URL. Required when SharePoint integration is enabled.',
+      'SHAREPOINT_BASE_URL=https://yourtenant.sharepoint.com',
+    ],
+    [
+      'SHAREPOINT_PICKER_SHAREPOINT_SCOPE',
+      'string',
+      'SharePoint-specific OAuth scope for the file picker. Used for authentication when opening the SharePoint file picker interface.',
+      'SHAREPOINT_PICKER_SHAREPOINT_SCOPE=https://yourtenant.sharepoint.com/AllSites.Read',
+    ],
+    [
+      'SHAREPOINT_PICKER_GRAPH_SCOPE',
+      'string',
+      'Microsoft Graph API scope for file downloads. Used for downloading files from SharePoint after selection.',
+      'SHAREPOINT_PICKER_GRAPH_SCOPE=Files.Read.All',
+    ],
   ]}
 />
 
@@ -1122,11 +2184,9 @@ LibreChat supports direct integration with SharePoint Online and OneDrive for Bu
 </Callout>
 
 <Callout type="info" title="Feature Capabilities">
-When enabled, users can:
-- Access files from SharePoint document libraries and OneDrive for Business
-- Select multiple files at once (default max: 10 files)
-- See real-time download progress
-- Files are downloaded and attached to the conversation like regular uploads
+  When enabled, users can: - Access files from SharePoint document libraries and OneDrive for
+  Business - Select multiple files at once (default max: 10 files) - See real-time download progress
+  - Files are downloaded and attached to the conversation like regular uploads
 </Callout>
 
 For detailed SharePoint configuration instructions, see: [SharePoint Integration Guide](/docs/configuration/sharepoint)
@@ -1134,30 +2194,97 @@ For detailed SharePoint configuration instructions, see: [SharePoint Integration
 #### SAML
 
 For more information:
-  - [Auth0](/docs/configuration/authentication/SAML/auth0)
+
+- [Auth0](/docs/configuration/authentication/SAML/auth0)
 
 <Callout type="warning" title="Mutual Exclusion of OpenID and SAML">
 If OpenID is enabled, SAML authentication will be automatically disabled.
 
 Only one authentication method can be active at a time.
+
 </Callout>
 
 <OptionTable
   options={[
-    ['SAML_ENTRY_POINT', 'string', 'The SAML identity provider (IdP) entry point URL.', 'SAML_ENTRY_POINT='],
+    [
+      'SAML_ENTRY_POINT',
+      'string',
+      'The SAML identity provider (IdP) entry point URL.',
+      'SAML_ENTRY_POINT=',
+    ],
     ['SAML_ISSUER', 'string', 'The SAML service provider (SP) entity ID.', 'SAML_ISSUER='],
-    ['SAML_CERT', 'string', 'The SAML signing certificate, provided as a file path or a one-line PEM string.', 'SAML_CERT='],
-    ['SAML_CALLBACK_URL', 'string', 'The callback URL for SAML authentication.','SAML_CALLBACK_URL=/oauth/saml/callback'],
-    ['SAML_SESSION_SECRET', 'string', 'The secret for SAML session storage.','SAML_SESSION_SECRET='],
-    ['SAML_EMAIL_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the user email. (default: email)','SAML_EMAIL_CLAIM='],
-    ['SAML_USERNAME_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the username. (default: username)','SAML_USERNAME_CLAIM='],
-    ['SAML_GIVEN_NAME_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the given name. (default: given_name)','SAML_GIVEN_NAME_CLAIM='],
-    ['SAML_FAMILY_NAME_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the family name. (default: family_name)','SAML_FAMILY_NAME_CLAIM='],
-    ['SAML_PICTURE_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the profile picture URL. (default: picture)','SAML_PICTURE_CLAIM='],
-    ['SAML_NAME_CLAIM', 'string', '<Optional>: The attribute in the SAML assertion containing the full name.','SAML_NAME_CLAIM='],
-    ['SAML_BUTTON_LABEL', 'string', '<Optional>: The label for the SAML login button.','SAML_BUTTON_LABEL='],
-    ['SAML_IMAGE_URL', 'string', '<Optional>: The URL of the SAML login button image.','SAML_IMAGE_URL='],
-    ['SAML_USE_AUTHN_RESPONSE_SIGNED', 'boolean', '<Optional>: If "true", signs the entire SAML Response. Otherwise, only the Assertion is signed (default).', 'SAML_USE_AUTHN_RESPONSE_SIGNED=']
+    [
+      'SAML_CERT',
+      'string',
+      'The SAML signing certificate, provided as a file path or a one-line PEM string.',
+      'SAML_CERT=',
+    ],
+    [
+      'SAML_CALLBACK_URL',
+      'string',
+      'The callback URL for SAML authentication.',
+      'SAML_CALLBACK_URL=/oauth/saml/callback',
+    ],
+    [
+      'SAML_SESSION_SECRET',
+      'string',
+      'The secret for SAML session storage.',
+      'SAML_SESSION_SECRET=',
+    ],
+    [
+      'SAML_EMAIL_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the user email. (default: email)',
+      'SAML_EMAIL_CLAIM=',
+    ],
+    [
+      'SAML_USERNAME_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the username. (default: username)',
+      'SAML_USERNAME_CLAIM=',
+    ],
+    [
+      'SAML_GIVEN_NAME_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the given name. (default: given_name)',
+      'SAML_GIVEN_NAME_CLAIM=',
+    ],
+    [
+      'SAML_FAMILY_NAME_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the family name. (default: family_name)',
+      'SAML_FAMILY_NAME_CLAIM=',
+    ],
+    [
+      'SAML_PICTURE_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the profile picture URL. (default: picture)',
+      'SAML_PICTURE_CLAIM=',
+    ],
+    [
+      'SAML_NAME_CLAIM',
+      'string',
+      '<Optional>: The attribute in the SAML assertion containing the full name.',
+      'SAML_NAME_CLAIM=',
+    ],
+    [
+      'SAML_BUTTON_LABEL',
+      'string',
+      '<Optional>: The label for the SAML login button.',
+      'SAML_BUTTON_LABEL=',
+    ],
+    [
+      'SAML_IMAGE_URL',
+      'string',
+      '<Optional>: The URL of the SAML login button image.',
+      'SAML_IMAGE_URL=',
+    ],
+    [
+      'SAML_USE_AUTHN_RESPONSE_SIGNED',
+      'boolean',
+      '<Optional>: If "true", signs the entire SAML Response. Otherwise, only the Assertion is signed (default).',
+      'SAML_USE_AUTHN_RESPONSE_SIGNED=',
+    ],
   ]}
 />
 
@@ -1166,66 +2293,66 @@ Only one authentication method can be active at a time.
 For more information: **[LDAP/AD Authentication](/docs/configuration/authentication/ldap)**
 
 <OptionTable
-    options={[
-        ['LDAP_URL', 'string', 'LDAP server URL.', 'LDAP_URL=ldap://localhost:389'],
-        ['LDAP_BIND_DN', 'string', 'Bind DN', 'LDAP_BIND_DN=cn=root'],
-        ['LDAP_BIND_CREDENTIALS', 'string', 'Password for bindDN', 'LDAP_BIND_CREDENTIALS=password'],
-        [
-            'LDAP_USER_SEARCH_BASE',
-            'string',
-            'LDAP user search base',
-            'LDAP_USER_SEARCH_BASE=o=users,o=example.com',
-        ],
-        ['LDAP_SEARCH_FILTER', 'string', 'LDAP search filter', 'LDAP_SEARCH_FILTER=mail={{username}}'],
-        [
-            'LDAP_CA_CERT_PATH',
-            'string',
-            'CA certificate path.',
-            'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
-        ],
-        [
-            'LDAP_TLS_REJECT_UNAUTHORIZED',
-            'string',
-            'LDAP TLS verification',
-            'LDAP_TLS_REJECT_UNAUTHORIZED=true',
-        ],
-        [
-            'LDAP_STARTTLS',
-            'string',
-            'Enable LDAP StartTLS for upgrading the connection to TLS. Set to true to enable this feature.',
-            'LDAP_STARTTLS=true',
-        ],
-        [
-            'LDAP_LOGIN_USES_USERNAME',
-            'boolean',
-            'Use username instead of email for LDAP login.',
-            '# LDAP_LOGIN_USES_USERNAME=true',
-        ],
-        [
-            'LDAP_ID',
-            'string',
-            'LDAP attribute for unique user ID. Default: uid or sAMAccountName, mail.',
-            '# LDAP_ID=uid',
-        ],
-        [
-            'LDAP_USERNAME',
-            'string',
-            'LDAP attribute for username. Default: givenName or mail.',
-            '# LDAP_USERNAME=givenName',
-        ],
-        [
-            'LDAP_EMAIL',
-            'string',
-            'LDAP attribute for email. Default: mail.',
-            '# LDAP_EMAIL=userPrincipalName',
-        ],
-        [
-            'LDAP_FULL_NAME',
-            'string',
-            'LDAP attribute(s) for full name. Can be comma-separated. Default: givenName + surname.',
-            '# LDAP_FULL_NAME=givenName,surname',
-        ],
-    ]}
+  options={[
+    ['LDAP_URL', 'string', 'LDAP server URL.', 'LDAP_URL=ldap://localhost:389'],
+    ['LDAP_BIND_DN', 'string', 'Bind DN', 'LDAP_BIND_DN=cn=root'],
+    ['LDAP_BIND_CREDENTIALS', 'string', 'Password for bindDN', 'LDAP_BIND_CREDENTIALS=password'],
+    [
+      'LDAP_USER_SEARCH_BASE',
+      'string',
+      'LDAP user search base',
+      'LDAP_USER_SEARCH_BASE=o=users,o=example.com',
+    ],
+    ['LDAP_SEARCH_FILTER', 'string', 'LDAP search filter', 'LDAP_SEARCH_FILTER=mail={{username}}'],
+    [
+      'LDAP_CA_CERT_PATH',
+      'string',
+      'CA certificate path.',
+      'LDAP_CA_CERT_PATH=/path/to/root_ca_cert.crt',
+    ],
+    [
+      'LDAP_TLS_REJECT_UNAUTHORIZED',
+      'string',
+      'LDAP TLS verification',
+      'LDAP_TLS_REJECT_UNAUTHORIZED=true',
+    ],
+    [
+      'LDAP_STARTTLS',
+      'string',
+      'Enable LDAP StartTLS for upgrading the connection to TLS. Set to true to enable this feature.',
+      'LDAP_STARTTLS=true',
+    ],
+    [
+      'LDAP_LOGIN_USES_USERNAME',
+      'boolean',
+      'Use username instead of email for LDAP login.',
+      '# LDAP_LOGIN_USES_USERNAME=true',
+    ],
+    [
+      'LDAP_ID',
+      'string',
+      'LDAP attribute for unique user ID. Default: uid or sAMAccountName, mail.',
+      '# LDAP_ID=uid',
+    ],
+    [
+      'LDAP_USERNAME',
+      'string',
+      'LDAP attribute for username. Default: givenName or mail.',
+      '# LDAP_USERNAME=givenName',
+    ],
+    [
+      'LDAP_EMAIL',
+      'string',
+      'LDAP attribute for email. Default: mail.',
+      '# LDAP_EMAIL=userPrincipalName',
+    ],
+    [
+      'LDAP_FULL_NAME',
+      'string',
+      'LDAP attribute(s) for full name. Can be comma-separated. Default: givenName + surname.',
+      '# LDAP_FULL_NAME=givenName,surname',
+    ],
+  ]}
 />
 
 ### Password Reset
@@ -1242,11 +2369,31 @@ Mailgun is particularly useful for deployments on servers that block SMTP ports.
 
 <OptionTable
   options={[
-    ['MAILGUN_API_KEY', 'string', 'Your Mailgun API key (required for Mailgun).','MAILGUN_API_KEY='],
-    ['MAILGUN_DOMAIN', 'string', 'Your Mailgun domain (required for Mailgun).','MAILGUN_DOMAIN=mg.yourdomain.com'],
-    ['MAILGUN_HOST', 'string', 'Custom Mailgun API host (optional). Use https://api.eu.mailgun.net for EU region.','MAILGUN_HOST=https://api.mailgun.net'],
-    ['EMAIL_FROM', 'string', 'From email address. Required.','EMAIL_FROM=noreply@librechat.ai'],
-    ['EMAIL_FROM_NAME', 'string', 'From name (defaults to APP_TITLE if not set).','EMAIL_FROM_NAME='],
+    [
+      'MAILGUN_API_KEY',
+      'string',
+      'Your Mailgun API key (required for Mailgun).',
+      'MAILGUN_API_KEY=',
+    ],
+    [
+      'MAILGUN_DOMAIN',
+      'string',
+      'Your Mailgun domain (required for Mailgun).',
+      'MAILGUN_DOMAIN=mg.yourdomain.com',
+    ],
+    [
+      'MAILGUN_HOST',
+      'string',
+      'Custom Mailgun API host (optional). Use https://api.eu.mailgun.net for EU region.',
+      'MAILGUN_HOST=https://api.mailgun.net',
+    ],
+    ['EMAIL_FROM', 'string', 'From email address. Required.', 'EMAIL_FROM=noreply@librechat.ai'],
+    [
+      'EMAIL_FROM_NAME',
+      'string',
+      'From name (defaults to APP_TITLE if not set).',
+      'EMAIL_FROM_NAME=',
+    ],
   ]}
 />
 
@@ -1261,16 +2408,26 @@ See: **[nodemailer well-known-services](https://community.nodemailer.com/2-0-0-b
 
 <OptionTable
   options={[
-    ['EMAIL_SERVICE', 'string', 'Email service (e.g., Gmail, Outlook).','EMAIL_SERVICE='],
-    ['EMAIL_HOST', 'string', 'Mail server host.','EMAIL_HOST='],
-    ['EMAIL_PORT', 'number', 'Mail server port.','EMAIL_PORT=25'],
-    ['EMAIL_ENCRYPTION', 'string', 'Encryption method (starttls, tls, etc.).','EMAIL_ENCRYPTION='],
-    ['EMAIL_ENCRYPTION_HOSTNAME', 'string', 'Hostname for encryption.','EMAIL_ENCRYPTION_HOSTNAME='],
-    ['EMAIL_ALLOW_SELFSIGNED', 'boolean', 'Allow self-signed certificates.','EMAIL_ALLOW_SELFSIGNED='],
-    ['EMAIL_USERNAME', 'string', 'Username for authentication.','EMAIL_USERNAME='],
-    ['EMAIL_PASSWORD', 'string', 'Password for authentication.','EMAIL_PASSWORD='],
-    ['EMAIL_FROM_NAME', 'string', 'From name.','EMAIL_FROM_NAME='],
-    ['EMAIL_FROM', 'string', 'From email address. Required.','EMAIL_FROM=noreply@librechat.ai'],
+    ['EMAIL_SERVICE', 'string', 'Email service (e.g., Gmail, Outlook).', 'EMAIL_SERVICE='],
+    ['EMAIL_HOST', 'string', 'Mail server host.', 'EMAIL_HOST='],
+    ['EMAIL_PORT', 'number', 'Mail server port.', 'EMAIL_PORT=25'],
+    ['EMAIL_ENCRYPTION', 'string', 'Encryption method (starttls, tls, etc.).', 'EMAIL_ENCRYPTION='],
+    [
+      'EMAIL_ENCRYPTION_HOSTNAME',
+      'string',
+      'Hostname for encryption.',
+      'EMAIL_ENCRYPTION_HOSTNAME=',
+    ],
+    [
+      'EMAIL_ALLOW_SELFSIGNED',
+      'boolean',
+      'Allow self-signed certificates.',
+      'EMAIL_ALLOW_SELFSIGNED=',
+    ],
+    ['EMAIL_USERNAME', 'string', 'Username for authentication.', 'EMAIL_USERNAME='],
+    ['EMAIL_PASSWORD', 'string', 'Password for authentication.', 'EMAIL_PASSWORD='],
+    ['EMAIL_FROM_NAME', 'string', 'From name.', 'EMAIL_FROM_NAME='],
+    ['EMAIL_FROM', 'string', 'From email address. Required.', 'EMAIL_FROM=noreply@librechat.ai'],
   ]}
 />
 
@@ -1279,36 +2436,98 @@ See: **[nodemailer well-known-services](https://community.nodemailer.com/2-0-0-b
 See: **[Firebase CDN Configuration](/docs/configuration/cdn/firebase)**
 
 <Callout type="warning" title="Important">
-- If you are using Firebase as your file storage strategy, make sure to set the `file_strategy` option to `firebase` in your `librechat.yaml` configuration file. - For more information on configuring the `librechat.yaml` file, please refer to the YAML Configuration Guide: [Custom Endpoints & Configuration](/docs/configuration/librechat_yaml)
+  - If you are using Firebase as your file storage strategy, set `fileStrategy` or `fileStrategies`
+  to `firebase` in your `librechat.yaml` configuration file. For more information on configuring the
+  `librechat.yaml` file, please refer to the YAML Configuration Guide: [Custom Endpoints &
+  Configuration](/docs/configuration/librechat_yaml)
 </Callout>
 
 <OptionTable
   options={[
     ['FIREBASE_API_KEY', 'string', 'The API key for your Firebase project.', 'FIREBASE_API_KEY='],
-    ['FIREBASE_AUTH_DOMAIN', 'string', 'The Firebase Auth domain for your project.', 'FIREBASE_AUTH_DOMAIN='],
+    [
+      'FIREBASE_AUTH_DOMAIN',
+      'string',
+      'The Firebase Auth domain for your project.',
+      'FIREBASE_AUTH_DOMAIN=',
+    ],
     ['FIREBASE_PROJECT_ID', 'string', 'The ID of your Firebase project.', 'FIREBASE_PROJECT_ID='],
-    ['FIREBASE_STORAGE_BUCKET', 'string', 'The Firebase Storage bucket for your project.', 'FIREBASE_STORAGE_BUCKET='],
-    ['FIREBASE_MESSAGING_SENDER_ID', 'string', 'The Firebase Cloud Messaging sender ID.', 'FIREBASE_MESSAGING_SENDER_ID='],
+    [
+      'FIREBASE_STORAGE_BUCKET',
+      'string',
+      'The Firebase Storage bucket for your project.',
+      'FIREBASE_STORAGE_BUCKET=',
+    ],
+    [
+      'FIREBASE_MESSAGING_SENDER_ID',
+      'string',
+      'The Firebase Cloud Messaging sender ID.',
+      'FIREBASE_MESSAGING_SENDER_ID=',
+    ],
     ['FIREBASE_APP_ID', 'string', 'The Firebase App ID for your project.', 'FIREBASE_APP_ID='],
   ]}
 />
 
-### Amazon S3 CDN
+### Amazon S3 and CloudFront
 
-See: **[Amazon S3 CDN Configuration](/docs/configuration/cdn/s3)**
+See: **[Amazon S3 Configuration](/docs/configuration/cdn/s3)** and **[CloudFront with S3](/docs/configuration/cdn/cloudfront)**
 
 <Callout type="warning" title="Important">
-If you are using S3 as your file storage strategy, make sure to set the `file_strategy` option to `s3` in your `librechat.yaml` configuration file.
+  If you are using S3 as your file storage strategy, set `fileStrategy` or `fileStrategies` in your
+  `librechat.yaml` configuration file. If you use CloudFront, S3 is still required as the storage
+  origin.
 </Callout>
 
 <OptionTable
   options={[
-    ['AWS_ACCESS_KEY_ID', 'string', 'Your IAM user access key ID. Optional if using IRSA.', 'AWS_ACCESS_KEY_ID=your_access_key_id'],
-    ['AWS_SECRET_ACCESS_KEY', 'string', 'Your IAM user secret access key. Optional if using IRSA.', 'AWS_SECRET_ACCESS_KEY=your_secret_access_key'],
-    ['AWS_REGION', 'string', 'The AWS region where your S3 bucket is located.', 'AWS_REGION=us-east-1'],
-    ['AWS_BUCKET_NAME', 'string', 'The name of the S3 bucket for file storage.', 'AWS_BUCKET_NAME=your_bucket_name'],
-    ['AWS_ENDPOINT_URL', 'string', 'Custom AWS endpoint URL (optional). For S3-compatible services.', '# AWS_ENDPOINT_URL='],
-    ['AWS_FORCE_PATH_STYLE', 'boolean', 'Set to true for S3-compatible providers that require path-style URLs (e.g. MinIO, Hetzner, Backblaze B2). Not needed for AWS S3. Default: false.', '# AWS_FORCE_PATH_STYLE=false'],
+    [
+      'AWS_ACCESS_KEY_ID',
+      'string',
+      'Your IAM user access key ID. Optional if using IRSA.',
+      'AWS_ACCESS_KEY_ID=your_access_key_id',
+    ],
+    [
+      'AWS_SECRET_ACCESS_KEY',
+      'string',
+      'Your IAM user secret access key. Optional if using IRSA.',
+      'AWS_SECRET_ACCESS_KEY=your_secret_access_key',
+    ],
+    [
+      'AWS_REGION',
+      'string',
+      'The AWS region where your S3 bucket is located.',
+      'AWS_REGION=us-east-1',
+    ],
+    [
+      'AWS_BUCKET_NAME',
+      'string',
+      'The name of the S3 bucket for file storage.',
+      'AWS_BUCKET_NAME=your_bucket_name',
+    ],
+    [
+      'AWS_ENDPOINT_URL',
+      'string',
+      'Custom AWS endpoint URL (optional). For S3-compatible services.',
+      '# AWS_ENDPOINT_URL=',
+    ],
+    [
+      'AWS_FORCE_PATH_STYLE',
+      'boolean',
+      'Set to true for S3-compatible providers that require path-style URLs (e.g. MinIO, Hetzner, Backblaze B2). Not needed for AWS S3. Default: false.',
+      '# AWS_FORCE_PATH_STYLE=false',
+    ],
+    [
+      'CLOUDFRONT_KEY_PAIR_ID',
+      'string',
+      'CloudFront public key pair ID. Required for signed cookies and signed CloudFront download URLs.',
+      '# CLOUDFRONT_KEY_PAIR_ID=K1234567890ABC',
+    ],
+    [
+      'CLOUDFRONT_PRIVATE_KEY',
+      'string',
+      'CloudFront private key PEM. Required for signed cookies and signed CloudFront download URLs. Preserve PEM newlines when injecting this secret.',
+      '# CLOUDFRONT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\n...\\n-----END RSA PRIVATE KEY-----"',
+    ],
   ]}
 />
 
@@ -1319,15 +2538,36 @@ If you are using S3 as your file storage strategy, make sure to set the `file_st
 See: **[Azure Blob Storage CDN Configuration](/docs/configuration/cdn/azure)**
 
 <Callout type="warning" title="Important">
-If you are using Azure Blob Storage as your file storage strategy, make sure to set the `file_strategy` option to `azure_blob` in your `librechat.yaml` configuration file.
+  If you are using Azure Blob Storage as your file storage strategy, set `fileStrategy` or
+  `fileStrategies` to `azure_blob` in your `librechat.yaml` configuration file.
 </Callout>
 
 <OptionTable
   options={[
-    ['AZURE_STORAGE_CONNECTION_STRING', 'string', 'Azure Blob Storage connection string. Use this OR AZURE_STORAGE_ACCOUNT_NAME for Managed Identity.', 'AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...'],
-    ['AZURE_STORAGE_ACCOUNT_NAME', 'string', 'Azure Storage account name. Use for Managed Identity authentication (do not set connection string).', '# AZURE_STORAGE_ACCOUNT_NAME=yourAccountName'],
-    ['AZURE_STORAGE_PUBLIC_ACCESS', 'boolean', 'Enable public access for blobs. Default: false.', 'AZURE_STORAGE_PUBLIC_ACCESS=false'],
-    ['AZURE_CONTAINER_NAME', 'string', 'Container name for file storage. Default: files.', 'AZURE_CONTAINER_NAME=files'],
+    [
+      'AZURE_STORAGE_CONNECTION_STRING',
+      'string',
+      'Azure Blob Storage connection string. Use this OR AZURE_STORAGE_ACCOUNT_NAME for Managed Identity.',
+      'AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...',
+    ],
+    [
+      'AZURE_STORAGE_ACCOUNT_NAME',
+      'string',
+      'Azure Storage account name. Use for Managed Identity authentication (do not set connection string).',
+      '# AZURE_STORAGE_ACCOUNT_NAME=yourAccountName',
+    ],
+    [
+      'AZURE_STORAGE_PUBLIC_ACCESS',
+      'boolean',
+      'Enable public access for blobs. Default: false.',
+      'AZURE_STORAGE_PUBLIC_ACCESS=false',
+    ],
+    [
+      'AZURE_CONTAINER_NAME',
+      'string',
+      'Container name for file storage. Default: files.',
+      'AZURE_CONTAINER_NAME=files',
+    ],
   ]}
 />
 
@@ -1339,7 +2579,12 @@ If you are using Azure Blob Storage as your file storage strategy, make sure to 
 
 <OptionTable
   options={[
-    ['HELP_AND_FAQ_URL', 'string', 'Help and FAQ URL. If empty or commented, the button is enabled. To disable the Help and FAQ button, set to "/".','HELP_AND_FAQ_URL=https://librechat.ai'],
+    [
+      'HELP_AND_FAQ_URL',
+      'string',
+      'Help and FAQ URL. If empty or commented, the button is enabled. To disable the Help and FAQ button, set to "/".',
+      'HELP_AND_FAQ_URL=https://librechat.ai',
+    ],
   ]}
 />
 
@@ -1349,42 +2594,46 @@ Sets the [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Heade
 
 Properly setting cache headers is crucial for optimizing the performance and efficiency of your web application. By controlling how long browsers and CDNs store copies of your static files, you can significantly reduce server load, decrease page load times, and improve the overall user experience.
 
-* Uncomment `STATIC_CACHE_MAX_AGE` to change the `max-age` for static files. By default this is set to 4 weeks.
-* Uncomment `STATIC_CACHE_S_MAX_AGE` to change the `s-maxage` for static files. By default this is set to 1 week.
+- Uncomment `STATIC_CACHE_MAX_AGE` to change the `max-age` for static files. By default this is set to 4 weeks.
+- Uncomment `STATIC_CACHE_S_MAX_AGE` to change the `s-maxage` for static files. By default this is set to 1 week.
   - This is for the _shared cache_, which is used by CDNs and proxies.
 
 #### App Title and Footer
 
 <OptionTable
   options={[
-    ['APP_TITLE', 'string', 'App title.','APP_TITLE=LibreChat'],
-    ['CUSTOM_FOOTER', 'string', 'Custom footer.','# CUSTOM_FOOTER="My custom footer"'],
-    ['TEMP_CHAT_RETENTION_HOURS', 'number', '**Deprecated:** Use `interface.temporaryChatRetention` in librechat.yaml instead. Hours to retain temporary chats. Default: 720 (30 days).','# TEMP_CHAT_RETENTION_HOURS=168'],
+    ['APP_TITLE', 'string', 'App title.', 'APP_TITLE=LibreChat'],
+    ['CUSTOM_FOOTER', 'string', 'Custom footer.', '# CUSTOM_FOOTER="My custom footer"'],
+    [
+      'TEMP_CHAT_RETENTION_HOURS',
+      'number',
+      '**Deprecated:** Use `interface.temporaryChatRetention` in librechat.yaml instead. Hours to retain temporary chats. Default: 720 (30 days).',
+      '# TEMP_CHAT_RETENTION_HOURS=168',
+    ],
   ]}
 />
 
 **Behaviour:**
 
- * Uncomment `CUSTOM_FOOTER` to add a custom footer.
- * Uncomment and leave `CUSTOM_FOOTER` empty to remove the footer.
- * You can now add one or more links in the CUSTOM_FOOTER value using the following format: `[Anchor text](URL)`. Each link should be delineated with a pipe (`|`).
+- Uncomment `CUSTOM_FOOTER` to add a custom footer.
+- Uncomment and leave `CUSTOM_FOOTER` empty to remove the footer.
+- You can now add one or more links in the CUSTOM_FOOTER value using the following format: `[Anchor text](URL)`. Each link should be delineated with a pipe (`|`).
 
- > **Markdown example:** `CUSTOM_FOOTER=[Link 1](http://example1.com) | [Link 2](http://example2.com)`
+> **Markdown example:** `CUSTOM_FOOTER=[Link 1](http://example1.com) | [Link 2](http://example2.com)`
 
 #### Birthday Hat
 
 <OptionTable
   options={[
-    ['SHOW_BIRTHDAY_ICON', 'boolean', 'Show the birthday hat icon.','# SHOW_BIRTHDAY_ICON=true'],
+    ['SHOW_BIRTHDAY_ICON', 'boolean', 'Show the birthday hat icon.', '# SHOW_BIRTHDAY_ICON=true'],
   ]}
 />
 
 **Behaviour:**
 
-* The birthday hat icon will show automatically on February 11th (LibreChat's birthday).
-* Set `SHOW_BIRTHDAY_ICON` to `false` to disable the birthday hat.
-* Set `SHOW_BIRTHDAY_ICON` to `true` to enable the birthday hat all the time.
-
+- The birthday hat icon will show automatically on February 11th (LibreChat's birthday).
+- Set `SHOW_BIRTHDAY_ICON` to `false` to disable the birthday hat.
+- Set `SHOW_BIRTHDAY_ICON` to `true` to enable the birthday hat all the time.
 
 ### Analytics
 
@@ -1395,9 +2644,7 @@ LibreChat supports Google Tag Manager for analytics. You will need a Google Tag 
 **Note:** If `ANALYTICS_GTM_ID` is not set, Google Tag Manager will not be enabled. If it is set incorrectly, you will see failing requests to `gtm.js`
 
 <OptionTable
-  options={[
-    ['ANALYTICS_GTM_ID', 'string', 'Google Tag Manager ID.','ANALYTICS_GTM_ID='],
-  ]}
+  options={[['ANALYTICS_GTM_ID', 'string', 'Google Tag Manager ID.', 'ANALYTICS_GTM_ID=']]}
 />
 
 #### Conversation Import
@@ -1406,7 +2653,12 @@ Configure limits for conversation file imports to prevent memory issues.
 
 <OptionTable
   options={[
-    ['CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES', 'number', 'Maximum file size in bytes for conversation imports. Default: 0 (no limit enforced). Example: 262144000 (250 MiB).','# CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000'],
+    [
+      'CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES',
+      'number',
+      'Maximum file size in bytes for conversation imports. Default: 0 (no limit enforced). Example: 262144000 (250 MiB).',
+      '# CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000',
+    ],
   ]}
 />
 
@@ -1418,10 +2670,30 @@ Configure Model Context Protocol settings for enhanced server management and OAu
 
 <OptionTable
   options={[
-    ['MCP_OAUTH_ON_AUTH_ERROR', 'boolean', 'Treat 401/403 responses as OAuth requirement when no oauth metadata found.', 'MCP_OAUTH_ON_AUTH_ERROR=true'],
-    ['MCP_OAUTH_DETECTION_TIMEOUT', 'number', 'Timeout for OAuth detection requests in milliseconds.', 'MCP_OAUTH_DETECTION_TIMEOUT=5000'],
-    ['MCP_CONNECTION_CHECK_TTL', 'number', 'Cache connection status checks for this many milliseconds to avoid expensive verification.', 'MCP_CONNECTION_CHECK_TTL=30000'],
-    ['MCP_SKIP_CODE_CHALLENGE_CHECK', 'boolean', 'Skip code challenge method validation. When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration', 'MCP_SKIP_CODE_CHALLENGE_CHECK=false'],
+    [
+      'MCP_OAUTH_ON_AUTH_ERROR',
+      'boolean',
+      'Treat 401/403 responses as OAuth requirement when no oauth metadata found.',
+      'MCP_OAUTH_ON_AUTH_ERROR=true',
+    ],
+    [
+      'MCP_OAUTH_DETECTION_TIMEOUT',
+      'number',
+      'Timeout for OAuth detection requests in milliseconds.',
+      'MCP_OAUTH_DETECTION_TIMEOUT=5000',
+    ],
+    [
+      'MCP_CONNECTION_CHECK_TTL',
+      'number',
+      'Cache connection status checks for this many milliseconds to avoid expensive verification.',
+      'MCP_CONNECTION_CHECK_TTL=30000',
+    ],
+    [
+      'MCP_SKIP_CODE_CHALLENGE_CHECK',
+      'boolean',
+      'Skip code challenge method validation. When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration',
+      'MCP_SKIP_CODE_CHALLENGE_CHECK=false',
+    ],
   ]}
 />
 
@@ -1439,23 +2711,89 @@ For detailed configuration and examples, see: **[Redis Configuration Guide](/doc
 
 <OptionTable
   options={[
-    ['USE_REDIS', 'boolean', 'Enable Redis for caching and session storage. When true, REDIS_URI must be provided.', 'USE_REDIS=true'],
-    ['USE_REDIS_STREAMS', 'boolean', 'Enable Redis for resumable LLM streams. Defaults to USE_REDIS value if not set. Set to false to use in-memory storage for streams.', '# USE_REDIS_STREAMS=true'],
-    ['REDIS_URI', 'string', 'Redis connection URI. For single instance: redis://host:port. For cluster: comma-separated URIs.', 'REDIS_URI=redis://127.0.0.1:6379'],
-    ['USE_REDIS_CLUSTER', 'boolean', 'Enable Redis cluster mode when using a single URI', '# USE_REDIS_CLUSTER="true"'],
-    ['REDIS_USERNAME', 'string', 'Redis username for authentication. Overrides username in URI if both provided.', '# REDIS_USERNAME=your_redis_username'],
-    ['REDIS_PASSWORD', 'string', 'Redis password for authentication. Overrides password in URI if both provided.', '# REDIS_PASSWORD=your_redis_password'],
-    ['REDIS_CA', 'string', 'Path to CA certificate for TLS verification when using rediss:// protocol.', '# REDIS_CA=/path/to/ca-cert.pem'],
-    ['REDIS_KEY_PREFIX', 'string', 'Static prefix for all Redis keys to prevent cross-deployment contamination.', '# REDIS_KEY_PREFIX=librechat-prod-v2'],
-    ['REDIS_KEY_PREFIX_VAR', 'string', 'Environment variable name containing dynamic prefix (e.g., K_REVISION for Cloud Run). Cannot be used with REDIS_KEY_PREFIX.', '# REDIS_KEY_PREFIX_VAR=K_REVISION'],
-    ['REDIS_MAX_LISTENERS', 'number', 'Maximum event listeners per Redis client. Prevents memory leaks. Default: 40.', '# REDIS_MAX_LISTENERS=40'],
-    ['REDIS_PING_INTERVAL', 'number', 'Ping interval in seconds to maintain connections. Default: 0 (disabled). Only set if experiencing timeouts.', '# REDIS_PING_INTERVAL=300'],
-    ['FORCED_IN_MEMORY_CACHE_NAMESPACES', 'string', 'Comma-separated cache keys to force in-memory storage even when Redis is enabled.', '# FORCED_IN_MEMORY_CACHE_NAMESPACES=ROLES,MESSAGES'],
-    ['REDIS_USE_ALTERNATIVE_DNS_LOOKUP', 'boolean', 'Enable alternate dnsLookup for TLS connections with AWS Elasticache. Required for Elasticache clusters with TLS.', '# REDIS_USE_ALTERNATIVE_DNS_LOOKUP=true'],
+    [
+      'USE_REDIS',
+      'boolean',
+      'Enable Redis for caching and session storage. When true, REDIS_URI must be provided.',
+      'USE_REDIS=true',
+    ],
+    [
+      'USE_REDIS_STREAMS',
+      'boolean',
+      'Enable Redis for resumable LLM streams. Defaults to USE_REDIS value if not set. Set to false to use in-memory storage for streams.',
+      '# USE_REDIS_STREAMS=true',
+    ],
+    [
+      'REDIS_URI',
+      'string',
+      'Redis connection URI. For single instance: redis://host:port. For cluster: comma-separated URIs.',
+      'REDIS_URI=redis://127.0.0.1:6379',
+    ],
+    [
+      'USE_REDIS_CLUSTER',
+      'boolean',
+      'Enable Redis cluster mode when using a single URI',
+      '# USE_REDIS_CLUSTER="true"',
+    ],
+    [
+      'REDIS_USERNAME',
+      'string',
+      'Redis username for authentication. Overrides username in URI if both provided.',
+      '# REDIS_USERNAME=your_redis_username',
+    ],
+    [
+      'REDIS_PASSWORD',
+      'string',
+      'Redis password for authentication. Overrides password in URI if both provided.',
+      '# REDIS_PASSWORD=your_redis_password',
+    ],
+    [
+      'REDIS_CA',
+      'string',
+      'Path to CA certificate for TLS verification when using rediss:// protocol.',
+      '# REDIS_CA=/path/to/ca-cert.pem',
+    ],
+    [
+      'REDIS_KEY_PREFIX',
+      'string',
+      'Static prefix for all Redis keys to prevent cross-deployment contamination.',
+      '# REDIS_KEY_PREFIX=librechat-prod-v2',
+    ],
+    [
+      'REDIS_KEY_PREFIX_VAR',
+      'string',
+      'Environment variable name containing dynamic prefix (e.g., K_REVISION for Cloud Run). Cannot be used with REDIS_KEY_PREFIX.',
+      '# REDIS_KEY_PREFIX_VAR=K_REVISION',
+    ],
+    [
+      'REDIS_MAX_LISTENERS',
+      'number',
+      'Maximum event listeners per Redis client. Prevents memory leaks. Default: 40.',
+      '# REDIS_MAX_LISTENERS=40',
+    ],
+    [
+      'REDIS_PING_INTERVAL',
+      'number',
+      'Ping interval in seconds to maintain connections. Default: 0 (disabled). Only set if experiencing timeouts.',
+      '# REDIS_PING_INTERVAL=300',
+    ],
+    [
+      'FORCED_IN_MEMORY_CACHE_NAMESPACES',
+      'string',
+      'Comma-separated cache keys to force in-memory storage even when Redis is enabled.',
+      '# FORCED_IN_MEMORY_CACHE_NAMESPACES=ROLES,MESSAGES',
+    ],
+    [
+      'REDIS_USE_ALTERNATIVE_DNS_LOOKUP',
+      'boolean',
+      'Enable alternate dnsLookup for TLS connections with AWS Elasticache. Required for Elasticache clusters with TLS.',
+      '# REDIS_USE_ALTERNATIVE_DNS_LOOKUP=true',
+    ],
   ]}
 />
 
 Notes:
+
 - When `USE_REDIS=true`, you must provide `REDIS_URI` or the application will throw an error.
 - For Redis Cluster mode, provide multiple URIs: `redis://node1:7001,redis://node2:7002,redis://node3:7003` (cluster mode is auto-detected).
 - Use `rediss://` protocol for TLS connections and set `REDIS_CA` if your CA is not publicly trusted.
@@ -1468,14 +2806,35 @@ Configure distributed leader election for multi-instance deployments with Redis.
 
 <OptionTable
   options={[
-    ['LEADER_LEASE_DURATION', 'number', 'Duration in seconds that the leader lease is valid before it expires. Default: 25.', 'LEADER_LEASE_DURATION=25'],
-    ['LEADER_RENEW_INTERVAL', 'number', 'Interval in seconds at which the leader renews its lease. Default: 10.', 'LEADER_RENEW_INTERVAL=10'],
-    ['LEADER_RENEW_ATTEMPTS', 'number', 'Maximum number of retry attempts when renewing the lease fails. Default: 3.', 'LEADER_RENEW_ATTEMPTS=3'],
-    ['LEADER_RENEW_RETRY_DELAY', 'number', 'Delay in seconds between retry attempts when renewing the lease. Default: 0.5.', 'LEADER_RENEW_RETRY_DELAY=0.5'],
+    [
+      'LEADER_LEASE_DURATION',
+      'number',
+      'Duration in seconds that the leader lease is valid before it expires. Default: 25.',
+      'LEADER_LEASE_DURATION=25',
+    ],
+    [
+      'LEADER_RENEW_INTERVAL',
+      'number',
+      'Interval in seconds at which the leader renews its lease. Default: 10.',
+      'LEADER_RENEW_INTERVAL=10',
+    ],
+    [
+      'LEADER_RENEW_ATTEMPTS',
+      'number',
+      'Maximum number of retry attempts when renewing the lease fails. Default: 3.',
+      'LEADER_RENEW_ATTEMPTS=3',
+    ],
+    [
+      'LEADER_RENEW_RETRY_DELAY',
+      'number',
+      'Delay in seconds between retry attempts when renewing the lease. Default: 0.5.',
+      'LEADER_RENEW_RETRY_DELAY=0.5',
+    ],
   ]}
 />
 
 Notes:
+
 - Leader election requires Redis to be enabled (`USE_REDIS=true`).
 - These settings are only relevant for multi-instance deployments.
 - The leader lease must be renewed before expiration to maintain leadership.

--- a/content/docs/configuration/librechat_yaml/example.mdx
+++ b/content/docs/configuration/librechat_yaml/example.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Example"
+title: 'Example'
 icon: FileCode
 ---
 
@@ -10,7 +10,7 @@ icon: FileCode
 This example config includes all documented endpoints (Except Azure, LiteLLM, MLX, and Ollama, which all require additional configurations)
 
 ```yaml filename="librechat.yaml"
-version: 1.3.5
+version: 1.3.11
 
 cache: true
 
@@ -18,7 +18,7 @@ interface:
   # MCP Servers UI configuration
   mcpServers:
     placeholder: 'MCP Servers'
-    
+
   # Privacy policy settings
   privacyPolicy:
     externalUrl: 'https://librechat.ai/privacy-policy'
@@ -30,220 +30,220 @@ interface:
     openNewTab: true
 
 registration:
-  socialLogins: ["discord", "facebook", "github", "google", "openid"]
+  socialLogins: ['discord', 'facebook', 'github', 'google', 'openid']
 
 endpoints:
   custom:
-
     # Anyscale
-    - name: "Anyscale"
-      apiKey: "${ANYSCALE_API_KEY}"
-      baseURL: "https://api.endpoints.anyscale.com/v1"
+    - name: 'Anyscale'
+      apiKey: '${ANYSCALE_API_KEY}'
+      baseURL: 'https://api.endpoints.anyscale.com/v1'
       models:
-        default: [
-          "meta-llama/Llama-2-7b-chat-hf",
-          ]
+        default: ['meta-llama/Llama-2-7b-chat-hf']
         fetch: true
       titleConvo: true
-      titleModel: "meta-llama/Llama-2-7b-chat-hf"
+      titleModel: 'meta-llama/Llama-2-7b-chat-hf'
       summarize: false
-      summaryModel: "meta-llama/Llama-2-7b-chat-hf"
-      modelDisplayLabel: "Anyscale"
+      summaryModel: 'meta-llama/Llama-2-7b-chat-hf'
+      modelDisplayLabel: 'Anyscale'
 
     # APIpie
-    - name: "APIpie"
-      apiKey: "${APIPIE_API_KEY}"
-      baseURL: "https://apipie.ai/v1/"
+    - name: 'APIpie'
+      apiKey: '${APIPIE_API_KEY}'
+      baseURL: 'https://apipie.ai/v1/'
       models:
-        default: [
-          "gpt-4",
-          "gpt-4-turbo",
-          "gpt-3.5-turbo",
-          "claude-3-opus",
-          "claude-3-sonnet",
-          "claude-3-haiku",
-          "llama-3-70b-instruct",
-          "llama-3-8b-instruct",
-          "gemini-pro-1.5",
-          "gemini-pro",
-          "mistral-large",
-          "mistral-medium",
-          "mistral-small",
-          "mistral-tiny",
-          "mixtral-8x22b",
+        default:
+          [
+            'gpt-4',
+            'gpt-4-turbo',
+            'gpt-3.5-turbo',
+            'claude-3-opus',
+            'claude-3-sonnet',
+            'claude-3-haiku',
+            'llama-3-70b-instruct',
+            'llama-3-8b-instruct',
+            'gemini-pro-1.5',
+            'gemini-pro',
+            'mistral-large',
+            'mistral-medium',
+            'mistral-small',
+            'mistral-tiny',
+            'mixtral-8x22b',
           ]
         fetch: false
       titleConvo: true
-      titleModel: "gpt-3.5-turbo"
-      dropParams: ["stream"]
+      titleModel: 'gpt-3.5-turbo'
+      dropParams: ['stream']
 
     #cohere
-    - name: "cohere"
-      apiKey: "${COHERE_API_KEY}"
-      baseURL: "https://api.cohere.ai/v1"
+    - name: 'cohere'
+      apiKey: '${COHERE_API_KEY}'
+      baseURL: 'https://api.cohere.ai/v1'
       models:
-        default: ["command-r","command-r-plus","command-light","command-light-nightly","command","command-nightly"]
+        default:
+          [
+            'command-r',
+            'command-r-plus',
+            'command-light',
+            'command-light-nightly',
+            'command',
+            'command-nightly',
+          ]
         fetch: false
-      modelDisplayLabel: "cohere"
-      titleModel: "command"
-      dropParams: ["stop", "user", "frequency_penalty", "presence_penalty", "temperature", "top_p"]
+      modelDisplayLabel: 'cohere'
+      titleModel: 'command'
+      dropParams: ['stop', 'user', 'frequency_penalty', 'presence_penalty', 'temperature', 'top_p']
 
     # Fireworks
-    - name: "Fireworks"
-      apiKey: "${FIREWORKS_API_KEY}"
-      baseURL: "https://api.fireworks.ai/inference/v1"
+    - name: 'Fireworks'
+      apiKey: '${FIREWORKS_API_KEY}'
+      baseURL: 'https://api.fireworks.ai/inference/v1'
       models:
-        default: [
-          "accounts/fireworks/models/mixtral-8x7b-instruct",
-          ]
+        default: ['accounts/fireworks/models/mixtral-8x7b-instruct']
         fetch: true
       titleConvo: true
-      titleModel: "accounts/fireworks/models/llama-v2-7b-chat"
+      titleModel: 'accounts/fireworks/models/llama-v2-7b-chat'
       summarize: false
-      summaryModel: "accounts/fireworks/models/llama-v2-7b-chat"
-      modelDisplayLabel: "Fireworks"
-      dropParams: ["user"]
-  
+      summaryModel: 'accounts/fireworks/models/llama-v2-7b-chat'
+      modelDisplayLabel: 'Fireworks'
+      dropParams: ['user']
+
     # groq
-    - name: "groq"
-      apiKey: "${GROQ_API_KEY}"
-      baseURL: "https://api.groq.com/openai/v1/"
+    - name: 'groq'
+      apiKey: '${GROQ_API_KEY}'
+      baseURL: 'https://api.groq.com/openai/v1/'
       models:
-        default: [
-          "llama2-70b-4096",
-          "llama3-70b-8192",
-          "llama3-8b-8192",
-          "mixtral-8x7b-32768",
-          "gemma-7b-it",
+        default:
+          [
+            'llama2-70b-4096',
+            'llama3-70b-8192',
+            'llama3-8b-8192',
+            'mixtral-8x7b-32768',
+            'gemma-7b-it',
           ]
         fetch: false
       titleConvo: true
-      titleModel: "mixtral-8x7b-32768"
-      modelDisplayLabel: "groq"
+      titleModel: 'mixtral-8x7b-32768'
+      modelDisplayLabel: 'groq'
 
     # Mistral AI API
-    - name: "Mistral"
-      apiKey: "${MISTRAL_API_KEY}"
-      baseURL: "https://api.mistral.ai/v1"
+    - name: 'Mistral'
+      apiKey: '${MISTRAL_API_KEY}'
+      baseURL: 'https://api.mistral.ai/v1'
       models:
-        default: [
-          "mistral-tiny",
-          "mistral-small",
-          "mistral-medium",
-          "mistral-large-latest"
-          ]
+        default: ['mistral-tiny', 'mistral-small', 'mistral-medium', 'mistral-large-latest']
         fetch: true
       titleConvo: true
-      titleModel: "mistral-tiny"
-      modelDisplayLabel: "Mistral"
-      dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
+      titleModel: 'mistral-tiny'
+      modelDisplayLabel: 'Mistral'
+      dropParams: ['stop', 'user', 'frequency_penalty', 'presence_penalty']
 
     # OpenRouter.ai
-    - name: "OpenRouter"
-      apiKey: "${OPENROUTER_KEY}"
-      baseURL: "https://openrouter.ai/api/v1"
+    - name: 'OpenRouter'
+      apiKey: '${OPENROUTER_KEY}'
+      baseURL: 'https://openrouter.ai/api/v1'
       models:
-        default: ["openai/gpt-3.5-turbo"]
+        default: ['openai/gpt-3.5-turbo']
         fetch: true
       titleConvo: true
-      titleModel: "gpt-3.5-turbo"
+      titleModel: 'gpt-3.5-turbo'
       summarize: false
-      summaryModel: "gpt-3.5-turbo"
-      modelDisplayLabel: "OpenRouter"
+      summaryModel: 'gpt-3.5-turbo'
+      modelDisplayLabel: 'OpenRouter'
 
     # Perplexity
-    - name: "Perplexity"
-      apiKey: "${PERPLEXITY_API_KEY}"
-      baseURL: "https://api.perplexity.ai/"
+    - name: 'Perplexity'
+      apiKey: '${PERPLEXITY_API_KEY}'
+      baseURL: 'https://api.perplexity.ai/'
       models:
-        default: [
-          "mistral-7b-instruct",
-          "sonar-small-chat",
-          "sonar-small-online",
-          "sonar-medium-chat",
-          "sonar-medium-online"
+        default:
+          [
+            'mistral-7b-instruct',
+            'sonar-small-chat',
+            'sonar-small-online',
+            'sonar-medium-chat',
+            'sonar-medium-online',
           ]
         fetch: false # fetching list of models is not supported
       titleConvo: true
-      titleModel: "sonar-medium-chat"
+      titleModel: 'sonar-medium-chat'
       summarize: false
-      summaryModel: "sonar-medium-chat"
-      dropParams: ["stop", "frequency_penalty"]
-      modelDisplayLabel: "Perplexity"
+      summaryModel: 'sonar-medium-chat'
+      dropParams: ['stop', 'frequency_penalty']
+      modelDisplayLabel: 'Perplexity'
 
     # ShuttleAI API
-    - name: "ShuttleAI"
-      apiKey: "${SHUTTLEAI_API_KEY}"
-      baseURL: "https://api.shuttleai.app/v1"
+    - name: 'ShuttleAI'
+      apiKey: '${SHUTTLEAI_API_KEY}'
+      baseURL: 'https://api.shuttleai.app/v1'
       models:
-        default: [
-          "shuttle-1", "shuttle-turbo"
-          ]
+        default: ['shuttle-1', 'shuttle-turbo']
         fetch: true
       titleConvo: true
-      titleModel: "gemini-pro"
+      titleModel: 'gemini-pro'
       summarize: false
-      summaryModel: "llama-summarize"
-      modelDisplayLabel: "ShuttleAI"
-      dropParams: ["user"]
+      summaryModel: 'llama-summarize'
+      modelDisplayLabel: 'ShuttleAI'
+      dropParams: ['user']
 
     # together.ai
-    - name: "together.ai"
-      apiKey: "${TOGETHERAI_API_KEY}"
-      baseURL: "https://api.together.xyz"
+    - name: 'together.ai'
+      apiKey: '${TOGETHERAI_API_KEY}'
+      baseURL: 'https://api.together.xyz'
       models:
-        default: [
-          "zero-one-ai/Yi-34B-Chat",
-          "Austism/chronos-hermes-13b",
-          "DiscoResearch/DiscoLM-mixtral-8x7b-v2",
-          "Gryphe/MythoMax-L2-13b",
-          "lmsys/vicuna-13b-v1.5",
-          "lmsys/vicuna-7b-v1.5",
-          "lmsys/vicuna-13b-v1.5-16k",
-          "codellama/CodeLlama-13b-Instruct-hf",
-          "codellama/CodeLlama-34b-Instruct-hf",
-          "codellama/CodeLlama-70b-Instruct-hf",
-          "codellama/CodeLlama-7b-Instruct-hf",
-          "togethercomputer/llama-2-13b-chat",
-          "togethercomputer/llama-2-70b-chat",
-          "togethercomputer/llama-2-7b-chat",
-          "NousResearch/Nous-Capybara-7B-V1p9",
-          "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
-          "NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT",
-          "NousResearch/Nous-Hermes-Llama2-70b",
-          "NousResearch/Nous-Hermes-llama-2-7b",
-          "NousResearch/Nous-Hermes-Llama2-13b",
-          "NousResearch/Nous-Hermes-2-Yi-34B",
-          "openchat/openchat-3.5-1210",
-          "Open-Orca/Mistral-7B-OpenOrca",
-          "togethercomputer/Qwen-7B-Chat",
-          "snorkelai/Snorkel-Mistral-PairRM-DPO",
-          "togethercomputer/alpaca-7b",
-          "togethercomputer/falcon-40b-instruct",
-          "togethercomputer/falcon-7b-instruct",
-          "togethercomputer/GPT-NeoXT-Chat-Base-20B",
-          "togethercomputer/Llama-2-7B-32K-Instruct",
-          "togethercomputer/Pythia-Chat-Base-7B-v0.16",
-          "togethercomputer/RedPajama-INCITE-Chat-3B-v1",
-          "togethercomputer/RedPajama-INCITE-7B-Chat",
-          "togethercomputer/StripedHyena-Nous-7B",
-          "Undi95/ReMM-SLERP-L2-13B",
-          "Undi95/Toppy-M-7B",
-          "WizardLM/WizardLM-13B-V1.2",
-          "garage-bAInd/Platypus2-70B-instruct",
-          "mistralai/Mistral-7B-Instruct-v0.1",
-          "mistralai/Mistral-7B-Instruct-v0.2",
-          "mistralai/Mixtral-8x7B-Instruct-v0.1",
-          "teknium/OpenHermes-2-Mistral-7B",
-          "teknium/OpenHermes-2p5-Mistral-7B",
-          "upstage/SOLAR-10.7B-Instruct-v1.0"
+        default:
+          [
+            'zero-one-ai/Yi-34B-Chat',
+            'Austism/chronos-hermes-13b',
+            'DiscoResearch/DiscoLM-mixtral-8x7b-v2',
+            'Gryphe/MythoMax-L2-13b',
+            'lmsys/vicuna-13b-v1.5',
+            'lmsys/vicuna-7b-v1.5',
+            'lmsys/vicuna-13b-v1.5-16k',
+            'codellama/CodeLlama-13b-Instruct-hf',
+            'codellama/CodeLlama-34b-Instruct-hf',
+            'codellama/CodeLlama-70b-Instruct-hf',
+            'codellama/CodeLlama-7b-Instruct-hf',
+            'togethercomputer/llama-2-13b-chat',
+            'togethercomputer/llama-2-70b-chat',
+            'togethercomputer/llama-2-7b-chat',
+            'NousResearch/Nous-Capybara-7B-V1p9',
+            'NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO',
+            'NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT',
+            'NousResearch/Nous-Hermes-Llama2-70b',
+            'NousResearch/Nous-Hermes-llama-2-7b',
+            'NousResearch/Nous-Hermes-Llama2-13b',
+            'NousResearch/Nous-Hermes-2-Yi-34B',
+            'openchat/openchat-3.5-1210',
+            'Open-Orca/Mistral-7B-OpenOrca',
+            'togethercomputer/Qwen-7B-Chat',
+            'snorkelai/Snorkel-Mistral-PairRM-DPO',
+            'togethercomputer/alpaca-7b',
+            'togethercomputer/falcon-40b-instruct',
+            'togethercomputer/falcon-7b-instruct',
+            'togethercomputer/GPT-NeoXT-Chat-Base-20B',
+            'togethercomputer/Llama-2-7B-32K-Instruct',
+            'togethercomputer/Pythia-Chat-Base-7B-v0.16',
+            'togethercomputer/RedPajama-INCITE-Chat-3B-v1',
+            'togethercomputer/RedPajama-INCITE-7B-Chat',
+            'togethercomputer/StripedHyena-Nous-7B',
+            'Undi95/ReMM-SLERP-L2-13B',
+            'Undi95/Toppy-M-7B',
+            'WizardLM/WizardLM-13B-V1.2',
+            'garage-bAInd/Platypus2-70B-instruct',
+            'mistralai/Mistral-7B-Instruct-v0.1',
+            'mistralai/Mistral-7B-Instruct-v0.2',
+            'mistralai/Mixtral-8x7B-Instruct-v0.1',
+            'teknium/OpenHermes-2-Mistral-7B',
+            'teknium/OpenHermes-2p5-Mistral-7B',
+            'upstage/SOLAR-10.7B-Instruct-v1.0',
           ]
         fetch: false # fetching list of models is not supported
       titleConvo: true
-      titleModel: "togethercomputer/llama-2-7b-chat"
+      titleModel: 'togethercomputer/llama-2-7b-chat'
       summarize: false
-      summaryModel: "togethercomputer/llama-2-7b-chat"
-      modelDisplayLabel: "together.ai"
+      summaryModel: 'togethercomputer/llama-2-7b-chat'
+      modelDisplayLabel: 'together.ai'
 ```
 
 </Callout>
@@ -254,17 +254,17 @@ This example configuration file sets up LibreChat with detailed options across s
 
 - **Caching**: Enabled to improve performance.
 - **File Handling**:
-    - **File Strategy**: Commented out but hints at possible integration with Firebase for file storage.
-    - **File Configurations**: Customizes file upload limits and allowed MIME types for different endpoints, including a global server file size limit and a specific limit for user avatar images.
+  - **File Strategy**: Commented out but hints at possible integration with Firebase for file storage.
+  - **File Configurations**: Customizes file upload limits and allowed MIME types for different endpoints, including a global server file size limit and a specific limit for user avatar images.
 - **Rate Limiting**: Defines thresholds for the maximum number of file uploads allowed per IP and user within a specified time window, aiming to prevent abuse.
 - **Registration**:
-    - Allows registration from specified social login providers and email domains, enhancing security and user management.
+  - Allows registration from specified social login providers and email domains, enhancing security and user management.
 - **Endpoints**:
-    - **Assistants**: Configures the assistants' endpoint with a polling interval and a timeout for operations, and provides an option to disable the builder interface.
-    - **Custom Endpoints**:
-        - Configures two external AI service endpoints, Mistral and OpenRouter, including API keys, base URLs, model handling, and specific feature toggles like conversation titles, summarization, and parameter adjustments.
-        - For Mistral, it enables dynamic model fetching, applies additional parameters for safe prompts, and explicitly drops unsupported parameters.
-        - For OpenRouter, it sets up a basic configuration without dynamic model fetching and specifies a model for conversation titles.
+  - **Assistants**: Configures the assistants' endpoint with a polling interval and a timeout for operations, and provides an option to disable the builder interface.
+  - **Custom Endpoints**:
+    - Configures two external AI service endpoints, Mistral and OpenRouter, including API keys, base URLs, model handling, and specific feature toggles like conversation titles, summarization, and parameter adjustments.
+    - For Mistral, it enables dynamic model fetching, applies additional parameters for safe prompts, and explicitly drops unsupported parameters.
+    - For OpenRouter, it sets up a basic configuration without dynamic model fetching and specifies a model for conversation titles.
 
 <Callout type="example" title="Commented Example" collapsible>
 
@@ -273,7 +273,7 @@ This example configuration file sets up LibreChat with detailed options across s
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.5
+version: 1.3.11
 
 # Cache settings: Set to true to enable caching
 cache: true
@@ -333,12 +333,13 @@ endpoints:
       apiKey: '${GROQ_API_KEY}'
       baseURL: 'https://api.groq.com/openai/v1/'
       models:
-        default: [
-          "llama3-70b-8192",
-          "llama3-8b-8192",
-          "llama2-70b-4096",
-          "mixtral-8x7b-32768",
-          "gemma-7b-it",
+        default:
+          [
+            'llama3-70b-8192',
+            'llama3-8b-8192',
+            'llama2-70b-4096',
+            'mixtral-8x7b-32768',
+            'gemma-7b-it',
           ]
         fetch: false
       titleConvo: true

--- a/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agents Endpoint Object Structure"
+title: 'Agents Endpoint Object Structure'
 icon: Bot
 ---
 
@@ -14,25 +14,32 @@ endpoints:
     maxRecursionLimit: 100
     disableBuilder: false
     # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
-    # capabilities: ["execute_code", "file_search", "actions", "tools", "artifacts", "context", "ocr", "chain", "web_search"]
+    # capabilities: ["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "tools", "chain", "ocr"]
     # (optional) File citation configuration for file_search capability
-    maxCitations: 30          # Maximum total citations in responses (1-50)
-    maxCitationsPerFile: 7    # Maximum citations from each file (1-10)
-    minRelevanceScore: 0.45   # Minimum relevance score threshold (0.0-1.0)
+    maxCitations: 30 # Maximum total citations in responses (1-50)
+    maxCitationsPerFile: 7 # Maximum citations from each file (1-10)
+    minRelevanceScore: 0.45 # Minimum relevance score threshold (0.0-1.0)
 ```
+
 > This configuration enables the builder interface for agents.
 
 ## recursionLimit
 
 <OptionTable
   options={[
-    ['recursionLimit', 'Number', 'Sets the default number of steps an agent can take in a run.', 'Controls recursion depth to prevent infinite loops. When limit is reached, raises GraphRecursionError. This value can be configured from the UI up to the maxRecursionLimit.'],
+    [
+      'recursionLimit',
+      'Number',
+      'Sets the default number of steps an agent can take in a run.',
+      'Controls recursion depth to prevent infinite loops. When limit is reached, raises GraphRecursionError. This value can be configured from the UI up to the maxRecursionLimit.',
+    ],
   ]}
 />
 
 **Default:** `25`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / recursionLimit"
 recursionLimit: 50
 ```
@@ -43,13 +50,19 @@ For more information about agent steps, see [Max Agent Steps](/docs/features/age
 
 <OptionTable
   options={[
-    ['maxRecursionLimit', 'Number', 'Sets the absolute maximum number of steps an agent can take in a run.', 'Defines the upper limit for the recursionLimit that can be set from the UI. This prevents users from setting excessively high values.'],
+    [
+      'maxRecursionLimit',
+      'Number',
+      'Sets the absolute maximum number of steps an agent can take in a run.',
+      'Defines the upper limit for the recursionLimit that can be set from the UI. This prevents users from setting excessively high values.',
+    ],
   ]}
 />
 
 **Default:** If omitted, defaults to the value of recursionLimit or 50 if recursionLimit is also omitted.
 
 **Example:**
+
 ```yaml filename="endpoints / agents / maxRecursionLimit"
 maxRecursionLimit: 100
 ```
@@ -60,13 +73,19 @@ For more information about agent steps, see [Max Agent Steps](/docs/features/age
 
 <OptionTable
   options={[
-    ['disableBuilder', 'Boolean', 'Controls the visibility and use of the builder interface for agents.', 'When set to `true`, disables the builder interface for the agent, limiting direct manual interaction.'],
+    [
+      'disableBuilder',
+      'Boolean',
+      'Controls the visibility and use of the builder interface for agents.',
+      'When set to `true`, disables the builder interface for the agent, limiting direct manual interaction.',
+    ],
   ]}
 />
 
 **Default:** `false`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / disableBuilder"
 disableBuilder: false
 ```
@@ -75,16 +94,21 @@ disableBuilder: false
 
 <OptionTable
   options={[
-    ['allowedProviders', 'Array/List of Strings', 'Specifies a list of endpoint providers (e.g., "openAI", "anthropic", "google") that are permitted for use with the Agents feature.', 'If defined, only agents configured with these providers can be initialized. If omitted or empty, all configured providers are allowed.'],
+    [
+      'allowedProviders',
+      'Array/List of Strings',
+      'Specifies a list of endpoint providers (e.g., "openAI", "anthropic", "google") that are permitted for use with the Agents feature.',
+      'If defined, only agents configured with these providers can be initialized. If omitted or empty, all configured providers are allowed.',
+    ],
   ]}
 />
 
 **Default:** `[]` (empty list, all providers allowed)
 
-**Note:** Must be one of the following, or a custom endpoint name as defined in your [configuration](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#name):
-    - `openAI, azureOpenAI, google, anthropic, assistants, azureAssistants, bedrock`
+**Note:** Must be one of the following, or a custom endpoint name as defined in your [configuration](/docs/configuration/librechat_yaml/object_structure/custom_endpoint#name): - `openAI, azureOpenAI, google, anthropic, assistants, azureAssistants, bedrock`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / allowedProviders"
 allowedProviders:
   - openAI
@@ -95,32 +119,47 @@ allowedProviders:
 
 <OptionTable
   options={[
-    ['capabilities', 'Array/List of Strings', 'Specifies the agent capabilities available to all users for the agents endpoint.', 'Defines the agent capabilities that are available to all users for the agents endpoint. You can omit the capabilities you wish to exclude from the list.'],
+    [
+      'capabilities',
+      'Array/List of Strings',
+      'Specifies the agent capabilities available to all users for the agents endpoint.',
+      'Defines the agent capabilities that are available to all users for the agents endpoint. You can omit the capabilities you wish to exclude from the list.',
+    ],
   ]}
 />
 
-**Default:** `["execute_code", "file_search", "actions", "tools", "artifacts", "context", "ocr", "chain", "web_search"]`
+**Default:** `["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "tools", "chain", "ocr"]`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / capabilities"
 capabilities:
-  - "execute_code"
-  - "file_search"
-  - "actions"
-  - "tools"
-  - "artifacts"
-  - "context"
-  - "ocr"
-  - "chain"
-  - "web_search"
+  - 'deferred_tools'
+  - 'execute_code'
+  - 'file_search'
+  - 'web_search'
+  - 'artifacts'
+  - 'subagents'
+  - 'actions'
+  - 'context'
+  - 'skills'
+  - 'tools'
+  - 'chain'
+  - 'ocr'
 ```
+
 **Note:** This field is optional. If omitted, the default behavior is to include all the capabilities listed in the default.
 
 ## maxCitations
 
 <OptionTable
   options={[
-    ['maxCitations', 'Number', 'Controls the maximum total number of citations that can be included in a single agent response.', 'When using file_search capability, limits the total number of source citations returned to prevent overwhelming responses while ensuring comprehensive coverage.'],
+    [
+      'maxCitations',
+      'Number',
+      'Controls the maximum total number of citations that can be included in a single agent response.',
+      'When using file_search capability, limits the total number of source citations returned to prevent overwhelming responses while ensuring comprehensive coverage.',
+    ],
   ]}
 />
 
@@ -129,6 +168,7 @@ capabilities:
 **Range:** `1-50`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / maxCitations"
 maxCitations: 30
 ```
@@ -137,7 +177,12 @@ maxCitations: 30
 
 <OptionTable
   options={[
-    ['maxCitationsPerFile', 'Number', 'Limits the maximum number of citations that can be extracted from any single file.', 'Ensures citation diversity by preventing any single file from dominating the citations, encouraging representation from multiple sources.'],
+    [
+      'maxCitationsPerFile',
+      'Number',
+      'Limits the maximum number of citations that can be extracted from any single file.',
+      'Ensures citation diversity by preventing any single file from dominating the citations, encouraging representation from multiple sources.',
+    ],
   ]}
 />
 
@@ -146,6 +191,7 @@ maxCitations: 30
 **Range:** `1-10`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / maxCitationsPerFile"
 maxCitationsPerFile: 7
 ```
@@ -154,7 +200,12 @@ maxCitationsPerFile: 7
 
 <OptionTable
   options={[
-    ['minRelevanceScore', 'Number', 'Sets the minimum relevance score threshold for sources to be included in responses.', 'Filters out low-quality matches based on vector similarity scores. Higher values (e.g., 0.7) ensure only highly relevant sources are cited, while lower values (e.g., 0.0) include all sources regardless of quality.'],
+    [
+      'minRelevanceScore',
+      'Number',
+      'Sets the minimum relevance score threshold for sources to be included in responses.',
+      'Filters out low-quality matches based on vector similarity scores. Higher values (e.g., 0.7) ensure only highly relevant sources are cited, while lower values (e.g., 0.0) include all sources regardless of quality.',
+    ],
   ]}
 />
 
@@ -163,6 +214,7 @@ maxCitationsPerFile: 7
 **Range:** `0.0-1.0`
 
 **Example:**
+
 ```yaml filename="endpoints / agents / minRelevanceScore"
 minRelevanceScore: 0.45
 ```
@@ -170,6 +222,7 @@ minRelevanceScore: 0.45
 ### File Citation Configuration Examples
 
 **Default Configuration (Balanced)**
+
 ```yaml
 endpoints:
   agents:
@@ -177,9 +230,11 @@ endpoints:
     maxCitationsPerFile: 7
     minRelevanceScore: 0.45
 ```
+
 Provides comprehensive citations while preventing overwhelming responses and filtering out low-quality matches.
 
 **Strict Configuration (High Quality)**
+
 ```yaml
 endpoints:
   agents:
@@ -187,9 +242,11 @@ endpoints:
     maxCitationsPerFile: 3
     minRelevanceScore: 0.7
 ```
+
 Only includes highly relevant citations with strict limits for focused responses.
 
 **Comprehensive Configuration (Research)**
+
 ```yaml
 endpoints:
   agents:
@@ -197,21 +254,25 @@ endpoints:
     maxCitationsPerFile: 10
     minRelevanceScore: 0.0
 ```
+
 Maximum information extraction for exhaustive research tasks, including all sources regardless of relevance.
 
 ## Agent Capabilities
 
 The `capabilities` field allows you to enable or disable specific functionalities for agents. The available capabilities are:
 
+- **deferred_tools**: Allows agents to discover deferred MCP tools at runtime instead of loading every tool into context upfront.
 - **execute_code**: Allows the agent to execute code.
 - **file_search**: Enables the agent to search and interact with files. When enabled, citation behavior is controlled by `maxCitations`, `maxCitationsPerFile`, and `minRelevanceScore` settings.
-- **actions**: Permits the agent to perform predefined actions.
-- **tools**: Grants the agent access to various tools.
-- **artifacts**: Enables the agent to generate interactive artifacts (React components, HTML, Mermaid diagrams).
-- **context**: Enables "Upload as Text" functionality in chat, and "File Context" for agents, allowing users to upload files and have their content extracted and included directly in the conversation.
-- **ocr**: Optionally enhances "Upload as Text" in chat, and "File Context" for agents, allowing files to be uploaded and processed with OCR. **Requires an OCR service to be configured.**
-- **chain**: Enables Beta feature for agent chaining, also known as Mixture-of-Agents (MoA) workflows.
 - **web_search**: Enables web search functionality for agents, allowing them to search and retrieve information from the internet.
+- **artifacts**: Enables the agent to generate interactive artifacts (React components, HTML, Mermaid diagrams).
+- **subagents**: Enables isolated-context child agent runs. See [Subagents](/docs/features/subagents).
+- **actions**: Permits the agent to perform predefined actions.
+- **context**: Enables "Upload as Text" functionality in chat, and "File Context" for agents, allowing users to upload files and have their content extracted and included directly in the conversation.
+- **skills**: Enables Skills in the side panel, manual `$` invocation, model-invoked skills, and agent skill allowlists. See [Skills](/docs/features/skills).
+- **tools**: Grants the agent access to various tools.
+- **chain**: Enables Beta feature for agent chaining, also known as Mixture-of-Agents (MoA) workflows.
+- **ocr**: Optionally enhances "Upload as Text" in chat, and "File Context" for agents, allowing files to be uploaded and processed with OCR. **Requires an OCR service to be configured.**
 
 By specifying the capabilities, you can control the features available to users when interacting with agents.
 
@@ -229,20 +290,61 @@ endpoints:
     minRelevanceScore: 0.6
     # Custom capabilities
     capabilities:
-      - "execute_code"
-      - "file_search"
-      - "actions"
-      - "artifacts"
-      - "context"
-      - "ocr"
-      - "web_search"
+      - 'execute_code'
+      - 'file_search'
+      - 'skills'
+      - 'subagents'
+      - 'actions'
+      - 'artifacts'
+      - 'context'
+      - 'ocr'
+      - 'web_search'
 ```
 
 In this example:
+
 - The builder interface is enabled
 - File citations are limited to 20 total, with maximum 5 per file
 - Only sources with 60%+ relevance are included
-- LibreChat Agents have access to code execution, file search (with citations), actions, artifacts, file context, ocr services if configured, and web search capabilities
+- LibreChat Agents have access to code execution, file search (with citations), Skills, Subagents, actions, artifacts, file context, ocr services if configured, and web search capabilities
+
+## Subagents
+
+The `subagents` field controls which isolated child agents a parent agent can spawn when the `subagents` capability is available.
+
+<OptionTable
+  options={[
+    [
+      'enabled',
+      'Boolean',
+      'Adds the subagent spawn tool to this agent when true. Default: disabled.',
+      'enabled: true',
+    ],
+    [
+      'allowSelf',
+      'Boolean',
+      'Allows the agent to spawn itself in a fresh isolated context. Default: true.',
+      'allowSelf: true',
+    ],
+    [
+      'agent_ids',
+      'Array/List of Strings',
+      'Specific agents this agent may spawn. Maximum: 10.',
+      'agent_ids: ["agent_researcher"]',
+    ],
+  ]}
+/>
+
+```yaml filename="Agent subagents"
+subagents:
+  enabled: true
+  allowSelf: true
+  agent_ids:
+    - 'agent_researcher'
+    - 'agent_reviewer'
+```
+
+For user-facing behavior and limits, see [Subagents](/docs/features/subagents).
 
 ## Notes
 

--- a/content/docs/configuration/librechat_yaml/object_structure/cloudfront.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/cloudfront.mdx
@@ -1,0 +1,122 @@
+---
+title: 'CloudFront Object Structure'
+icon: Cloud
+---
+
+The `cloudfront` object configures CloudFront delivery for files stored in S3. It is required when `fileStrategy` or any `fileStrategies` entry uses `"cloudfront"`.
+
+## Example
+
+```yaml filename="cloudfront"
+fileStrategies:
+  avatar: 'cloudfront'
+  image: 'cloudfront'
+  document: 's3'
+
+cloudfront:
+  domain: 'https://cdn.example.com'
+  distributionId: 'E1234ABCD'
+  invalidateOnDelete: false
+  imageSigning: 'cookies'
+  cookieDomain: '.example.com'
+  cookieExpiry: 1800
+  urlExpiry: 3600
+  storageRegion: 'us-east-2'
+  includeRegionInPath: false
+  requireSignedAccess: true
+```
+
+## Fields
+
+<OptionTable
+  options={[
+    [
+      'domain',
+      'String',
+      'CloudFront distribution domain or CNAME. Required.',
+      'domain: "https://cdn.example.com"',
+    ],
+    [
+      'distributionId',
+      'String',
+      'CloudFront distribution ID. Required when `invalidateOnDelete` is true.',
+      'distributionId: "E1234ABCD"',
+    ],
+    [
+      'invalidateOnDelete',
+      'Boolean',
+      'Creates a CloudFront invalidation after deleting the S3 object. Default: false.',
+      'invalidateOnDelete: false',
+    ],
+    [
+      'imageSigning',
+      'String',
+      'Inline media signing mode. Options: `"none"`, `"cookies"`, `"url"`. `"url"` is reserved and not implemented for images.',
+      'imageSigning: "cookies"',
+    ],
+    [
+      'urlExpiry',
+      'Number',
+      'Signed CloudFront download URL lifetime in seconds. Default: 3600.',
+      'urlExpiry: 3600',
+    ],
+    [
+      'cookieExpiry',
+      'Number',
+      'Signed cookie lifetime in seconds. Default: 1800. Maximum: 604800.',
+      'cookieExpiry: 1800',
+    ],
+    [
+      'cookieDomain',
+      'String',
+      'Shared parent domain for signed cookies. Required when `imageSigning` is `"cookies"`. Must start with a dot.',
+      'cookieDomain: ".example.com"',
+    ],
+    [
+      'storageRegion',
+      'String',
+      'Optional region label used in generated object keys when `includeRegionInPath` is true.',
+      'storageRegion: "us-east-2"',
+    ],
+    [
+      'includeRegionInPath',
+      'Boolean',
+      'Includes the storage region in newly generated object keys. Default: false.',
+      'includeRegionInPath: false',
+    ],
+    [
+      'requireSignedAccess',
+      'Boolean',
+      'Requires signed-cookie CloudFront access to initialize successfully at startup. Default: false.',
+      'requireSignedAccess: true',
+    ],
+  ]}
+/>
+
+## Validation Rules
+
+- `distributionId` is required when `invalidateOnDelete` is `true`.
+- `cookieDomain` is required when `imageSigning` is `"cookies"`.
+- `cookieDomain` must start with a dot, for example `.example.com`.
+- `requireSignedAccess: true` requires `imageSigning: "cookies"`.
+
+## Related Environment Variables
+
+<OptionTable
+  options={[
+    [
+      'CLOUDFRONT_KEY_PAIR_ID',
+      'String',
+      'CloudFront public key pair ID. Required for signed cookies and signed downloads.',
+      '# CLOUDFRONT_KEY_PAIR_ID=K1234567890ABC',
+    ],
+    [
+      'CLOUDFRONT_PRIVATE_KEY',
+      'String',
+      'CloudFront private key PEM. Required for signed cookies and signed downloads.',
+      '# CLOUDFRONT_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\n...\\n-----END RSA PRIVATE KEY-----"',
+    ],
+  ]}
+/>
+
+For deployment guidance, see [CloudFront with S3](/docs/configuration/cdn/cloudfront).

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -1,16 +1,17 @@
 ---
-title: "Config Structure"
+title: 'Config Structure'
 icon: Settings
 ---
 
 **Note:** Fields not specifically mentioned as required are optional.
 
 ## version
-- **required** 
+
+- **required**
 
 <OptionTable
   options={[
-    ['version', 'String', 'Specifies the version of the configuration file.', 'version: 1.3.10' ],
+    ['version', 'String', 'Specifies the version of the configuration file.', 'version: 1.3.11'],
   ]}
 />
 
@@ -18,35 +19,51 @@ icon: Settings
 
 <OptionTable
   options={[
-    ['cache', 'Boolean', 'Toggles caching on or off. Set to `true` to enable caching (default).', 'cache: true' ],
+    [
+      'cache',
+      'Boolean',
+      'Toggles caching on or off. Set to `true` to enable caching (default).',
+      'cache: true',
+    ],
   ]}
 />
 
 ## fileStrategy
 
-- **Options**: "local" | "firebase" | "s3" | "azure_blob"
+- **Options**: "local" | "firebase" | "s3" | "azure_blob" | "cloudfront"
 
 <OptionTable
   options={[
-    ['fileStrategy', 'String', 'Determines where to save user uploaded/generated files. Defaults to `"local"` if omitted.', 'fileStrategy: "firebase"' ],
+    [
+      'fileStrategy',
+      'String',
+      'Determines where to save user uploaded/generated files. Defaults to `"local"` if omitted.',
+      'fileStrategy: "firebase"',
+    ],
   ]}
 />
 
 - **Notes**:
-  - `"firebase"` is currently the only option that serves files through a true CDN (Content Delivery Network), which means images and avatars are delivered from edge locations globally. S3 and Azure Blob Storage are object storage backends — files are accessible but not CDN-served by default.
+  - `"cloudfront"` stores files in S3 and returns CloudFront URLs for stable media delivery, signed cookies, and signed downloads.
+  - `"firebase"` serves files through Firebase Storage and Firebase Hosting edge locations.
   - S3 serves files via **presigned URLs** (temporary signed tokens) that expire. Once expired, any image or avatar referencing that URL will appear broken in the UI. This makes S3 unsuitable as a primary strategy for visual assets. See the [related discussion](https://github.com/danny-avila/LibreChat/discussions/10280#discussioncomment-14803903) for details.
-  - CloudFront (CDN for S3) is planned and in active development.
-  - For best performance of images and avatars, use `"firebase"` or configure `fileStrategies` to route `avatar` and `image` to a CDN-backed strategy.
+  - For best performance of images and avatars, use `"cloudfront"` or `"firebase"`, or configure `fileStrategies` to route `avatar` and `image` to a CDN-backed strategy.
   - Please refer to the [File Storage & CDN documentation](/docs/configuration/cdn) for setup details
 
 ## fileStrategies
 
 Allows granular control over file storage strategies for different file types.
-- **Available Strategies**: "local" | "firebase" | "s3" | "azure_blob"
+
+- **Available Strategies**: "local" | "firebase" | "s3" | "azure_blob" | "cloudfront"
 
 <OptionTable
   options={[
-    ['fileStrategies', 'Object', 'Configures different storage strategies for different file types. More flexible than the single fileStrategy option.', ''],
+    [
+      'fileStrategies',
+      'Object',
+      'Configures different storage strategies for different file types. More flexible than the single fileStrategy option.',
+      '',
+    ],
   ]}
 />
 
@@ -54,18 +71,33 @@ Allows granular control over file storage strategies for different file types.
 
 <OptionTable
   options={[
-    ['default', 'String', 'Fallback storage strategy when specific type is not defined. Defaults to "local".', ''],
-    ['avatar', 'String', 'Storage strategy for user and agent avatar images. Recommended to use a CDN-backed strategy (`"firebase"`) for best performance.', ''],
-    ['image', 'String', 'Storage strategy for images uploaded in chats. Recommended to use a CDN-backed strategy (`"firebase"`) for best performance.', ''],
+    [
+      'default',
+      'String',
+      'Fallback storage strategy when specific type is not defined. Defaults to "local".',
+      '',
+    ],
+    [
+      'avatar',
+      'String',
+      'Storage strategy for user and agent avatar images. Recommended to use a CDN-backed strategy (`"cloudfront"` or `"firebase"`) for best performance.',
+      '',
+    ],
+    [
+      'image',
+      'String',
+      'Storage strategy for images uploaded in chats. Recommended to use a CDN-backed strategy (`"cloudfront"` or `"firebase"`) for best performance.',
+      '',
+    ],
     ['document', 'String', 'Storage strategy for document uploads (PDFs, text files, etc.).', ''],
+    ['skills', 'String', 'Storage strategy for files bundled with Skills.', ''],
   ]}
 />
 
 - **Notes**:
   - This setting takes precedence over the single `fileStrategy` option
   - If a specific file type is not configured, it falls back to `default`, then to `fileStrategy`, and finally to `"local"`
-  - Images and avatars need persistent, stable URLs to render correctly across the UI. S3 presigned URLs expire (AWS cap: 7 days for IAM users, hours for STS/role-based credentials), causing broken images in the model selector and chat UI. See the [related discussion](https://github.com/danny-avila/LibreChat/discussions/10280#discussioncomment-14803903) for full context. Use `"firebase"` (the only current CDN-backed strategy) for `avatar` and `image` to avoid this.
-  - CloudFront support for S3 is in active development and will eliminate presigned URL limitations.
+  - Images and avatars need persistent, stable URLs to render correctly across the UI. S3 presigned URLs expire (AWS cap: 7 days for IAM users, hours for STS/role-based credentials), causing broken images in the model selector and chat UI. See the [related discussion](https://github.com/danny-avila/LibreChat/discussions/10280#discussioncomment-14803903) for full context. Use `"cloudfront"` or `"firebase"` for `avatar` and `image` to avoid this.
   - S3 and Azure Blob Storage are well-suited for `document` storage, where short-lived presigned download URLs are appropriate.
   - Please refer to the [File Storage & CDN documentation](/docs/configuration/cdn) for setup details for each storage provider
 
@@ -74,60 +106,153 @@ Allows granular control over file storage strategies for different file types.
 ```yaml filename="fileStrategies - All in one place"
 # Use a single strategy for all file types
 fileStrategies:
-  default: "s3"
+  default: 's3'
 ```
 
 ```yaml filename="fileStrategies - Mixed strategies"
 # Route images and avatars to CDN, keep documents in object storage
 fileStrategies:
-  avatar: "firebase"   # CDN delivery for avatars
-  image: "firebase"    # CDN delivery for generated/uploaded images
-  document: "s3"       # Object storage for documents
+  avatar: 'cloudfront' # CDN delivery for avatars
+  image: 'cloudfront' # CDN delivery for generated/uploaded images
+  document: 's3' # Object storage for documents
 ```
 
 ```yaml filename="fileStrategies - Partial configuration"
 # Only configure specific types, others use default
 fileStrategies:
-  default: "local"
-  avatar: "firebase"   # Only avatars use Firebase CDN, everything else is local
+  default: 'local'
+  avatar: 'firebase' # Only avatars use Firebase CDN, everything else is local
 ```
+
+## cloudfront
+
+**Key:**
+
+<OptionTable
+  options={[['cloudfront', 'Object', 'Configures CloudFront delivery for files stored in S3.', '']]}
+/>
+
+**Subkeys:**
+
+<OptionTable
+  options={[
+    [
+      'domain',
+      'String',
+      'CloudFront distribution domain or CNAME. Required when any file strategy uses `"cloudfront"`.',
+      'domain: "https://cdn.example.com"',
+    ],
+    [
+      'distributionId',
+      'String',
+      'CloudFront distribution ID. Required when `invalidateOnDelete` is true.',
+      'distributionId: "E1234ABCD"',
+    ],
+    [
+      'invalidateOnDelete',
+      'Boolean',
+      'Creates a CloudFront invalidation for deleted files. Default: false.',
+      'invalidateOnDelete: false',
+    ],
+    [
+      'imageSigning',
+      'String',
+      'Controls inline image/avatar access. Options: `"none"` or `"cookies"`. `"url"` is reserved and not implemented for images.',
+      'imageSigning: "cookies"',
+    ],
+    [
+      'cookieDomain',
+      'String',
+      'Shared parent cookie domain required for signed cookies. Must start with a dot.',
+      'cookieDomain: ".example.com"',
+    ],
+    [
+      'cookieExpiry',
+      'Number',
+      'Signed cookie lifetime in seconds. Default: 1800, maximum: 604800.',
+      'cookieExpiry: 1800',
+    ],
+    [
+      'urlExpiry',
+      'Number',
+      'Signed CloudFront download URL lifetime in seconds. Default: 3600.',
+      'urlExpiry: 3600',
+    ],
+    [
+      'storageRegion',
+      'String',
+      'Optional region label used in generated object keys when region paths are enabled.',
+      'storageRegion: "us-east-2"',
+    ],
+    [
+      'includeRegionInPath',
+      'Boolean',
+      'Includes the storage region in newly generated object keys. Default: false.',
+      'includeRegionInPath: false',
+    ],
+    [
+      'requireSignedAccess',
+      'Boolean',
+      'Refuses startup when signed-cookie CloudFront access cannot initialize. Default: false.',
+      'requireSignedAccess: true',
+    ],
+  ]}
+/>
+
+see: [CloudFront Object Structure](/docs/configuration/librechat_yaml/object_structure/cloudfront) and [CloudFront with S3](/docs/configuration/cdn/cloudfront)
+
 ## filteredTools
 
 <OptionTable
   options={[
-    ['filteredTools', 'Array of Strings', 'Filters out specific tools from both Plugins and OpenAI Assistants endpoints.', 'filteredTools: ["scholarai", "calculator"]' ],
+    [
+      'filteredTools',
+      'Array of Strings',
+      'Filters out specific tools from both Plugins and OpenAI Assistants endpoints.',
+      'filteredTools: ["scholarai", "calculator"]',
+    ],
   ]}
 />
 
 - **Notes**:
-    - If `includedTools` and `filteredTools` are both specified, only `includedTools` will be recognized.
-    - Affects both `gptPlugins` and `assistants` endpoints
-    - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
-        - Use the `pluginKey` value
-    - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
-        - Use the `name_for_model` value
+  - If `includedTools` and `filteredTools` are both specified, only `includedTools` will be recognized.
+  - Affects both `gptPlugins` and `assistants` endpoints
+  - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
+    - Use the `pluginKey` value
+  - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
+    - Use the `name_for_model` value
 
 ## includedTools
 
 <OptionTable
   options={[
-    ['includedTools', 'Array of Strings', 'Includes specific tools from both Plugins and OpenAI Assistants endpoints.', 'includedTools: ["calculator"]' ],
+    [
+      'includedTools',
+      'Array of Strings',
+      'Includes specific tools from both Plugins and OpenAI Assistants endpoints.',
+      'includedTools: ["calculator"]',
+    ],
   ]}
 />
 
 - **Notes**:
-    - If `includedTools` and `filteredTools` are both specified, only `includedTools` will be recognized.
-    - Affects both `gptPlugins` and `assistants` endpoints
-    - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
-        - Use the `pluginKey` value
-    - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
-        - Use the `name_for_model` value
+  - If `includedTools` and `filteredTools` are both specified, only `includedTools` will be recognized.
+  - Affects both `gptPlugins` and `assistants` endpoints
+  - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
+    - Use the `pluginKey` value
+  - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
+    - Use the `name_for_model` value
 
 ## secureImageLinks
 
 <OptionTable
   options={[
-    ['secureImageLinks', 'Boolean', 'Whether or not to secure access to image links that are hosted locally by the app. Default: false.', 'secureImageLinks: true' ],
+    [
+      'secureImageLinks',
+      'Boolean',
+      'Whether or not to secure access to image links that are hosted locally by the app. Default: false.',
+      'secureImageLinks: true',
+    ],
   ]}
 />
 
@@ -138,25 +263,42 @@ fileStrategies:
 
 <OptionTable
   options={[
-    ['imageOutputType', 'String', 'The image output type for image responses. Defaults to "png" if omitted.', 'imageOutputType: "webp"' ],
+    [
+      'imageOutputType',
+      'String',
+      'The image output type for image responses. Defaults to "png" if omitted.',
+      'imageOutputType: "webp"',
+    ],
   ]}
 />
 
 ## ocr
 
 **Key:**
+
 <OptionTable
   options={[
-    ['ocr', 'Object', 'Configures Optical Character Recognition (OCR) settings for extracting text from images.', ''],
+    [
+      'ocr',
+      'Object',
+      'Configures Optical Character Recognition (OCR) settings for extracting text from images.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
     ['apiKey', 'String', 'The API key for the OCR service.', ''],
     ['baseURL', 'String', 'The base URL for the OCR service API.', ''],
-    ['strategy', 'String', 'The OCR strategy to use. Options are "mistral_ocr", "azure_mistral_ocr", "vertexai_mistral_ocr", "document_parser", or "custom_ocr".', ''],
+    [
+      'strategy',
+      'String',
+      'The OCR strategy to use. Options are "mistral_ocr", "azure_mistral_ocr", "vertexai_mistral_ocr", "document_parser", or "custom_ocr".',
+      '',
+    ],
     ['mistralModel', 'String', 'The Mistral model to use for OCR processing.', ''],
   ]}
 />
@@ -166,31 +308,113 @@ see: [OCR Config Object Structure](/docs/configuration/librechat_yaml/object_str
 ## webSearch
 
 **Key:**
+
 <OptionTable
   options={[
-    ['webSearch', 'Object', 'Configures web search functionality, including search providers, content scrapers, and result rerankers.', ''],
+    [
+      'webSearch',
+      'Object',
+      'Configures web search functionality, including search providers, content scrapers, and result rerankers.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['serperApiKey', 'String', 'Environment variable name for the Serper API key. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['searxngInstanceUrl', 'String', 'Environment variable name for the SearXNG instance URL. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['searxngApiKey', 'String', 'Environment variable name for the SearXNG API key. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['tavilyApiKey', 'String', 'Environment variable name for the Tavily API key. Used for both search and scraper. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['tavilySearchUrl', 'String', 'Environment variable name for a custom Tavily Search API URL. Optional; defaults to Tavily hosted search when unset.', ''],
-    ['tavilyExtractUrl', 'String', 'Environment variable name for a custom Tavily Extract API URL. Optional; defaults to Tavily hosted extract when unset.', ''],
-    ['firecrawlApiKey', 'String', 'Environment variable name for the Firecrawl API key. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['firecrawlApiUrl', 'String', 'Environment variable name for the Firecrawl API URL. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['jinaApiKey', 'String', 'Environment variable name for the Jina API key. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['cohereApiKey', 'String', 'Environment variable name for the Cohere API key. If not set in .env, users will be prompted to provide it via UI.', ''],
-    ['searchProvider', 'String', 'Specifies which search provider to use. Options: "serper", "searxng", "tavily".', ''],
-    ['scraperProvider', 'String', 'Specifies which scraper service to use. Options: "firecrawl", "serper", "tavily".', ''],
+    [
+      'serperApiKey',
+      'String',
+      'Environment variable name for the Serper API key. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'searxngInstanceUrl',
+      'String',
+      'Environment variable name for the SearXNG instance URL. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'searxngApiKey',
+      'String',
+      'Environment variable name for the SearXNG API key. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'tavilyApiKey',
+      'String',
+      'Environment variable name for the Tavily API key. Used for both search and scraper. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'tavilySearchUrl',
+      'String',
+      'Environment variable name for a custom Tavily Search API URL. Optional; defaults to Tavily hosted search when unset.',
+      '',
+    ],
+    [
+      'tavilyExtractUrl',
+      'String',
+      'Environment variable name for a custom Tavily Extract API URL. Optional; defaults to Tavily hosted extract when unset.',
+      '',
+    ],
+    [
+      'firecrawlApiKey',
+      'String',
+      'Environment variable name for the Firecrawl API key. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'firecrawlApiUrl',
+      'String',
+      'Environment variable name for the Firecrawl API URL. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'jinaApiKey',
+      'String',
+      'Environment variable name for the Jina API key. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'cohereApiKey',
+      'String',
+      'Environment variable name for the Cohere API key. If not set in .env, users will be prompted to provide it via UI.',
+      '',
+    ],
+    [
+      'searchProvider',
+      'String',
+      'Specifies which search provider to use. Options: "serper", "searxng", "tavily".',
+      '',
+    ],
+    [
+      'scraperProvider',
+      'String',
+      'Specifies which scraper service to use. Options: "firecrawl", "serper", "tavily".',
+      '',
+    ],
     ['firecrawlVersion', 'String', 'Specifies Firecrawl API version (v0 or v1).', ''],
-    ['rerankerType', 'String', 'Specifies which reranker service to use. Set to "none" to skip reranking. Options: "jina", "cohere", "none".', ''],
-    ['scraperTimeout', 'Integer', 'Timeout in milliseconds for scraper requests. Must be a non-negative integer.', ''],
-    ['safeSearch', 'Number', 'Safe search filtering level. 0 = OFF, 1 = MODERATE (default), 2 = STRICT.', ''],
+    [
+      'rerankerType',
+      'String',
+      'Specifies which reranker service to use. Set to "none" to skip reranking. Options: "jina", "cohere", "none".',
+      '',
+    ],
+    [
+      'scraperTimeout',
+      'Integer',
+      'Timeout in milliseconds for scraper requests. Must be a non-negative integer.',
+      '',
+    ],
+    [
+      'safeSearch',
+      'Number',
+      'Safe search filtering level. 0 = OFF, 1 = MODERATE (default), 2 = STRICT.',
+      '',
+    ],
   ]}
 />
 
@@ -199,43 +423,102 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
 ## fileConfig
 
 **Key:**
+
 <OptionTable
   options={[
-    ['fileConfig', 'Object', 'Configures file handling settings for the application, including size limits and MIME type restrictions.', ''],
+    [
+      'fileConfig',
+      'Object',
+      'Configures file handling settings for the application, including size limits and MIME type restrictions.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['endpoints', 'Record/Object', 'Specifies file handling configurations for individual endpoints, allowing customization per endpoint basis.', ''],
-    ['serverFileSizeLimit', 'Number', 'The maximum file size (in MB) that the server will accept. Applies globally across all endpoints unless overridden by endpoint-specific settings.', ''],
+    [
+      'endpoints',
+      'Record/Object',
+      'Specifies file handling configurations for individual endpoints, allowing customization per endpoint basis.',
+      '',
+    ],
+    [
+      'serverFileSizeLimit',
+      'Number',
+      'The maximum file size (in MB) that the server will accept. Applies globally across all endpoints unless overridden by endpoint-specific settings.',
+      '',
+    ],
     ['avatarSizeLimit', 'Number', 'Maximum size (in MB) for user avatar images.', ''],
-    ['clientImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
+    [
+      'clientImageResize',
+      'Object',
+      'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.',
+      '',
+    ],
     ['ocr', 'Object', 'Settings for Optical Character Recognition (OCR) file processing.', ''],
     ['text', 'Object', 'Settings for direct text file parsing.', ''],
     ['stt', 'Object', 'Settings for Speech-to-Text (STT) audio file processing.', ''],
-    ['fileTokenLimit', 'Number', 'Maximum number of tokens from text files to include in prompts before truncation.', 'fileTokenLimit: 100000'],
+    [
+      'fileTokenLimit',
+      'Number',
+      'Maximum number of tokens from text files to include in prompts before truncation.',
+      'fileTokenLimit: 100000',
+    ],
   ]}
 />
 
 ## clientImageResize
 
 **Key:**
+
 <OptionTable
   options={[
-    ['clientImageResize', 'Object', 'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.', ''],
+    [
+      'clientImageResize',
+      'Object',
+      'Configures client-side image resizing to optimize file uploads and prevent upload errors due to large image sizes.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['enabled', 'Boolean', 'Enables or disables client-side image resizing functionality. Default: false.', 'enabled: true'],
-    ['maxWidth', 'Number', 'Maximum width in pixels for resized images. Images wider than this will be resized. Default: 1920.', 'maxWidth: 1024'],
-    ['maxHeight', 'Number', 'Maximum height in pixels for resized images. Images taller than this will be resized. Default: 1080.', 'maxHeight: 768'],
-    ['quality', 'Number', 'JPEG compression quality (0.1 to 1.0). Higher values mean better quality but larger file sizes. Default: 0.8.', 'quality: 0.9'],
-    ['compressFormat', 'String', 'Output format for compressed images. Options: "jpeg", "webp". Default: "jpeg".', 'compressFormat: "webp"'],
+    [
+      'enabled',
+      'Boolean',
+      'Enables or disables client-side image resizing functionality. Default: false.',
+      'enabled: true',
+    ],
+    [
+      'maxWidth',
+      'Number',
+      'Maximum width in pixels for resized images. Images wider than this will be resized. Default: 1920.',
+      'maxWidth: 1024',
+    ],
+    [
+      'maxHeight',
+      'Number',
+      'Maximum height in pixels for resized images. Images taller than this will be resized. Default: 1080.',
+      'maxHeight: 768',
+    ],
+    [
+      'quality',
+      'Number',
+      'JPEG compression quality (0.1 to 1.0). Higher values mean better quality but larger file sizes. Default: 0.8.',
+      'quality: 0.9',
+    ],
+    [
+      'compressFormat',
+      'String',
+      'Output format for compressed images. Options: "jpeg", "webp". Default: "jpeg".',
+      'compressFormat: "webp"',
+    ],
   ]}
 />
 
@@ -244,13 +527,14 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
 The `clientImageResize` configuration enables automatic client-side image resizing before upload. This feature helps:
 
 - **Prevent upload failures** due to large image files exceeding server limits
-- **Reduce bandwidth usage** by compressing images before transmission  
+- **Reduce bandwidth usage** by compressing images before transmission
 - **Improve upload performance** with smaller file sizes
 - **Maintain image quality** while optimizing file size
 
 When enabled, images that exceed the specified `maxWidth` or `maxHeight` dimensions are automatically resized on the client side before being uploaded to the server. The resizing maintains the original aspect ratio while ensuring the image fits within the specified bounds.
 
 **Example:**
+
 ```yaml filename="clientImageResize"
 fileConfig:
   clientImageResize:
@@ -258,7 +542,7 @@ fileConfig:
     maxWidth: 1920
     maxHeight: 1080
     quality: 0.8
-    compressFormat: "jpeg"
+    compressFormat: 'jpeg'
 ```
 
 **Notes:**
@@ -275,59 +559,100 @@ see: [File Config Object Structure](/docs/configuration/librechat_yaml/object_st
 ## rateLimits
 
 **Key:**
+
 <OptionTable
   options={[
-    ['rateLimits', 'Object', 'Defines rate limiting policies to prevent abuse by limiting the number of requests.', ''],
+    [
+      'rateLimits',
+      'Object',
+      'Defines rate limiting policies to prevent abuse by limiting the number of requests.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['fileUploads', 'Object', 'Configures rate limits specifically for file upload operations.', ''],
-    ['conversationsImport', 'Object', 'Configures rate limits specifically for conversation import operations.', ''],
+    [
+      'fileUploads',
+      'Object',
+      'Configures rate limits specifically for file upload operations.',
+      '',
+    ],
+    [
+      'conversationsImport',
+      'Object',
+      'Configures rate limits specifically for conversation import operations.',
+      '',
+    ],
     ['stt', 'Object', 'Configures rate limits specifically for speech-to-text (stt) requests', ''],
     ['tts', 'Object', 'Configures rate limits specifically for text-to-speech (tts) requests', ''],
   ]}
 />
 
 **fileUploads Subkeys:**
+
 <OptionTable
   options={[
     ['ipMax', 'Number', 'Maximum number of uploads allowed per IP address per window.', ''],
     ['ipWindowInMinutes', 'Number', 'Time window in minutes for the IP-based upload limit.', ''],
     ['userMax', 'Number', 'Maximum number of uploads allowed per user per window.', ''],
-    ['userWindowInMinutes', 'Number', 'Time window in minutes for the user-based upload limit.', ''],
+    [
+      'userWindowInMinutes',
+      'Number',
+      'Time window in minutes for the user-based upload limit.',
+      '',
+    ],
   ]}
 />
 
 **conversationsImport Subkeys:**
+
 <OptionTable
   options={[
     ['ipMax', 'Number', 'Maximum number of imports allowed per IP address per window.', ''],
     ['ipWindowInMinutes', 'Number', 'Time window in minutes for the IP-based imports limit.', ''],
     ['userMax', 'Number', 'Maximum number of imports per user per window.', ''],
-    ['userWindowInMinutes', 'Number', 'Time window in minutes for the user-based imports limit.', ''],
+    [
+      'userWindowInMinutes',
+      'Number',
+      'Time window in minutes for the user-based imports limit.',
+      '',
+    ],
   ]}
 />
 
 **tts Subkeys:**
+
 <OptionTable
   options={[
     ['ipMax', 'Number', 'Maximum number of requests allowed per IP address per window.', ''],
     ['ipWindowInMinutes', 'Number', 'Time window in minutes for the IP-based requests limit.', ''],
     ['userMax', 'Number', 'Maximum number of requests per user per window.', ''],
-    ['userWindowInMinutes', 'Number', 'Time window in minutes for the user-based requests limit.', ''],
+    [
+      'userWindowInMinutes',
+      'Number',
+      'Time window in minutes for the user-based requests limit.',
+      '',
+    ],
   ]}
 />
 
 **stt Subkeys:**
+
 <OptionTable
   options={[
     ['ipMax', 'Number', 'Maximum number of requests allowed per IP address per window.', ''],
     ['ipWindowInMinutes', 'Number', 'Time window in minutes for the IP-based requests limit.', ''],
     ['userMax', 'Number', 'Maximum number of requests per user per window.', ''],
-    ['userWindowInMinutes', 'Number', 'Time window in minutes for the user-based requests limit.', ''],
+    [
+      'userWindowInMinutes',
+      'Number',
+      'Time window in minutes for the user-based requests limit.',
+      '',
+    ],
   ]}
 />
 
@@ -359,6 +684,7 @@ see: [File Config Object Structure](/docs/configuration/librechat_yaml/object_st
 ## registration
 
 **Key:**
+
 <OptionTable
   options={[
     ['registration', 'Object', 'Configures registration-related settings for the application.', ''],
@@ -366,6 +692,7 @@ see: [File Config Object Structure](/docs/configuration/librechat_yaml/object_st
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
     ['socialLogins', '', 'Social login configurations.', ''],
@@ -373,7 +700,8 @@ see: [File Config Object Structure](/docs/configuration/librechat_yaml/object_st
   ]}
 />
 
-see also: 
+see also:
+
 - [socialLogins](/docs/configuration/librechat_yaml/object_structure/registration#sociallogins),
 - [alloweddomains](/docs/configuration/librechat_yaml/object_structure/registration#alloweddomains),
 - [Registration Object Structure](/docs/configuration/librechat_yaml/object_structure/registration)
@@ -381,21 +709,43 @@ see also:
 ## memory
 
 **Key:**
+
 <OptionTable
   options={[
-    ['memory', 'Object', 'Configures conversation memory and personalization features for the application.', ''],
+    [
+      'memory',
+      'Object',
+      'Configures conversation memory and personalization features for the application.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
     ['disabled', 'Boolean', 'Disables memory functionality when set to true.', ''],
     ['validKeys', 'Array of Strings', 'Specifies which keys are valid for memory storage.', ''],
-    ['tokenLimit', 'Number', 'Sets the maximum number of tokens for memory storage and processing.', ''],
-    ['charLimit', 'Number', 'Sets the maximum number of characters for memory storage. Default: 10000.', ''],
+    [
+      'tokenLimit',
+      'Number',
+      'Sets the maximum number of tokens for memory storage and processing.',
+      '',
+    ],
+    [
+      'charLimit',
+      'Number',
+      'Sets the maximum number of characters for memory storage. Default: 10000.',
+      '',
+    ],
     ['personalize', 'Boolean', 'Enables or disables personalization features.', ''],
-    ['messageWindowSize', 'Number', 'Specifies the number of recent messages to include in memory context.', ''],
+    [
+      'messageWindowSize',
+      'Number',
+      'Specifies the number of recent messages to include in memory context.',
+      '',
+    ],
     ['agent', 'Object | Union', 'Configures the agent responsible for memory processing.', ''],
   ]}
 />
@@ -405,24 +755,56 @@ see: [Memory Object Structure](/docs/configuration/librechat_yaml/object_structu
 ## summarization
 
 **Key:**
+
 <OptionTable
   options={[
-    ['summarization', 'Object', 'Configures conversation summarization and context pruning. Replaces the per-endpoint `summarize` and `summaryModel` fields.', ''],
+    [
+      'summarization',
+      'Object',
+      'Configures conversation summarization and context pruning. Replaces the per-endpoint `summarize` and `summaryModel` fields.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['provider', 'String', 'LLM provider for summarization calls. Defaults to the agent\'s own provider.', ''],
-    ['model', 'String', 'Model for summarization calls. Defaults to the agent\'s own model.', ''],
+    [
+      'provider',
+      'String',
+      "LLM provider for summarization calls. Defaults to the agent's own provider.",
+      '',
+    ],
+    ['model', 'String', "Model for summarization calls. Defaults to the agent's own model.", ''],
     ['parameters', 'Object', 'Additional LLM parameters for summarization requests.', ''],
     ['prompt', 'String', 'Custom prompt for initial summarization.', ''],
     ['updatePrompt', 'String', 'Custom prompt for re-compaction when a prior summary exists.', ''],
-    ['trigger', 'Object', 'Defines when summarization is triggered (by token ratio, remaining tokens, or message count).', ''],
-    ['maxSummaryTokens', 'Number', 'Maximum output tokens for the summarization model response.', ''],
-    ['reserveRatio', 'Number', 'Fraction of token budget reserved as headroom (0–1). Default: 0.05.', ''],
-    ['contextPruning', 'Object', 'Configures position-based tool result degradation for older messages.', ''],
+    [
+      'trigger',
+      'Object',
+      'Defines when summarization is triggered (by token ratio, remaining tokens, or message count).',
+      '',
+    ],
+    [
+      'maxSummaryTokens',
+      'Number',
+      'Maximum output tokens for the summarization model response.',
+      '',
+    ],
+    [
+      'reserveRatio',
+      'Number',
+      'Fraction of token budget reserved as headroom (0–1). Default: 0.05.',
+      '',
+    ],
+    [
+      'contextPruning',
+      'Object',
+      'Configures position-based tool result degradation for older messages.',
+      '',
+    ],
   ]}
 />
 
@@ -431,6 +813,7 @@ see: [Summarization Object Structure](/docs/configuration/librechat_yaml/object_
 ## actions
 
 **Key:**
+
 <OptionTable
   options={[
     ['actions', 'Object', 'Configures actions-related settings, used by Agents and Assistants', ''],
@@ -438,14 +821,26 @@ see: [Summarization Object Structure](/docs/configuration/librechat_yaml/object_
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['allowedDomains', 'Array of Strings', 'Strict whitelist of domains for actions. When set, only listed domains are reachable.', ''],
-    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits specific private host:port services without restricting public destinations when `allowedDomains` is not configured.', ''],
+    [
+      'allowedDomains',
+      'Array of Strings',
+      'Strict whitelist of domains for actions. When set, only listed domains are reachable.',
+      '',
+    ],
+    [
+      'allowedAddresses',
+      'Array of Strings',
+      'SSRF exemption list (private IP space only). Permits specific private host:port services without restricting public destinations when `allowedDomains` is not configured.',
+      '',
+    ],
   ]}
 />
 
-see also: 
+see also:
+
 - [allowedDomains](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains),
 - [allowedAddresses](/docs/configuration/librechat_yaml/object_structure/actions#allowedaddresses),
 - [Actions Object Structure](/docs/configuration/librechat_yaml/object_structure/actions)
@@ -453,56 +848,144 @@ see also:
 ## interface
 
 **Key:**
+
 <OptionTable
   options={[
-    ['interface', 'Object', 'Configures user interface elements within the application, allowing for customization of visibility and behavior of various components.', ''],
+    [
+      'interface',
+      'Object',
+      'Configures user interface elements within the application, allowing for customization of visibility and behavior of various components.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['privacyPolicy', 'Object', 'Contains settings related to the privacy policy link provided.', ''],
-    ['termsOfService', 'Object', 'Contains settings related to the terms of service link provided.', ''],
+    [
+      'privacyPolicy',
+      'Object',
+      'Contains settings related to the privacy policy link provided.',
+      '',
+    ],
+    [
+      'termsOfService',
+      'Object',
+      'Contains settings related to the terms of service link provided.',
+      '',
+    ],
     ['modelSelect', 'Boolean', 'Determines whether the model selection feature is available.', ''],
-    ['parameters', 'Boolean', 'Toggles the visibility of parameter configuration options AKA conversation settings.', ''],
+    [
+      'parameters',
+      'Boolean',
+      'Toggles the visibility of parameter configuration options AKA conversation settings.',
+      '',
+    ],
     ['presets', 'Boolean', 'Enables or disables the presets menu', ''],
-    ['prompts', 'Boolean or Object', 'Enables or disables all prompt-related features for all users', ''],
-    ['bookmarks', 'Boolean', 'Enables or disables all bookmarks-related features for all users', ''],
+    [
+      'prompts',
+      'Boolean or Object',
+      'Enables or disables all prompt-related features for all users',
+      '',
+    ],
+    [
+      'bookmarks',
+      'Boolean',
+      'Enables or disables all bookmarks-related features for all users',
+      '',
+    ],
     ['memories', 'Boolean', 'Enables or disables the memories feature for all users', ''],
-    ['multiConvo', 'Boolean', 'Enables or disables all "multi convo", AKA multiple response streaming, related features for all users', ''],
+    [
+      'multiConvo',
+      'Boolean',
+      'Enables or disables all "multi convo", AKA multiple response streaming, related features for all users',
+      '',
+    ],
     ['agents', 'Boolean or Object', 'Enables or disables all agents features for all users', ''],
     ['temporaryChat', 'Boolean', 'Enables or disables the temporary chat feature', ''],
-    ['temporaryChatRetention', 'Number', 'Configures the retention period for temporary chats in hours. Min: 1, Max: 8760. Default: 720 (30 days).', ''],
-    ['autoSubmitFromUrl', 'Boolean', 'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model. When `false`, the prompt is pre-filled but not submitted.', ''],
-    ['mcpServers', 'Object', 'Contains settings related to MCP server selection and access control.', ''],
+    [
+      'temporaryChatRetention',
+      'Number',
+      'Configures the retention period for temporary chats in hours. Min: 1, Max: 8760. Default: 720 (30 days).',
+      '',
+    ],
+    [
+      'autoSubmitFromUrl',
+      'Boolean',
+      'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model. When `false`, the prompt is pre-filled but not submitted.',
+      '',
+    ],
+    [
+      'mcpServers',
+      'Object',
+      'Contains settings related to MCP server selection and access control.',
+      '',
+    ],
     ['customWelcome', 'String', 'Custom welcome message displayed in the chat interface.', ''],
-    ['runCode', 'Boolean', 'Enables or disables the "Run Code" button for Markdown Code Blocks', ''],
+    [
+      'runCode',
+      'Boolean',
+      'Enables or disables the "Run Code" button for Markdown Code Blocks',
+      '',
+    ],
     ['webSearch', 'Boolean', 'Enables or disables the web search button in the chat interface', ''],
-    ['fileSearch', 'Boolean', 'Enables or disables the file search button in the chat interface', ''],
+    [
+      'fileSearch',
+      'Boolean',
+      'Enables or disables the file search button in the chat interface',
+      '',
+    ],
     ['fileCitations', 'Boolean', 'Globally enables or disables file citations for all users', ''],
-    ['peoplePicker', 'Object', 'Configures which principal types are available controls in the people picker interface', ''],
+    [
+      'peoplePicker',
+      'Object',
+      'Configures which principal types are available controls in the people picker interface',
+      '',
+    ],
     ['marketplace', 'Object', 'Enables or disables access to the Agent Marketplace', ''],
   ]}
 />
-  
 see: [Interface Object Structure](/docs/configuration/librechat_yaml/object_structure/interface)
 
 ## modelSpecs
 
 **Key:**
+
 <OptionTable
   options={[
-    ['modelSpecs', 'Object', 'Configures model specifications, allowing for detailed setup and customization of AI models and their behaviors within the application.', ''],
+    [
+      'modelSpecs',
+      'Object',
+      'Configures model specifications, allowing for detailed setup and customization of AI models and their behaviors within the application.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['enforce', 'Boolean', 'Determines whether the model specifications should strictly override other configuration settings.', ''],
-    ['prioritize', 'Boolean', 'Specifies if model specifications should take priority over the default configuration when both are applicable.', ''],
-    ['list', 'Array of Objects', 'Contains a list of individual model specifications detailing various configurations and behaviors.', ''],
+    [
+      'enforce',
+      'Boolean',
+      'Determines whether the model specifications should strictly override other configuration settings.',
+      '',
+    ],
+    [
+      'prioritize',
+      'Boolean',
+      'Specifies if model specifications should take priority over the default configuration when both are applicable.',
+      '',
+    ],
+    [
+      'list',
+      'Array of Objects',
+      'Contains a list of individual model specifications detailing various configurations and behaviors.',
+      '',
+    ],
   ]}
 />
 
@@ -511,22 +994,37 @@ see: [Model Specs Object Structure](/docs/configuration/librechat_yaml/object_st
 ## endpoints
 
 **Key:**
+
 <OptionTable
-  options={[
-    ['endpoints', 'Object', 'Defines custom API endpoints for the application.', ''],
-  ]}
+  options={[['endpoints', 'Object', 'Defines custom API endpoints for the application.', '']]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['custom', 'Array of Objects', 'Each object in the array represents a unique endpoint configuration.', ''],
+    [
+      'custom',
+      'Array of Objects',
+      'Each object in the array represents a unique endpoint configuration.',
+      '',
+    ],
     ['azureOpenAI', 'Object', 'Azure OpenAI endpoint-specific configuration', ''],
     ['assistants', 'Object', 'Assistants endpoint-specific configuration.', ''],
     ['azureAssistants', 'Object', 'Azure Assistants endpoint-specific configuration.', ''],
     ['agents', 'Object', 'Agents endpoint-specific configuration.', ''],
-    ['all', 'Object', 'Global endpoint settings that apply to all endpoints. See Shared Endpoint Settings.', ''],
-    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits user-provided baseURLs to point at specific private host:port services (e.g. self-hosted Ollama) without disabling SSRF protection for everything else.', ''],
+    [
+      'all',
+      'Object',
+      'Global endpoint settings that apply to all endpoints. See Shared Endpoint Settings.',
+      '',
+    ],
+    [
+      'allowedAddresses',
+      'Array of Strings',
+      'SSRF exemption list (private IP space only). Permits user-provided baseURLs to point at specific private host:port services (e.g. self-hosted Ollama) without disabling SSRF protection for everything else.',
+      '',
+    ],
   ]}
 />
 
@@ -537,17 +1035,34 @@ see: [Model Specs Object Structure](/docs/configuration/librechat_yaml/object_st
 ## mcpSettings
 
 **Key:**
+
 <OptionTable
   options={[
-    ['mcpSettings', 'Object', 'Defines global settings for Model Context Protocol (MCP) servers', ''],
+    [
+      'mcpSettings',
+      'Object',
+      'Defines global settings for Model Context Protocol (MCP) servers',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['allowedDomains', 'Array of Strings', 'Strict whitelist of domains for MCP server connections. When set, only listed entries are reachable.', ''],
-    ['allowedAddresses', 'Array of Strings', 'SSRF exemption list (private IP space only). Permits specific private host:port services without flipping `allowedDomains` into strict-whitelist mode.', ''],
+    [
+      'allowedDomains',
+      'Array of Strings',
+      'Strict whitelist of domains for MCP server connections. When set, only listed entries are reachable.',
+      '',
+    ],
+    [
+      'allowedAddresses',
+      'Array of Strings',
+      'SSRF exemption list (private IP space only). Permits specific private host:port services without flipping `allowedDomains` into strict-whitelist mode.',
+      '',
+    ],
   ]}
 />
 
@@ -570,8 +1085,8 @@ mcpSettings:
 
   # Default SSRF mode with private service exemptions:
   allowedAddresses:
-    - "host.docker.internal:8080"  # Permit one private host on one port
-    - "10.0.0.5:8000"             # Permit one private IP on one port
+    - 'host.docker.internal:8080' # Permit one private host on one port
+    - '10.0.0.5:8000' # Permit one private IP on one port
 ```
 
 see: [MCP Settings Object Structure](/docs/configuration/librechat_yaml/object_structure/mcp_settings)
@@ -579,16 +1094,28 @@ see: [MCP Settings Object Structure](/docs/configuration/librechat_yaml/object_s
 ## mcpServers
 
 **Key:**
+
 <OptionTable
   options={[
-    ['mcpServers', 'Object', 'Defines the configuration for Model Context Protocol (MCP) servers, allowing dynamic integration of MCP servers within the application.', ''],
+    [
+      'mcpServers',
+      'Object',
+      'Defines the configuration for Model Context Protocol (MCP) servers, allowing dynamic integration of MCP servers within the application.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['<serverName>', 'Object', 'Each key under `mcpServers` represents an individual MCP server configuration, identified by a unique name.', ''],
+    [
+      '<serverName>',
+      'Object',
+      'Each key under `mcpServers` represents an individual MCP server configuration, identified by a unique name.',
+      '',
+    ],
   ]}
 />
 
@@ -621,44 +1148,44 @@ mcpServers:
     url: http://localhost:3001/sse
     timeout: 30000
     initTimeout: 10000
-    serverInstructions: true  # Use server-provided instructions
+    serverInstructions: true # Use server-provided instructions
   puppeteer:
     type: stdio
     command: npx
     args:
       - -y
-      - "@modelcontextprotocol/server-puppeteer"
+      - '@modelcontextprotocol/server-puppeteer'
     timeout: 30000
     initTimeout: 10000
-    serverInstructions: "Do not access any local files or local/internal IP addresses"
+    serverInstructions: 'Do not access any local files or local/internal IP addresses'
   filesystem:
     # type: stdio
     command: npx
     args:
       - -y
-      - "@modelcontextprotocol/server-filesystem"
+      - '@modelcontextprotocol/server-filesystem'
       - /home/user/LibreChat/
     iconPath: /home/user/LibreChat/client/public/assets/logo.svg
   mcp-obsidian:
     command: npx
     args:
       - -y
-      - "mcp-obsidian"
+      - 'mcp-obsidian'
       - /path/to/obsidian/vault
   streamable-http-example:
     type: streamable-http
     url: https://example.com/mcp
     headers:
-      Authorization: "Bearer ${API_TOKEN}"
+      Authorization: 'Bearer ${API_TOKEN}'
     timeout: 30000
   per-user-crendentials-example:
     type: sse
-    url: "https//some.mcp/sse"
+    url: 'https//some.mcp/sse'
     headers:
-      X-Custom-Auth-Token: "{{USER_API_KEY}}" # Placeholder for the user-provided API key, defined in `customUserVars` below.
+      X-Custom-Auth-Token: '{{USER_API_KEY}}' # Placeholder for the user-provided API key, defined in `customUserVars` below.
     customUserVars:
       USER_API_KEY:
-        title: "Service API Key"
+        title: 'Service API Key'
         description: "Your personal API key for this service. You can get it <a href='https://example.com/api-keys' target='_blank'>here</a>."
     serverInstructions: true
 ```
@@ -668,16 +1195,28 @@ see: [MCP Servers Object Structure](/docs/configuration/librechat_yaml/object_st
 ## speech
 
 **Key:**
+
 <OptionTable
   options={[
-    ['speech', 'Object', 'Configures Text-to-Speech (TTS) and Speech-to-Text (STT) providers for the application.', ''],
+    [
+      'speech',
+      'Object',
+      'Configures Text-to-Speech (TTS) and Speech-to-Text (STT) providers for the application.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
-    ['tts', 'Object', 'Text-to-Speech provider configurations (OpenAI, Azure OpenAI, ElevenLabs, LocalAI).', ''],
+    [
+      'tts',
+      'Object',
+      'Text-to-Speech provider configurations (OpenAI, Azure OpenAI, ElevenLabs, LocalAI).',
+      '',
+    ],
     ['stt', 'Object', 'Speech-to-Text provider configurations (OpenAI, Azure OpenAI).', ''],
     ['speechTab', 'Object', 'Default UI settings for speech features.', ''],
   ]}
@@ -688,13 +1227,20 @@ see: [Speech Object Structure](/docs/configuration/librechat_yaml/object_structu
 ## turnstile
 
 **Key:**
+
 <OptionTable
   options={[
-    ['turnstile', 'Object', 'Configures Cloudflare Turnstile for bot protection on registration and login forms.', ''],
+    [
+      'turnstile',
+      'Object',
+      'Configures Cloudflare Turnstile for bot protection on registration and login forms.',
+      '',
+    ],
   ]}
 />
 
 **Subkeys:**
+
 <OptionTable
   options={[
     ['siteKey', 'String', 'Your Cloudflare Turnstile site key (required).', ''],
@@ -707,6 +1253,7 @@ see: [Turnstile Object Structure](/docs/configuration/librechat_yaml/object_stru
 ## transactions
 
 **Key:**
+
 <OptionTable
   options={[
     ['transactions', 'Object', 'Controls transaction logging and visibility features.', ''],
@@ -714,15 +1261,15 @@ see: [Turnstile Object Structure](/docs/configuration/librechat_yaml/object_stru
 />
 
 **Subkeys:**
+
 <OptionTable
-  options={[
-    ['enabled', 'Boolean', 'Enables or disables transaction logging. Default: true.', ''],
-  ]}
+  options={[['enabled', 'Boolean', 'Enables or disables transaction logging. Default: true.', '']]}
 />
 
 see: [Transactions Object Structure](/docs/configuration/librechat_yaml/object_structure/transactions)
 
 ## Additional links
+
 - [Summarization Object Structure](/docs/configuration/librechat_yaml/object_structure/summarization)
 - [AWS Bedrock Object Structure](/docs/configuration/librechat_yaml/object_structure/aws_bedrock)
 - [Custom Endpoint Object Structure](/docs/configuration/librechat_yaml/object_structure/custom_endpoint)

--- a/content/docs/configuration/librechat_yaml/object_structure/meta.json
+++ b/content/docs/configuration/librechat_yaml/object_structure/meta.json
@@ -30,6 +30,7 @@
     "ocr",
     "speech",
     "---Files & Storage---",
+    "cloudfront",
     "file_config",
     "---Billing---",
     "transactions",

--- a/content/docs/configuration/logging.mdx
+++ b/content/docs/configuration/logging.mdx
@@ -13,9 +13,9 @@ LibreChat has central logging built into its backend (api).
 <FileTree>
   <FileTree.Folder name="librechat" defaultOpen>
     <FileTree.Folder name="logs" defaultOpen>
-      <FileTree.File name="debug-2024-01-01.log" active/>
-      <FileTree.File name="error-2024-01-01.log" active/>
-      <FileTree.File name="meiliSync-2024-01-01.log" active/>
+      <FileTree.File name="debug-2024-01-01.log" active />
+      <FileTree.File name="error-2024-01-01.log" active />
+      <FileTree.File name="meiliSync-2024-01-01.log" active />
     </FileTree.Folder>
   </FileTree.Folder>
 </FileTree>
@@ -24,13 +24,13 @@ LibreChat has central logging built into its backend (api).
 
 <FileTree>
   <FileTree.Folder name="librechat" defaultOpen>
-      <FileTree.Folder name="api" defaultOpen>
-        <FileTree.Folder name="logs" defaultOpen>
-        <FileTree.File name="debug-2024-01-01.log" active/>
-        <FileTree.File name="error-2024-01-01.log" active/>
-        <FileTree.File name="meiliSync-2024-01-01.log" active/>
-        </FileTree.Folder>
-      </FileTree.Folder>  
+    <FileTree.Folder name="api" defaultOpen>
+      <FileTree.Folder name="logs" defaultOpen>
+        <FileTree.File name="debug-2024-01-01.log" active />
+        <FileTree.File name="error-2024-01-01.log" active />
+        <FileTree.File name="meiliSync-2024-01-01.log" active />
+      </FileTree.Folder>
+    </FileTree.Folder>
   </FileTree.Folder>
 </FileTree>
 
@@ -38,13 +38,14 @@ Error logs are saved by default. Debug logs are enabled by default but can be tu
 
 This allows you to monitor your server through external tools that inspect log files, such as **[the ELK stack](https://aws.amazon.com/what-is/elk-stack/)**.
 
-Debug logs are essential for developer work and fixing issues. If you encounter any problems running LibreChat, reproduce as close as possible, and **[report the issue](https://github.com/danny-avila/LibreChat/issues)** with your logs found in `./api/logs/debug-%DATE%.log`. 
+Debug logs are essential for developer work and fixing issues. If you encounter any problems running LibreChat, reproduce as close as possible, and **[report the issue](https://github.com/danny-avila/LibreChat/issues)** with your logs found in `./api/logs/debug-%DATE%.log`.
 
 Errors logs are also saved in the same location: `./api/logs/error-%DATE%.log`. If you have meilisearch configured, there is a separate log file for this as well.
 
 <Callout type="note" title="Note:">
-Note: Logs are rotated on a 14-day basis, so you will generate one error log file, one debug log file, and one meiliSync log file per 14 days.
-Errors will also be present in debug log files as well, but provide stack traces and more detail in the error log files.
+  Note: Logs are rotated on a 14-day basis, so you will generate one error log file, one debug log
+  file, and one meiliSync log file per 14 days. Errors will also be present in debug log files as
+  well, but provide stack traces and more detail in the error log files.
 </Callout>
 
 ### Setup
@@ -52,9 +53,7 @@ Errors will also be present in debug log files as well, but provide stack traces
 - Toggle debug logs with the following environment variable. By default, even if you never set this variable, debug logs will be generated, but you have the option to disable them by setting it to `FALSE`.
 
 <OptionTable
-  options={[
-    ['DEBUG_LOGGING', 'boolean', 'Keep debug logs active.','DEBUG_LOGGING=true'],
-  ]}
+  options={[['DEBUG_LOGGING', 'boolean', 'Keep debug logs active.', 'DEBUG_LOGGING=true']]}
 />
 
 > Note: it's recommended to disable debug logs in a production environment.
@@ -63,7 +62,12 @@ Errors will also be present in debug log files as well, but provide stack traces
 
 <OptionTable
   options={[
-    ['DEBUG_CONSOLE', 'boolean', 'Enable verbose console/stdout logs in the same format as file debug logs.', 'DEBUG_CONSOLE=false'],
+    [
+      'DEBUG_CONSOLE',
+      'boolean',
+      'Enable verbose console/stdout logs in the same format as file debug logs.',
+      'DEBUG_CONSOLE=false',
+    ],
   ]}
 />
 
@@ -73,7 +77,12 @@ This is not recommended however, as the outputs can be quite verbose. It's disab
 
 <OptionTable
   options={[
-    ['CONSOLE_JSON', 'boolean', 'Enable verbose JSON console/stdout logs suitable for cloud deployments like GCP/AWS.', 'CONSOLE_JSON=false'],
+    [
+      'CONSOLE_JSON',
+      'boolean',
+      'Enable verbose JSON console/stdout logs suitable for cloud deployments like GCP/AWS.',
+      'CONSOLE_JSON=false',
+    ],
   ]}
 />
 
@@ -81,6 +90,11 @@ By default, the JSON string length is truncated to 255 characters. You can confi
 
 <OptionTable
   options={[
-    ['CONSOLE_JSON_STRING_LENGTH', 'number', 'Configure the truncation size for console/stdout logs, defaults to 255', 'CONSOLE_JSON_STRING_LENGTH=1000'],
+    [
+      'CONSOLE_JSON_STRING_LENGTH',
+      'number',
+      'Configure the truncation size for string values in JSON console/stdout logs. Default: 255.',
+      '# CONSOLE_JSON_STRING_LENGTH=255',
+    ],
   ]}
 />

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -135,6 +135,26 @@ This is especially useful when an agent has access to many MCP servers with doze
 
 **Note:** The `deferred_tools` capability is enabled by default. It can be toggled via the [`librechat.yaml` agents configuration](/docs/configuration/librechat_yaml/object_structure/agents#capabilities).
 
+{/* ### Programmatic Tool Calling */}
+{/*  */}
+{/* **Note:** this feature is still in private beta and not accessible to all users. */}
+{/*  */}
+{/* Programmatic Tool Calling (PTC) allows MCP tools to be executed via code in a sandbox environment rather than being called directly by the LLM. This enables more complex tool orchestration—for example, calling multiple tools in sequence, processing results with code, or building dynamic workflows. */}
+{/*  */}
+{/* **How it works:** */}
+{/*  */}
+{/* - Tools marked for "code execution" calling are routed through the Code Interpreter sandbox */}
+{/* - The LLM writes code that calls the tools programmatically, allowing for loops, conditionals, and data transformations */}
+{/* - Results flow back through the sandbox to the LLM */}
+{/*  */}
+{/* **Configuring programmatic tools:** */}
+{/*  */}
+{/* 1. Open the Agent Builder and add MCP tools */}
+{/* 2. Click the dropdown on any MCP tool */}
+{/* 3. Toggle "Code Execution" calling — programmatic tools show a code icon */}
+{/*  */}
+{/* **Note:** The `programmatic_tools` capability is **disabled by default** and requires the latest [Code Interpreter API](/docs/features/code_interpreter). It can be enabled via the [`librechat.yaml` agents configuration](/docs/configuration/librechat_yaml/object_structure/agents#capabilities). */}
+
 ### Skills
 
 Skills let agents load reusable instructions from `SKILL.md` definitions. They can be selected manually from chat with `$`, automatically discovered by the model through the skill catalog, or always applied on every turn.

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -25,6 +25,7 @@ The creation form includes:
 - **Model**: Select from available providers and models
 
 **Existing agents can be selected from the top dropdown of the Side Panel.**
+
 - **Also by mention with "@" in the chat input.**
 
 ![Agents - Mention](/images/agents/mention.png)
@@ -45,6 +46,7 @@ The model parameters interface allows fine-tuning of your agent's responses:
 ### Code Interpreter
 
 When enabled, the Code Interpreter capability allows your agent to:
+
 - Execute code in multiple languages, including:
   - Python, JavaScript, TypeScript, Go, C, C++, Java, PHP, Rust, and Fortran
 - Process files securely through the LibreChat Code Interpreter API
@@ -56,6 +58,7 @@ When enabled, the Code Interpreter capability allows your agent to:
 ### File Search
 
 The File Search capability enables:
+
 - RAG (Retrieval-Augmented Generation) functionality
 - Semantic search across uploaded documents
 - Context-aware responses based on file contents
@@ -85,7 +88,6 @@ For more information, see documentation on [MCP](/docs/features/mcp).
 
 #### Agents with MCP Tools
 
-
 1. Configure MCP servers in your `librechat.yaml` file
 2. Restart LibreChat to initialize the connections
 3. Create or edit an agent
@@ -109,6 +111,7 @@ Once an MCP server is added to an agent, you can fine-tune which specific tools 
 ![Agents - MCP Tools](/images/agents/mcp_agent_tools.png)
 
 Learn More:
+
 - [Configuring MCP Servers](/docs/features/mcp)
 - [Model Context Protocol Introduction](https://modelcontextprotocol.io/introduction)
 
@@ -119,36 +122,24 @@ Deferred tools allow agents to have access to many MCP tools without loading the
 This is especially useful when an agent has access to many MCP servers with dozens of tools—loading them all would consume a large portion of the context window and degrade response quality.
 
 **How it works:**
+
 - Tools marked as "deferred" are excluded from the initial LLM context
 - A `ToolSearch` tool is automatically added, allowing the LLM to discover and load deferred tools on demand
 - Once discovered, the tool is available for the rest of the conversation
 
 **Configuring deferred tools:**
+
 1. Open the Agent Builder and add MCP tools
 2. Click the dropdown on any MCP tool
 3. Toggle "Defer Loading" — deferred tools show a clock icon
 
 **Note:** The `deferred_tools` capability is enabled by default. It can be toggled via the [`librechat.yaml` agents configuration](/docs/configuration/librechat_yaml/object_structure/agents#capabilities).
 
-{/*
-### Programmatic Tool Calling
+### Skills
 
-**Note:** this feature is still in private beta and not accessible to all users.
+Skills let agents load reusable instructions from `SKILL.md` definitions. They can be selected manually from chat with `$`, automatically discovered by the model through the skill catalog, or always applied on every turn.
 
-Programmatic Tool Calling (PTC) allows MCP tools to be executed via code in a sandbox environment rather than being called directly by the LLM. This enables more complex tool orchestration—for example, calling multiple tools in sequence, processing results with code, or building dynamic workflows.
-
-**How it works:**
-- Tools marked for "code execution" calling are routed through the Code Interpreter sandbox
-- The LLM writes code that calls the tools programmatically, allowing for loops, conditionals, and data transformations
-- Results flow back through the sandbox to the LLM
-
-**Configuring programmatic tools:**
-1. Open the Agent Builder and add MCP tools
-2. Click the dropdown on any MCP tool
-3. Toggle "Code Execution" calling — programmatic tools show a code icon
-
-**Note:** The `programmatic_tools` capability is **disabled by default** and requires the latest [Code Interpreter API](/docs/features/code_interpreter). It can be enabled via the [`librechat.yaml` agents configuration](/docs/configuration/librechat_yaml/object_structure/agents#capabilities).
-*/}
+For authoring, invocation, and access control details, see [Skills](/docs/features/skills).
 
 ### Artifacts
 
@@ -174,12 +165,15 @@ Here's a simple example of the minimum instructions needed:
 When creating content that should be displayed as an artifact, use the following format:
 
 :::artifact{identifier="unique-identifier" type="mime-type" title="Artifact Title"}
+
 ```
 Your artifact content here
 ```
+
 :::
 
 For the type attribute, use one of:
+
 - "text/html" for HTML content
 - "application/vnd.mermaid" for Mermaid diagrams
 - "application/vnd.react" for React components
@@ -219,7 +213,7 @@ With the Actions capability, you can dynamically create tools from [OpenAPI spec
 - Individual domains can be whitelisted for agent actions:
   - [More info](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains)
 - Note that you can add add the 'x-strict': true flag at operation-level in the OpenAPI spec for actions.
-If using an OpenAI model supporting it, this will automatically generate function calls with 'strict' mode enabled.
+  If using an OpenAI model supporting it, this will automatically generate function calls with 'strict' mode enabled.
   - Strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported for details.
 
 ### Agent Chain
@@ -233,9 +227,20 @@ The Agent Chain capability enables a Mixture-of-Agents (MoA) approach, allowing 
 - **Note:** This feature is currently in beta and may be subject to change
   - The current maximum of agents that can be chained is 10, but this may be configurable in the future
 
-<img src="https://firebasestorage.googleapis.com/v0/b/superb-reporter-407417.appspot.com/o/agent_chain.png?alt=media&token=bfa209b9-d2ab-403f-b097-6300b4017fc8" alt="Agent Chain" width={488} height={269}/>
+<img
+  src="https://firebasestorage.googleapis.com/v0/b/superb-reporter-407417.appspot.com/o/agent_chain.png?alt=media&token=bfa209b9-d2ab-403f-b097-6300b4017fc8"
+  alt="Agent Chain"
+  width={488}
+  height={269}
+/>
 
 This feature introduces a layered Mixture-of-Agents architecture to LibreChat, where each agent takes all the outputs from agents in the previous layer as auxiliary information in generating its response, as described in [the eponymous "Mixture-of-Agents" paper](https://arxiv.org/abs/2406.04692).
+
+### Subagents
+
+Subagents let an agent delegate a focused task to an isolated child run. The child gets its own context window and tool execution flow, then returns a compact result to the parent instead of filling the parent context with every intermediate step.
+
+Subagents are different from Agent Chain: chain runs coordinate multiple agents as graph participants, while subagents are spawned by an agent as a tool call for scoped delegation. For setup and limits, see [Subagents](/docs/features/subagents).
 
 ### Advanced Settings
 
@@ -305,11 +310,11 @@ Agents use LibreChat's granular [access control](/docs/features/access_control) 
 
 When sharing an agent, the grantee is assigned one of three roles:
 
-| Role | What the grantee can do |
-| --- | --- |
+| Role       | What the grantee can do                                                                               |
+| ---------- | ----------------------------------------------------------------------------------------------------- |
 | **Viewer** | Use the agent in conversations; cannot open the builder or see instructions, tools, or attached files |
-| **Editor** | View + modify the agent's instructions, model, tools, and files |
-| **Owner** | Full control: view, edit, delete, and re-share the agent |
+| **Editor** | View + modify the agent's instructions, model, tools, and files                                       |
+| **Owner**  | Full control: view, edit, delete, and re-share the agent                                              |
 
 The original author and administrators always retain full control regardless of the ACL.
 
@@ -342,7 +347,7 @@ db.users.updateOne(
 
 The use of agents for all users can also be disabled via config, [more info](/docs/configuration/librechat_yaml/object_structure/interface).
 
-Feature-level permissions (who can *use*, *create*, *share*, or *share publicly* agents) are managed from the [**LibreChat Admin Panel**](/docs/features/admin_panel) on each role, including any custom roles. The [`interface.agents`](/docs/configuration/librechat_yaml/object_structure/interface#agents) block in `librechat.yaml` can still seed defaults for the built-in `USER` role at startup, but the admin panel is the recommended way to edit them going forward.
+Feature-level permissions (who can _use_, _create_, _share_, or _share publicly_ agents) are managed from the [**LibreChat Admin Panel**](/docs/features/admin_panel) on each role, including any custom roles. The [`interface.agents`](/docs/configuration/librechat_yaml/object_structure/interface#agents) block in `librechat.yaml` can still seed defaults for the built-in `USER` role at startup, but the admin panel is the recommended way to edit them going forward.
 
 ### User-Level Sharing
 
@@ -386,6 +391,7 @@ LibreChat allows admins to configure the use of agents via the [`librechat.yaml`
 7. Create and start using your agent
 
 When chatting with agents, you can:
+
 - Use "Upload as Text" to include full document content in conversations (text parsing by default, enhanced by OCR)
 - Use "Upload for File Search" for semantic search over documents (requires RAG API)
 - Add files to agent's "File Context" to included a file's full content as part of the agent's system instructions
@@ -393,12 +399,15 @@ When chatting with agents, you can:
 ## Migration Required (v0.8.0-rc3+)
 
 <Callout type="warning" title="Important: Agent Permissions Migration Required">
-Starting from version v0.8.0-rc3, LibreChat uses a new Access Control List (ACL) based permission system for agents. If you're upgrading from an earlier version, you must run the agent permissions migration for existing agents to remain accessible.
+  Starting from version v0.8.0-rc3, LibreChat uses a new Access Control List (ACL) based permission
+  system for agents. If you're upgrading from an earlier version, you must run the agent permissions
+  migration for existing agents to remain accessible.
 </Callout>
 
 ### What the Migration Does
 
 The agent permissions migration transitions your agents from a simple ownership model to a sophisticated ACL-based system with multiple permission levels:
+
 - **OWNER**: Full control over the agent
 - **EDITOR**: Can view and modify the agent
 - **VIEWER**: Read-only access to the agent
@@ -412,16 +421,19 @@ Choose the appropriate command based on your deployment method:
 #### 1. For the default `docker-compose.yml` (if you use `docker compose up` to start the app):
 
 **Preview changes (dry run):**
+
 ```bash
 docker compose exec api npm run migrate:agent-permissions:dry-run
 ```
 
 **Execute migration:**
+
 ```bash
 docker compose exec api npm run migrate:agent-permissions
 ```
 
 **Custom batch size (for large datasets):**
+
 ```bash
 docker compose exec api npm run migrate:agent-permissions:batch
 ```
@@ -429,16 +441,19 @@ docker compose exec api npm run migrate:agent-permissions:batch
 #### 2. For the `deploy-compose.yml` (if you followed the [Ubuntu Docker Guide](/docs/remote/docker_linux)):
 
 **Preview changes (dry run):**
+
 ```bash
 docker exec -it LibreChat-API /bin/sh -c "cd .. && npm run migrate:agent-permissions:dry-run"
 ```
 
 **Execute migration:**
+
 ```bash
 docker exec -it LibreChat-API /bin/sh -c "cd .. && npm run migrate:agent-permissions"
 ```
 
 **Custom batch size (for large datasets):**
+
 ```bash
 docker exec -it LibreChat-API /bin/sh -c "cd .. && npm run migrate:agent-permissions:batch"
 ```
@@ -446,16 +461,19 @@ docker exec -it LibreChat-API /bin/sh -c "cd .. && npm run migrate:agent-permiss
 #### 3. For local development (from project root):
 
 **Preview changes (dry run):**
+
 ```bash
 npm run migrate:agent-permissions:dry-run
 ```
 
 **Execute migration:**
+
 ```bash
 npm run migrate:agent-permissions
 ```
 
 **Custom batch size (for large datasets):**
+
 ```bash
 npm run migrate:agent-permissions:batch
 ```
@@ -469,7 +487,9 @@ npm run migrate:agent-permissions:batch
 You can adjust the resulting agent permissions via the Agent Builder UI.
 
 <Callout type="info" title="Note">
-The same migration process applies to prompts. If you also have existing prompts, run the prompt permissions migration using the same commands but replace `agent` with `prompt` in the command names.
+  The same migration process applies to prompts. If you also have existing prompts, run the prompt
+  permissions migration using the same commands but replace `agent` with `prompt` in the command
+  names.
 </Callout>
 
 ## Agents API (Beta)
@@ -483,6 +503,7 @@ See the [Agents API documentation](/docs/features/agents_api) for setup and usag
 LibreChat Agents usher in a new era for the app where future pipelines can be streamlined via Agents for specific tasks and workflows across your experience in LibreChat.
 
 Future updates will include:
+
 - General improvements to the current Agent experience
 - Multi-agent orchestration for complex workflows
 - Ability to customize agents for various functions: titling (chat thread naming), memory management (user context/history), and prompt enhancement (input assistance/predictions)

--- a/content/docs/features/meta.json
+++ b/content/docs/features/meta.json
@@ -5,6 +5,8 @@
     "---Agentic AI---",
     "mcp",
     "agents",
+    "skills",
+    "subagents",
     "agents_api",
     "artifacts",
     "code_interpreter",

--- a/content/docs/features/skills.mdx
+++ b/content/docs/features/skills.mdx
@@ -1,0 +1,146 @@
+---
+title: Skills
+icon: ScrollText
+description: Create reusable SKILL.md instructions that agents can invoke manually, automatically, or on every turn.
+---
+
+Skills are reusable instruction bundles for LibreChat Agents. A skill is centered on a `SKILL.md` file: frontmatter describes when the skill should be used, and the markdown body gives the agent the procedure, rules, examples, or references to follow.
+
+Skills are useful for repeatable work such as:
+
+- Applying brand or writing guidelines
+- Following internal review checklists
+- Running a standard research workflow
+- Priming a specialized tool workflow
+- Packaging reusable scripts, references, and assets with an instruction file
+
+## Enable Skills
+
+The `skills` agent capability is enabled by default. Admins can remove it from the agents endpoint capability list to hide Skills from users.
+
+```yaml filename="librechat.yaml"
+endpoints:
+  agents:
+    capabilities:
+      - 'deferred_tools'
+      - 'execute_code'
+      - 'file_search'
+      - 'web_search'
+      - 'artifacts'
+      - 'subagents'
+      - 'actions'
+      - 'context'
+      - 'skills'
+      - 'tools'
+      - 'chain'
+      - 'ocr'
+```
+
+Role permissions also control who can use, create, share, and publicly share skills.
+
+## Create a Skill
+
+Open **Skills** from the side panel. You can write a skill directly in LibreChat or upload a `.md`, `.zip`, or `.skill` file that contains `SKILL.md`.
+
+Minimum `SKILL.md`:
+
+```md filename="SKILL.md"
+---
+name: brand-guidelines
+description: Use when writing public-facing content that must follow the company voice and terminology.
+---
+
+# Brand Guidelines
+
+Write in a concise, practical tone.
+Prefer active voice.
+Use product terminology consistently.
+```
+
+### Frontmatter
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'String',
+      'Stable kebab-case identifier. It must start with a lowercase letter or digit and can contain lowercase letters, digits, and hyphens.',
+      'name: brand-guidelines',
+    ],
+    [
+      'description',
+      'String',
+      'The most important trigger text. Describe when the model should use the skill.',
+      'description: Use when writing public-facing launch copy.',
+    ],
+    [
+      'always-apply',
+      'Boolean',
+      'Automatically primes the skill into every turn where it is active.',
+      'always-apply: true',
+    ],
+    [
+      'user-invocable',
+      'Boolean',
+      'Set to false to hide the skill from manual `$` invocation. Default: true.',
+      'user-invocable: false',
+    ],
+    [
+      'disable-model-invocation',
+      'Boolean',
+      'Set to true to exclude the skill from the model-invoked skill catalog. Manual invocation is still allowed unless `user-invocable` is false.',
+      'disable-model-invocation: true',
+    ],
+    [
+      'allowed-tools',
+      'Array/List of Strings',
+      'Temporarily unions these tools into the agent effective tool set when the skill is manually or always applied.',
+      'allowed-tools: ["execute_code"]',
+    ],
+  ]}
+/>
+
+## Invocation Modes
+
+Skills can reach an agent in three ways:
+
+- **Manual**: the user types `$` in chat and selects a skill from the popover.
+- **Model-invoked**: the model chooses a skill from the injected skill catalog and calls the skill tool.
+- **Always apply**: the skill is primed into every turn when active.
+
+Manual invocation is explicit user intent. It can use skills that are hidden from model invocation with `disable-model-invocation: true`, as long as `user-invocable` is not false.
+
+## Agent Scope
+
+Agents must have Skills enabled before they can use the catalog.
+
+- If `skills_enabled` is false or unset on a persisted agent, skills are inactive for that agent.
+- If `skills_enabled` is true and no skill allowlist is set, the agent can use the full active catalog visible to the user.
+- If `skills_enabled` is true and `skills` contains specific skill IDs, the agent is narrowed to that list.
+
+This lets admins expose the Skills feature globally while keeping each agent's usable skill set focused.
+
+## Active and Shared Skills
+
+Users can toggle skills active or inactive. Owned skills default to active. Shared skills use the admin-configured default until the user overrides them.
+
+Inactive skills are excluded from:
+
+- The `$` popover
+- The model-invoked skill catalog
+- Always-apply priming
+
+## Bundled Files
+
+Uploaded skill bundles can include files alongside `SKILL.md`, such as:
+
+- `references/...`
+- `scripts/...`
+- `assets/...`
+
+The backend stores those files with the skill. The agent can resolve skill files when the skill is active and in scope.
+
+<Callout type="note" title="Authoring tip">
+  Keep `description` specific. It is the strongest signal for model-invoked skills. A short or vague
+  description will under-trigger.
+</Callout>

--- a/content/docs/features/subagents.mdx
+++ b/content/docs/features/subagents.mdx
@@ -1,0 +1,109 @@
+---
+title: Subagents
+icon: Network
+description: Delegate focused work from one agent to isolated child agent runs.
+---
+
+Subagents let a LibreChat Agent spawn an isolated child run for focused work. The child agent gets its own context window and tool execution flow. The parent receives the child result without absorbing every intermediate tool call, trace, or verbose file operation into its own context.
+
+Use subagents for:
+
+- Research subtasks that may generate long intermediate output
+- Review passes with a specialized agent
+- Tool-heavy work that should stay outside the parent context
+- Parallel-style decomposition where the parent coordinates and summarizes
+
+## How Subagents Differ from Agent Chain
+
+Agent Chain builds a multi-agent graph where agents pass results through configured chain steps. Subagents are spawned by an agent as a tool call during a run.
+
+- **Agent Chain**: graph-level multi-agent workflow
+- **Subagents**: runtime delegation from a parent agent to isolated child runs
+
+Both can use existing agents, but subagents are designed for scoped delegation from inside a single agent's reasoning loop.
+
+## Enable the Capability
+
+The `subagents` capability is enabled by default. Admins can remove it from the agents endpoint capability list to disable the feature.
+
+```yaml filename="librechat.yaml"
+endpoints:
+  agents:
+    capabilities:
+      - 'deferred_tools'
+      - 'execute_code'
+      - 'file_search'
+      - 'web_search'
+      - 'artifacts'
+      - 'subagents'
+      - 'actions'
+      - 'context'
+      - 'skills'
+      - 'tools'
+      - 'chain'
+      - 'ocr'
+```
+
+## Configure an Agent
+
+In the Agent Builder, open **Advanced Settings** and enable **Subagents**.
+
+Available settings:
+
+- **Enable subagents**: adds the subagent spawn tool to the agent.
+- **Allow self-spawn**: lets the agent spawn a fresh copy of itself in an isolated context. This is enabled by default when subagents are enabled.
+- **Additional subagents**: selects specific agents the parent may spawn.
+
+Equivalent agent shape:
+
+```yaml filename="agent subagents"
+subagents:
+  enabled: true
+  allowSelf: true
+  agent_ids:
+    - 'agent_researcher'
+    - 'agent_reviewer'
+```
+
+## Runtime Behavior
+
+When subagents are enabled, the parent agent receives a `subagent` tool. The tool can spawn:
+
+- `self`, when `allowSelf` is not false
+- Any configured child agent in `agent_ids`
+
+Child agents run with isolated context. Parent tool-search state and accumulated context are not copied into the child run. The UI shows the child run as an expandable agent activity part with status, ticker updates, and the final result.
+
+## Limits
+
+LibreChat enforces these limits to keep subagent graphs bounded:
+
+<OptionTable
+  options={[
+    ['MAX_SUBAGENTS', 'Number', 'Maximum explicit subagents per parent agent.', '10'],
+    ['MAX_SUBAGENT_DEPTH', 'Number', 'Maximum explicit subagent hops from a root agent.', '5'],
+    [
+      'MAX_SUBAGENT_GRAPH_NODES',
+      'Number',
+      'Maximum unique explicit subagent targets loaded at runtime.',
+      '50',
+    ],
+    [
+      'MAX_SUBAGENT_RUN_CONFIGS',
+      'Number',
+      'Maximum expanded subagent configurations embedded into one run request.',
+      '100',
+    ],
+  ]}
+/>
+
+## Access Control
+
+Configured child agents must be visible to the user. If the user lacks view access to a referenced agent, LibreChat skips that subagent. For create and update requests, invalid or unauthorized `subagents.agent_ids` entries are rejected.
+
+## Design Tips
+
+- Enable self-spawn when the parent agent is already well-scoped and just needs a fresh context for a subtask.
+- Add specific child agents when the task needs a different model, instruction set, tool set, or skill allowlist.
+- Keep child descriptions clear. The parent uses each child name and description to choose the right delegation target.
+- Use subagents for intermediate work that should return a compact result, not for permanent handoffs to another conversation path.


### PR DESCRIPTION
## Summary

I added documentation for CloudFront-backed S3 storage, Skills, Subagents, and the config/env updates needed for config v1.3.11, then added the v0.8.6-rc1 release changelog in the existing docs format.

- Added a CloudFront with S3 guide covering stable media links, signed cookies, signed downloads, cookie domains, cache invalidation, multi-region paths, IAM, and troubleshooting.
- Added CloudFront object-structure docs and a Config v1.3.11 changelog entry.
- Added Skills and Subagents feature pages, and linked them from Agents and feature navigation.
- Added the v0.8.6-rc1 changelog with highlights, categorized PR notes, new contributors, and compare link.
- Updated CDN, S3, Firebase, dotenv, logging, and LibreChat YAML config pages for CloudFront, capability defaults, `CONSOLE_JSON_STRING_LENGTH`, and current config examples.
- Updated docs navigation metadata.

## Change Type

- [x] Documentation update

## Testing

- Ran `git diff --check`.
- Parsed modified navigation JSON metadata with Node.
- Ran targeted `pnpm exec prettier --check` on the touched docs files.
- Ran `pnpm exec prettier --check content/changelog/v0.8.6-rc1.mdx`.
- Ran `pnpm build`.

### **Test Configuration**:

- Base branch: `origin/main`
- Branch: `danny-avila/docs-v0.8.6-features`
- Docs toolchain: repo-configured pnpm build setup

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
