### PR TITLE
Update dotenv.mdx

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -685,7 +685,7 @@ Follow these instructions to setup the [Google Endpoint](/docs/configuration/pre
       'GOOGLE_MODELS',
       'string',
       'Available Google models for Gemini Enterprise Agent Platform (Gemini API / Vertex AI), separated by commas.',
-      'GOOGLE_MODELS=gemini-3.5-flash,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001',  
+      'GOOGLE_MODELS=gemini-3.5-flash,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001',
     ],
     [
       'GOOGLE_TITLE_MODEL',

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -684,14 +684,8 @@ Follow these instructions to setup the [Google Endpoint](/docs/configuration/pre
     [
       'GOOGLE_MODELS',
       'string',
-      'Available Gemini API Google models, separated by commas.',
-      'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite',
-    ],
-    [
-      'GOOGLE_MODELS',
-      'string',
-      'Available Vertex AI Google models, separated by commas.',
-      'GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001',
+      'Available Google models for Gemini Enterprise Agent Platform (Gemini API / Vertex AI), separated by commas.',
+      'GOOGLE_MODELS=gemini-3.5-flash,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001',  
     ],
     [
       'GOOGLE_TITLE_MODEL',


### PR DESCRIPTION
Update default Vertex AI Google model list.

- Add `gemini-3.5-flash`
- Add `gemini-3.1-flash-lite`
- Keep `gemini-3.1-pro-preview-customtools` for agentic/custom-tools workflows
- Keep existing Gemini 2.5 and 2.0 model IDs for backward compatibility