### PR TITLE
docs: add Tuning Engines endpoint example

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/tuning-engines.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/tuning-engines.mdx
@@ -1,0 +1,29 @@
+---
+title: Tuning Engines
+icon: Network
+description: Example configuration for Tuning Engines
+---
+
+> Tuning Engines dashboard: [app.tuningengines.com](https://app.tuningengines.com/)
+
+**Notes:**
+
+- Tuning Engines exposes an OpenAI-compatible inference endpoint for routed model access.
+- Use an inference key from the Tuning Engines dashboard, not an account password or provider key.
+- The model name should match a model alias enabled for the key's tenant or role.
+
+```yaml filename="librechat.yaml"
+- name: 'Tuning Engines'
+  apiKey: '${TUNING_ENGINES_API_KEY}'
+  baseURL: 'https://api.tuningengines.com/v1'
+  models:
+    default: ['gpt-4o-mini']
+    fetch: true
+  titleConvo: true
+  titleModel: 'gpt-4o-mini'
+  summarize: false
+  summaryModel: 'gpt-4o-mini'
+  modelDisplayLabel: 'Tuning Engines'
+```
+
+For deployments that restrict model access by tenant, role, or key, set `default` to the specific model alias your Tuning Engines admin assigned.


### PR DESCRIPTION
Adds a Tuning Engines custom AI endpoint example for LibreChat's librechat.yaml configuration. The example uses the OpenAI-compatible base URL, tenant-scoped inference key, and model aliases enabled in Tuning Engines.