### PR TITLE
docs: fix Docker image cleanup command

### DIFF
--- a/content/docs/local/docker.mdx
+++ b/content/docs/local/docker.mdx
@@ -132,7 +132,7 @@ docker compose down
 
 ```bash filename="Remove all existing docker images"
 # Linux/Mac
-docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
+docker images -a --filter "reference=*librechat*" --format "{{.ID}}" | xargs docker rmi
 
 # Windows (PowerShell)
 docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }

--- a/content/docs/remote/docker_linux.mdx
+++ b/content/docs/remote/docker_linux.mdx
@@ -336,7 +336,7 @@ docker compose -f ./deploy-compose.yml down
 
 ```bash filename="Remove all existing docker images"
 # Linux/Mac
-docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
+docker images -a --filter "reference=*librechat*" --format "{{.ID}}" | xargs docker rmi
 
 # Windows (PowerShell)
 docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }


### PR DESCRIPTION
## Summary
- replace grep/awk parsing of `docker images -a` output with Docker's `--filter` and `--format "{{.ID}}"` options
- update both local and remote Docker docs that used the same cleanup command

## Testing
- `rg -n "docker images -a \| grep|awk '\{print \$3\}'" content/docs` returns no matches
- `bun run build` passes

Note: build emitted existing remote image-size warnings for GitHub-hosted images, then completed successfully.
