### PR TITLE
docs(balance): document auto-refill behavior and account-menu indicator

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/balance.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/balance.mdx
@@ -175,4 +175,8 @@ A fresh user has no `lastRefill` value (it is set only by a real refill event). 
 
 ### Indicator in the account menu
 
-After a refill occurs, the user's account-settings popover shows a green `(+refillAmount)` badge under the current balance for 24 hours, with a tooltip showing the exact refill timestamp. Outside that window, the popover shows a muted `Next refill in X days` subtext whenever a future refill is scheduled, so users always know when their next refill arrives.
+The account-settings popover surfaces refill state under the current balance so users always know how much spending headroom they have:
+
+- **Green `(+refillAmount)` badge** when a refill is available — i.e. the interval has elapsed since the last refill (or the user has never been refilled) and the user still has a positive balance. Their effective headroom is `tokenCredits + refillAmount`, since the refill will be applied automatically as soon as their balance reaches zero.
+- **Muted `Next refill in X days` subtext** when the balance has reached zero and the user is not yet eligible for a refill — i.e. when they're actually waiting.
+- **Just the current balance** when the user has a positive balance and no refill is available yet.

--- a/content/docs/configuration/librechat_yaml/object_structure/balance.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/balance.mdx
@@ -155,3 +155,24 @@ balance:
 balance:
   refillAmount: 10000
 ```
+
+
+## Auto-refill behavior
+
+When `autoRefillEnabled` is `true`, LibreChat tops up a user's balance by `refillAmount` once **both** of these conditions are met:
+
+1. The user's `tokenCredits` would drop to zero or below.
+2. The configured interval (`refillIntervalValue` + `refillIntervalUnit`) has elapsed since the user's last refill.
+
+The refill is applied automatically when the user either:
+
+- Sends a message (the existing path — refill happens during balance check).
+- Opens the app (the balance endpoint also runs the same eligibility check and applies the refill before returning).
+
+This means a user who returns after a long absence with a depleted balance does **not** need to send a message before being topped up — simply loading LibreChat is enough.
+
+A fresh user has no `lastRefill` value (it is set only by a real refill event). Their `startBalance` carries them until depletion; once their balance reaches zero, the first eligible read or send applies the refill.
+
+### Indicator in the account menu
+
+After a refill occurs, the user's account-settings popover shows a green `(+refillAmount)` badge under the current balance for 24 hours, with a tooltip showing the exact refill timestamp. Outside that window, the popover shows a muted `Next refill in X days` subtext whenever a future refill is scheduled, so users always know when their next refill arrives.


### PR DESCRIPTION
## Summary

Add an "Auto-refill behavior" section to the Balance object docs (`librechat_yaml/object_structure/balance.mdx`). Today, the page documents each individual config field but doesn't explain *when* a refill actually happens, which has been a source of user confusion.

The new section covers:

- The two conditions a refill requires (`tokenCredits ≤ 0` **and** the configured interval elapsed since the last refill).
- The two triggers that apply the refill (sending a message **and** opening the app — the balance endpoint also runs the same eligibility check).
- The semantics of a fresh user (no `lastRefill` set until a real refill happens; `startBalance` carries them until depletion).
- The new account-settings popover indicator: green `(+refillAmount)` badge for 24 h after a refill (with a timestamp tooltip), or a muted "Next refill in X days" subtext otherwise.

## Related

Tracks the LibreChat feature PR that introduces eager refill on balance read and the popover indicator: danny-avila/LibreChat#13233.

This docs PR is opened as a **draft** so it can be linked from the feature PR. It should be merged after the feature PR is merged and reaches a release, so the docs don't describe behavior that isn't yet shipped.