### PR TITLE
Updated Documentation on Docker image removal commands

### DIFF
--- a/content/docs/local/docker.mdx
+++ b/content/docs/local/docker.mdx
@@ -132,10 +132,10 @@ docker compose down
 
 ```bash filename="Remove all existing docker images"
 # Linux/Mac
-docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
+docker images -a --format '{{.ID}}' --filter 'reference=*librechat*' | xargs -r docker rmi -f
 
 # Windows (PowerShell)
-docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }
+docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi -f $_ }
 ```
 
 ```bash filename="Pull latest project changes"


### PR DESCRIPTION
Edited markdown code to improve the unix command to also use Docker's built in filtering
Add -f flag to handle images that have multiple tags

I wrote these lines on the documentation previously, but have since improved them.
https://github.com/LibreChat-AI/librechat.ai/pull/281
https://github.com/danny-avila/LibreChat/discussions/6072