### PR TITLE
docs: add Scheduled Tasks feature documentation

### DIFF
--- a/content/docs/features/meta.json
+++ b/content/docs/features/meta.json
@@ -8,6 +8,7 @@
     "skills",
     "subagents",
     "agents_api",
+    "scheduled_tasks",
     "artifacts",
     "code_interpreter",
     "---Search & Knowledge---",

--- a/content/docs/features/scheduled_tasks.mdx
+++ b/content/docs/features/scheduled_tasks.mdx
@@ -1,0 +1,71 @@
+---
+title: Scheduled Tasks
+icon: CalendarClock
+description: Run any Agent or Assistant on a cron schedule, fixed interval, or one-shot future date — completely decoupled from the active chat session.
+---
+
+Scheduled Tasks turn an Agent or Assistant into a background worker. Define a schedule, hand it a prompt, and the task runs in its own conversation context every time it fires — with the same tools, MCP servers, web search, and code execution your interactive chats have access to.
+
+Useful for repeatable work such as:
+
+- Daily summaries (open PRs, tickets, news) delivered every morning
+- Periodic data checks via an MCP-exposed system
+- One-shot reminders at a specific wall-clock time
+- Fire-and-forget automations that post a notification via an MCP webhook tool
+
+## Prerequisites
+
+Scheduled Tasks are backed by [BullMQ](https://docs.bullmq.io/) and require a running Redis instance. The same Redis you already use for caching and resumable streams works — no extra service to operate.
+
+```bash filename=".env"
+USE_REDIS=true
+REDIS_URI=redis://localhost:6379
+```
+
+If Redis is not configured the backend boots normally but the UI's task definitions will never fire. See [Redis Configuration](/docs/configuration/redis) for hosted / cluster setups.
+
+## Creating a Task
+
+Open the **Scheduled Tasks** tab in the unified left sidebar (calendar-clock icon) and click the **+** button.
+
+### Target and Prompt
+
+- **Target Type** — `Agent` or `Assistant`.
+- **Target ID** — the unique ID of an Agent / Assistant you own.
+- **Prompt** — the message sent to the target every time the task runs. Treated identically to a chat input.
+
+### Trigger
+
+Pick one of three trigger types:
+
+- **Cron** — a standard 5-field expression, e.g. `0 9 * * 1-5` for _9 AM every weekday_. The task builder also ships a **Quick presets…** dropdown beneath the cron input (every minute, every 15 minutes, hourly, weekdays at 09:00, etc.); a friendly description is shown below the field when LibreChat recognizes the pattern. Power users can still type any 5-field expression directly — [crontab.guru](https://crontab.guru/) is a good visual helper.
+- **Interval** — a fixed delay in **milliseconds**, e.g. `3600000` for hourly.
+- **Date** — a one-shot execution at a specific datetime. Date triggers in the past simply produce no queued job.
+
+Cron and Date triggers honor an IANA timezone (e.g. `America/New_York`, `Asia/Kolkata`). New tasks default to your browser's detected zone, and cron schedules respect Daylight Saving Time transitions for the chosen zone. Interval triggers are timezone-agnostic.
+
+### Per-Task Capabilities
+
+The task builder mirrors the in-chat tool picker, scoped per task rather than inherited from the target Agent's default:
+
+- **Tools** — Web Search, File Search, Code Execution toggles.
+- **MCP Servers** — checkbox list of servers configured for your account; only the ones you tick are exposed to this task's run.
+
+This makes it easy to ship narrow, least-privilege background jobs (e.g. _"only the GitHub MCP server, nothing else"_). Per-task switches can only enable capabilities that are also enabled globally in `librechat.yaml` — if an admin has disabled Web Search, the task's Web Search toggle is a no-op.
+
+## Output Handling
+
+Every run starts a **fresh conversation** so background activity never pollutes your interactive chat history.
+
+- Scheduled-run conversations are marked `isScheduled: true` and excluded from the default conversation list.
+- The **History** (clock) icon on each task card opens the **Task Runs** modal listing every persisted run, newest first. Clicking an entry navigates to that conversation where you can read the output, inspect tool invocations, and continue manually if you want.
+- Check **Run as Temporary Chat** in the builder to skip persisting the conversation entirely — useful for fire-and-forget tasks that only need to perform a side effect. Temporary runs do not appear in the Task Runs modal.
+
+## Managing Tasks
+
+Each task card in the panel exposes inline controls for the most common workflows:
+
+- **Pause / Resume** — pause stops a recurring task without losing its configuration or history; resume re-arms the schedule.
+- **Edit** — reopens the builder pre-populated with the task's current settings. Saving atomically replaces the underlying schedule.
+- **History** — opens the Task Runs modal described above.
+- **Delete** — removes the task and its scheduled job. Past run conversations keep `isScheduled: true` and remain filtered out of the main chat sidebar even after deletion; they're still accessible via their direct conversation URL.

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -75,6 +75,7 @@ import {
   Import,
   Share2,
   Clock,
+  CalendarClock,
   Zap,
   // Config & structure
   Variable,
@@ -156,6 +157,7 @@ const icons: Record<string, ReactElement> = {
   Import: <Import />,
   Share2: <Share2 />,
   Clock: <Clock />,
+  CalendarClock: <CalendarClock />,
   Zap: <Zap />,
   Variable: <Variable />,
   Code: <Code />,


### PR DESCRIPTION
> ⚠️ **Draft** — pending the core PR merge.

This PR adds the documentation for the new **Scheduled Tasks** feature introduced in the core repository (see [danny-avila/LibreChat#13159](https://github.com/danny-avila/LibreChat/pull/13159)).

## Changes

- **New Documentation Page:** Created `content/docs/features/scheduled_tasks.mdx` which covers:
  - Prerequisites (Redis requirement).
  - Triggers (Cron, Interval, Date) and Timezone support (IANA identifiers).
  - Per-task capabilities (Tools, MCP servers override).
  - Output handling (Task Runs History modal, Temporary Chat mode).
- **Sidebar Update:** Added `scheduled_tasks` to the Agentic AI section in `content/docs/features/meta.json`.

## Cross-reference

- Core feature PR: [danny-avila/LibreChat#13159](https://github.com/danny-avila/LibreChat/pull/13159)

## Local QA

Done via `pnpm build` and `pnpm start`.

<img width="1727" height="853" alt="image" src="https://github.com/user-attachments/assets/f8ac1f39-2f81-4b5b-8e38-9545d032f471" />


Made with [Cursor](https://cursor.com)