### PR TITLE
🪪 docs: Document Bedrock AWS Profile Credentials

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -623,6 +623,18 @@ See: [AWS Bedrock Setup](/docs/configuration/pre_configured_ai/bedrock)
       '# BEDROCK_AWS_SESSION_TOKEN=your_session_token',
     ],
     [
+      'BEDROCK_AWS_PROFILE',
+      'string',
+      'AWS shared config profile name for Bedrock. Optional if using the default AWS credentials chain.',
+      '# BEDROCK_AWS_PROFILE=your-profile-name',
+    ],
+    [
+      'BEDROCK_AWS_BEARER_TOKEN',
+      'string',
+      'Amazon Bedrock API key for bearer auth, or user_provided to let users enter their own Bedrock API key in the UI.',
+      '# BEDROCK_AWS_BEARER_TOKEN=your_bedrock_api_key',
+    ],
+    [
       'BEDROCK_AWS_MODELS',
       'string',
       'Comma-separated list of Bedrock model IDs. If omitted, all known supported models are included.',

--- a/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
@@ -1,5 +1,5 @@
 ---
-title: "AWS Bedrock Object Structure"
+title: 'AWS Bedrock Object Structure'
 icon: Braces
 ---
 
@@ -10,16 +10,16 @@ Integrating AWS Bedrock with your application allows you to seamlessly utilize m
 ```yaml filename="Example AWS Bedrock Object Structure"
 endpoints:
   bedrock:
-    titleModel: "anthropic.claude-3-haiku-20240307-v1:0"
+    titleModel: 'anthropic.claude-3-haiku-20240307-v1:0'
     streamRate: 35
     availableRegions:
-      - "us-east-1"
-      - "us-west-2"
+      - 'us-east-1'
+      - 'us-west-2'
     guardrailConfig:
-      guardrailIdentifier: "your-guardrail-id"
-      guardrailVersion: "1"
-      trace: "enabled"
-      streamProcessingMode: "sync"
+      guardrailIdentifier: 'your-guardrail-id'
+      guardrailVersion: '1'
+      trace: 'enabled'
+      streamProcessingMode: 'sync'
 ```
 
 > **Note:** AWS Bedrock endpoint supports all [Shared Endpoint Settings](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings), including `streamRate`, `titleModel`, `titleMethod`, `titlePrompt`, `titlePromptTemplate`, and `titleEndpoint`. The settings shown below are specific to Bedrock or have Bedrock-specific defaults.
@@ -27,31 +27,45 @@ endpoints:
 ## titleModel
 
 **Key:**
+
 <OptionTable
   options={[
-    ['titleModel', 'String', 'Specifies the model to use for generating conversation titles.', 'Recommended: anthropic.claude-3-haiku-20240307-v1:0. Set to "current_model" to use the same model as the chat.'],
+    [
+      'titleModel',
+      'String',
+      'Specifies the model to use for generating conversation titles.',
+      'Recommended: anthropic.claude-3-haiku-20240307-v1:0. Set to "current_model" to use the same model as the chat.',
+    ],
   ]}
 />
 
 **Default:** Not specified
 
 **Example:**
+
 ```yaml filename="titleModel"
-titleModel: "anthropic.claude-3-haiku-20240307-v1:0"
+titleModel: 'anthropic.claude-3-haiku-20240307-v1:0'
 ```
 
 ## streamRate
 
 **Key:**
+
 <OptionTable
   options={[
-    ['streamRate', 'Number', 'Sets the rate of processing each new token in milliseconds.', 'This can help stabilize processing of concurrent requests and provide smoother frontend stream rendering.'],
+    [
+      'streamRate',
+      'Number',
+      'Sets the rate of processing each new token in milliseconds.',
+      'This can help stabilize processing of concurrent requests and provide smoother frontend stream rendering.',
+    ],
   ]}
 />
 
 **Default:** Not specified
 
 **Example:**
+
 ```yaml filename="streamRate"
 streamRate: 35
 ```
@@ -59,63 +73,85 @@ streamRate: 35
 ## availableRegions
 
 **Key:**
+
 <OptionTable
   options={[
-    ['availableRegions', 'Array', 'Specifies the AWS regions you want to make available for Bedrock.', 'If provided, users will see a dropdown to select the region. If not selected, the default region is used.'],
+    [
+      'availableRegions',
+      'Array',
+      'Specifies the AWS regions you want to make available for Bedrock.',
+      'If provided, users will see a dropdown to select the region. If not selected, the default region is used.',
+    ],
   ]}
 />
 
 **Default:** Not specified
 
 **Example:**
+
 ```yaml filename="availableRegions"
 availableRegions:
-  - "us-east-1"
-  - "us-west-2"
+  - 'us-east-1'
+  - 'us-west-2'
 ```
 
 ## models
 
 **Key:**
+
 <OptionTable
   options={[
-    ['models', 'Array of Strings', 'Specifies custom model IDs available for the Bedrock endpoint.', 'When provided, these models appear in the model selector for Bedrock.'],
+    [
+      'models',
+      'Array of Strings',
+      'Specifies custom model IDs available for the Bedrock endpoint.',
+      'When provided, these models appear in the model selector for Bedrock.',
+    ],
   ]}
 />
 
 **Default:** Not specified (uses default Bedrock model list)
 
 **Example:**
+
 ```yaml filename="models"
 endpoints:
   bedrock:
     models:
-      - "anthropic.claude-sonnet-4-20250514-v1:0"
-      - "anthropic.claude-haiku-4-20250514-v1:0"
-      - "us.anthropic.claude-sonnet-4-20250514-v1:0"
+      - 'anthropic.claude-sonnet-4-20250514-v1:0'
+      - 'anthropic.claude-haiku-4-20250514-v1:0'
+      - 'us.anthropic.claude-sonnet-4-20250514-v1:0'
 ```
 
 ## inferenceProfiles
 
 **Key:**
+
 <OptionTable
   options={[
-    ['inferenceProfiles', 'Object (Record)', 'Maps model IDs to inference profile ARNs for cross-region inference. Keys are model IDs and values are the inference profile ARN or an environment variable reference.', 'When a selected model matches a key, the corresponding ARN is used as the application inference profile.'],
+    [
+      'inferenceProfiles',
+      'Object (Record)',
+      'Maps model IDs to inference profile ARNs for cross-region inference. Keys are model IDs and values are the inference profile ARN or an environment variable reference.',
+      'When a selected model matches a key, the corresponding ARN is used as the application inference profile.',
+    ],
   ]}
 />
 
 **Default:** Not specified
 
 **Example:**
+
 ```yaml filename="inferenceProfiles"
 endpoints:
   bedrock:
     inferenceProfiles:
-      "us.anthropic.claude-sonnet-4-20250514-v1:0": "${BEDROCK_INFERENCE_PROFILE_CLAUDE_SONNET}"
-      "anthropic.claude-3-7-sonnet-20250219-v1:0": "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc123"
+      'us.anthropic.claude-sonnet-4-20250514-v1:0': '${BEDROCK_INFERENCE_PROFILE_CLAUDE_SONNET}'
+      'anthropic.claude-3-7-sonnet-20250219-v1:0': 'arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc123'
 ```
 
 **Notes:**
+
 - Inference profiles enable cross-region inference, allowing you to route requests to models in different AWS regions
 - Values support environment variable interpolation with `${ENV_VAR}` syntax
 - The model ID in the key must match the model selected by the user in the UI
@@ -123,48 +159,78 @@ endpoints:
 - For a complete guide on creating and managing inference profiles, see [AWS Bedrock Inference Profiles](/docs/configuration/pre_configured_ai/bedrock_inference_profiles)
 
 **Combined Example:**
+
 ```yaml filename="Bedrock with inference profiles"
 endpoints:
   bedrock:
     models:
-      - "us.anthropic.claude-sonnet-4-20250514-v1:0"
-      - "us.anthropic.claude-haiku-4-20250514-v1:0"
+      - 'us.anthropic.claude-sonnet-4-20250514-v1:0'
+      - 'us.anthropic.claude-haiku-4-20250514-v1:0'
     inferenceProfiles:
-      "us.anthropic.claude-sonnet-4-20250514-v1:0": "${BEDROCK_CLAUDE_SONNET_PROFILE}"
-      "us.anthropic.claude-haiku-4-20250514-v1:0": "${BEDROCK_CLAUDE_HAIKU_PROFILE}"
+      'us.anthropic.claude-sonnet-4-20250514-v1:0': '${BEDROCK_CLAUDE_SONNET_PROFILE}'
+      'us.anthropic.claude-haiku-4-20250514-v1:0': '${BEDROCK_CLAUDE_HAIKU_PROFILE}'
 ```
 
 ## guardrailConfig
 
 **Key:**
+
 <OptionTable
   options={[
-    ['guardrailConfig', 'Object', 'Configuration for AWS Bedrock Guardrails to filter and moderate model inputs and outputs.', 'Optional. When configured, all Bedrock requests will be validated against the specified guardrail.'],
+    [
+      'guardrailConfig',
+      'Object',
+      'Configuration for AWS Bedrock Guardrails to filter and moderate model inputs and outputs.',
+      'Optional. When configured, all Bedrock requests will be validated against the specified guardrail.',
+    ],
   ]}
 />
 
 **Sub-keys:**
+
 <OptionTable
   options={[
-    ['guardrailIdentifier', 'String', 'The unique identifier of the guardrail to apply.', 'Required when using guardrails.'],
-    ['guardrailVersion', 'String', 'The version of the guardrail to use.', 'Required when using guardrails.'],
-    ['trace', 'String', 'Controls guardrail trace output for debugging. Options: "enabled", "enabled_full", or "disabled".', 'Optional. Default: "disabled"'],
-    ['streamProcessingMode', 'String', 'Controls guardrail stream processing mode. Options: "sync" or "async".', 'Optional. Default: "sync"'],
+    [
+      'guardrailIdentifier',
+      'String',
+      'The unique identifier of the guardrail to apply.',
+      'Required when using guardrails.',
+    ],
+    [
+      'guardrailVersion',
+      'String',
+      'The version of the guardrail to use.',
+      'Required when using guardrails.',
+    ],
+    [
+      'trace',
+      'String',
+      'Controls guardrail trace output for debugging. Options: "enabled", "enabled_full", or "disabled".',
+      'Optional. Default: "disabled"',
+    ],
+    [
+      'streamProcessingMode',
+      'String',
+      'Controls guardrail stream processing mode. Options: "sync" or "async".',
+      'Optional. Default: "sync"',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml filename="guardrailConfig"
 endpoints:
   bedrock:
     guardrailConfig:
-      guardrailIdentifier: "abc123xyz"
-      guardrailVersion: "1"
-      trace: "enabled"
-      streamProcessingMode: "sync"
+      guardrailIdentifier: 'abc123xyz'
+      guardrailVersion: '1'
+      trace: 'enabled'
+      streamProcessingMode: 'sync'
 ```
 
 **Notes:**
+
 - Guardrails help ensure responsible AI usage by filtering harmful content, PII, and other sensitive information
 - The `guardrailIdentifier` can be found in the AWS Bedrock console under Guardrails
 - Set `trace` to `"enabled"` or `"enabled_full"` during development to see which guardrail policies are triggered
@@ -173,4 +239,4 @@ endpoints:
 
 ## Notes
 
-- The main configuration for AWS Bedrock is done through environment variables, additional forms of authentication are in development.
+- AWS Bedrock authentication is configured through environment variables. You can use `BEDROCK_AWS_PROFILE`, the AWS SDK default credential provider chain, or Bedrock-specific static credentials. See the [AWS Bedrock setup guide](/docs/configuration/pre_configured_ai/bedrock#authentication) for details.

--- a/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
@@ -239,4 +239,4 @@ endpoints:
 
 ## Notes
 
-- AWS Bedrock authentication is configured through environment variables. You can use `BEDROCK_AWS_PROFILE`, the AWS SDK default credential provider chain, or Bedrock-specific static credentials. See the [AWS Bedrock setup guide](/docs/configuration/pre_configured_ai/bedrock#authentication) for details.
+- AWS Bedrock authentication is configured through environment variables. You can use `BEDROCK_AWS_PROFILE`, the AWS SDK default credential provider chain, `BEDROCK_AWS_BEARER_TOKEN` for Bedrock API keys, or Bedrock-specific static credentials. See the [AWS Bedrock setup guide](/docs/configuration/pre_configured_ai/bedrock#authentication) for details.

--- a/content/docs/configuration/pre_configured_ai/bedrock.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock.mdx
@@ -42,6 +42,26 @@ This is the preferred approach for deployments that use IAM roles or another AWS
 
 For example, if AWS-standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set, those credentials can take precedence over profile-based credentials in `~/.aws/credentials` or `~/.aws/config`.
 
+### Bedrock API key
+
+Amazon Bedrock API keys authenticate Bedrock calls with bearer auth instead of SigV4-signed AWS credentials. In LibreChat, configure them with the Bedrock-scoped environment variable:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+BEDROCK_AWS_BEARER_TOKEN=your_bedrock_api_key
+```
+
+`BEDROCK_AWS_BEARER_TOKEN` is LibreChat-specific. AWS documentation and raw AWS SDK/CLI examples use the AWS-standard `AWS_BEARER_TOKEN_BEDROCK` environment variable, but LibreChat intentionally uses a Bedrock-scoped name so the token only affects the Bedrock endpoint configuration. LibreChat passes this value to the AWS SDK as bearer auth.
+
+To let users provide their own Bedrock API key from the LibreChat UI, set:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+BEDROCK_AWS_BEARER_TOKEN=user_provided
+```
+
+Short-term Bedrock API keys inherit the permissions of the AWS principal used to generate them, are valid only in the AWS region where they were generated, and expire no later than 12 hours or the source session expiry. Long-term Bedrock API keys are recommended only for exploration and development. See the AWS docs for [using Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html) and [generating Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html).
+
 ### Static Bedrock credentials
 
 Use static Bedrock-specific environment variables only when profiles or IAM roles are not suitable:
@@ -54,6 +74,8 @@ BEDROCK_AWS_SECRET_ACCESS_KEY=your_secret_access_key
 ```
 
 If `BEDROCK_AWS_ACCESS_KEY_ID` and `BEDROCK_AWS_SECRET_ACCESS_KEY` are set, LibreChat passes them directly to the Bedrock client. They must be provided together, and they take precedence over `BEDROCK_AWS_PROFILE` and the SDK default provider chain for Bedrock.
+
+If `BEDROCK_AWS_BEARER_TOKEN` is set, LibreChat uses bearer auth for Bedrock instead of static credentials, `BEDROCK_AWS_PROFILE`, or the SDK default provider chain.
 
 For AWS credential behavior details, see the [AWS SDK for JavaScript credential provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html), the [AWS SDKs and Tools settings reference](https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html), and the [AWS `credential_process` security notes](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).
 

--- a/content/docs/configuration/pre_configured_ai/bedrock.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock.mdx
@@ -1,5 +1,5 @@
 ---
-title: "AWS Bedrock"
+title: 'AWS Bedrock'
 icon: Bot
 ---
 
@@ -9,31 +9,53 @@ You’ll also need to turn on model access for your account, which you can do by
 
 ## Authentication
 
-- You will need to set the following environment variables:
+Always set the Bedrock region LibreChat should use:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+```
+
+LibreChat supports the following authentication methods for Bedrock.
+
+### AWS profile
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+BEDROCK_AWS_PROFILE=your-profile-name
+```
+
+Use this when you already have credentials in `~/.aws/config` or `~/.aws/credentials`, or when your profile uses AWS IAM Identity Center, role assumption, or `credential_process`.
+
+`BEDROCK_AWS_PROFILE` is a LibreChat-specific setting that passes the selected profile to the AWS SDK credential provider chain for Bedrock. This scopes profile selection to Bedrock without changing credentials used by other integrations. The AWS-standard `AWS_PROFILE` environment variable is still supported by the AWS SDK default provider chain.
+
+If your profile uses `credential_process`, secure the AWS config file and helper command. AWS warns that secret material written to `stderr` can be captured or logged by SDKs and tools.
+
+### Default AWS credential provider chain
+
+You can omit Bedrock-specific credentials and profile settings to let the AWS SDK for JavaScript resolve credentials automatically:
+
+```bash filename=".env"
+BEDROCK_AWS_DEFAULT_REGION=us-east-1
+```
+
+This is the preferred approach for deployments that use IAM roles or another AWS-native short-term credential source. The SDK checks supported credential providers in precedence order and stops at the first valid credentials it finds. Common sources include environment variables, IAM Identity Center/SSO, shared config and credentials files, web identity, ECS container credentials, EC2 instance metadata, and process credentials.
+
+For example, if AWS-standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set, those credentials can take precedence over profile-based credentials in `~/.aws/credentials` or `~/.aws/config`.
+
+### Static Bedrock credentials
+
+Use static Bedrock-specific environment variables only when profiles or IAM roles are not suitable:
 
 ```bash filename=".env"
 BEDROCK_AWS_DEFAULT_REGION=us-east-1
 BEDROCK_AWS_ACCESS_KEY_ID=your_access_key_id
 BEDROCK_AWS_SECRET_ACCESS_KEY=your_secret_access_key
+# BEDROCK_AWS_SESSION_TOKEN=your_session_token
 ```
 
-**Note:** You can also omit the access keys in order to use the default AWS credentials chain but you must set the default region:
+If `BEDROCK_AWS_ACCESS_KEY_ID` and `BEDROCK_AWS_SECRET_ACCESS_KEY` are set, LibreChat passes them directly to the Bedrock client. They must be provided together, and they take precedence over `BEDROCK_AWS_PROFILE` and the SDK default provider chain for Bedrock.
 
-```bash filename=".env"
-BEDROCK_AWS_DEFAULT_REGION=us-east-1
-```
-
-Doing so prompts the credential provider to find credentials from the following sources (listed in order of precedence):
-
-- Environment variables exposed via process.env
-- SSO credentials from token cache
-- Web identity token credentials
-- Shared credentials and config ini files
-- The EC2/ECS Instance Metadata Service
-
-The default credential provider will invoke one provider at a time and only continue to the next if no credentials have been located.
-
-For example, if the process finds values defined via the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables, the files at ~/.aws/credentials and ~/.aws/config will not be read, nor will any messages be sent to the Instance Metadata Service.
+For AWS credential behavior details, see the [AWS SDK for JavaScript credential provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html), the [AWS SDKs and Tools settings reference](https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html), and the [AWS `credential_process` security notes](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).
 
 ## Configuring models
 
@@ -46,7 +68,7 @@ BEDROCK_AWS_MODELS=anthropic.claude-3-5-sonnet-20240620-v1:0,meta.llama3-1-8b-in
 Note: If omitted, all known, supported model IDs will be included automatically.
 
 - See all Bedrock model IDs here:
-    - **[https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns)**
+  - **[https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns)**
 
 ## Additional Configuration
 
@@ -56,34 +78,34 @@ You can further configure the Bedrock endpoint in your [`librechat.yaml`](/docs/
 endpoints:
   bedrock:
     availableRegions:
-      - "us-east-1"
-      - "us-west-2"
+      - 'us-east-1'
+      - 'us-west-2'
     streamRate: 35
     titleModel: 'anthropic.claude-3-haiku-20240307-v1:0'
     guardrailConfig:
-      guardrailIdentifier: "abc123xyz"
-      guardrailVersion: "1"
-      trace: "enabled"
-      streamProcessingMode: "sync"
+      guardrailIdentifier: 'abc123xyz'
+      guardrailVersion: '1'
+      trace: 'enabled'
+      streamProcessingMode: 'sync'
 ```
 
 - `streamRate`: (Optional) Set the rate of processing each new token in milliseconds.
-    - This can help stabilize processing of concurrent requests and provide smoother frontend stream rendering.
+  - This can help stabilize processing of concurrent requests and provide smoother frontend stream rendering.
 
 - `titleModel`: (Optional) Specify the model to use for generating conversation titles.
-    - Recommended: `anthropic.claude-3-haiku-20240307-v1:0`.
-    - Omit or set as `current_model` to use the same model as the chat.
+  - Recommended: `anthropic.claude-3-haiku-20240307-v1:0`.
+  - Omit or set as `current_model` to use the same model as the chat.
 
 - `availableRegions`: (Optional) Specify the AWS regions you want to make available.
-    - If provided, users will see a dropdown to select the region. If not selected, the default region is used.
-    - ![image](https://github.com/user-attachments/assets/6f3c5e82-9c6b-4643-8487-07db1061ba49)
+  - If provided, users will see a dropdown to select the region. If not selected, the default region is used.
+  - ![image](https://github.com/user-attachments/assets/6f3c5e82-9c6b-4643-8487-07db1061ba49)
 
 - `guardrailConfig`: (Optional) Configure AWS Bedrock Guardrails for content filtering.
-    - `guardrailIdentifier`: The guardrail ID or ARN from your AWS Bedrock Console.
-    - `guardrailVersion`: The guardrail version number (e.g., `"1"`) or `"DRAFT"`.
-    - `trace`: (Optional) Enable trace logging: `"enabled"`, `"disabled"`, or `"enabled_full"`.
-    - `streamProcessingMode`: (Optional) Set stream processing mode: `"sync"` or `"async"` (defaults to `"sync"`).
-    - See [AWS Bedrock Guardrails documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-how.html) for creating and managing guardrails.
+  - `guardrailIdentifier`: The guardrail ID or ARN from your AWS Bedrock Console.
+  - `guardrailVersion`: The guardrail version number (e.g., `"1"`) or `"DRAFT"`.
+  - `trace`: (Optional) Enable trace logging: `"enabled"`, `"disabled"`, or `"enabled_full"`.
+  - `streamProcessingMode`: (Optional) Set stream processing mode: `"sync"` or `"async"` (defaults to `"sync"`).
+  - See [AWS Bedrock Guardrails documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-how.html) for creating and managing guardrails.
 
 ## Inference Profiles
 
@@ -93,7 +115,7 @@ AWS Bedrock inference profiles let you create custom routing configurations for 
 endpoints:
   bedrock:
     inferenceProfiles:
-      "us.anthropic.claude-3-7-sonnet-20250219-v1:0": "${BEDROCK_CLAUDE_37_PROFILE}"
+      'us.anthropic.claude-3-7-sonnet-20250219-v1:0': '${BEDROCK_CLAUDE_37_PROFILE}'
 ```
 
 For the full guide on creating profiles, configuring LibreChat, setting up logging, and troubleshooting, see **[Bedrock Inference Profiles](/docs/configuration/pre_configured_ai/bedrock_inference_profiles)**.
@@ -107,6 +129,7 @@ Bedrock supports uploading documents directly to the provider via the `Upload to
 **Supported formats:** PDF, CSV, DOC, DOCX, XLS, XLSX, HTML, TXT, and Markdown (.md)
 
 **Limitations:**
+
 - Maximum file size per document: **4.5 MB**
 - File names are automatically sanitized to conform to Bedrock's naming requirements (alphanumeric, spaces, hyphens, parentheses, square brackets; max 200 characters)
 

--- a/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
@@ -190,6 +190,9 @@ BEDROCK_AWS_PROFILE=your-profile-name
 # BEDROCK_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 # BEDROCK_AWS_SESSION_TOKEN=your-session-token
 
+# Option 4: Bedrock API key (bearer auth)
+# BEDROCK_AWS_BEARER_TOKEN=your-bedrock-api-key
+
 # Inference Profile ARNs
 BEDROCK_CLAUDE_37_PROFILE=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123
 BEDROCK_OPUS_45_PROFILE=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/def456
@@ -425,6 +428,8 @@ endpoints:
 # AWS Bedrock
 BEDROCK_AWS_DEFAULT_REGION=us-east-1
 BEDROCK_AWS_PROFILE=your-profile-name
+# Or use a Bedrock API key instead:
+# BEDROCK_AWS_BEARER_TOKEN=your-bedrock-api-key
 
 # Inference Profiles
 BEDROCK_CLAUDE_37_PROFILE=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123

--- a/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
@@ -15,19 +15,20 @@ arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123def45
 ```
 
 LibreChat's inference profile mapping feature allows you to:
+
 1. Map friendly model IDs to custom inference profile ARNs
 2. Route requests through your custom profiles while maintaining model capability detection
 3. Use environment variables for secure ARN management
 
 ## Why Use Custom Inference Profiles?
 
-| Benefit | Description |
-|---------|-------------|
+| Benefit                         | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
 | **Cross-Region Load Balancing** | Automatically distribute requests across multiple AWS regions |
-| **Cost Allocation** | Tag and track costs per application or team |
-| **Throughput Management** | Configure dedicated throughput for your applications |
-| **Compliance** | Route requests through specific regions for data residency |
-| **Monitoring** | Track usage per inference profile in CloudWatch |
+| **Cost Allocation**             | Tag and track costs per application or team                   |
+| **Throughput Management**       | Configure dedicated throughput for your applications          |
+| **Compliance**                  | Route requests through specific regions for data residency    |
+| **Monitoring**                  | Track usage per inference profile in CloudWatch               |
 
 ## Prerequisites
 
@@ -150,38 +151,43 @@ endpoints:
   bedrock:
     # List the models you want available in the UI
     models:
-      - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-      - "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
-      - "global.anthropic.claude-opus-4-5-20251101-v1:0"
+      - 'us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+      - 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+      - 'global.anthropic.claude-opus-4-5-20251101-v1:0'
     # Map model IDs to their custom inference profile ARNs
     inferenceProfiles:
       # Using environment variable (recommended for security)
-      "us.anthropic.claude-3-7-sonnet-20250219-v1:0": "${BEDROCK_CLAUDE_37_PROFILE}"
+      'us.anthropic.claude-3-7-sonnet-20250219-v1:0': '${BEDROCK_CLAUDE_37_PROFILE}'
       # Using direct ARN
-      "us.anthropic.claude-sonnet-4-5-20250929-v1:0": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0': 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123'
       # Another env variable example
-      "global.anthropic.claude-opus-4-5-20251101-v1:0": "${BEDROCK_OPUS_45_PROFILE}"
+      'global.anthropic.claude-opus-4-5-20251101-v1:0': '${BEDROCK_OPUS_45_PROFILE}'
     # Optional: Configure available regions for cross-region inference
     availableRegions:
-      - "us-east-1"
-      - "us-west-2"
+      - 'us-east-1'
+      - 'us-west-2'
 ```
 
 ### Environment Variables
 
-Add your AWS credentials and inference profile ARNs to your `.env` file:
+Add your Bedrock region, AWS authentication settings, and inference profile ARNs to your `.env` file:
 
 ```bash filename=".env"
 #===================================#
 # AWS Bedrock Configuration         #
 #===================================#
 
-# AWS Credentials
-BEDROCK_AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
-BEDROCK_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 BEDROCK_AWS_DEFAULT_REGION=us-east-1
 
-# Optional: Session token for temporary credentials
+# Option 1: Use an AWS profile
+BEDROCK_AWS_PROFILE=your-profile-name
+
+# Option 2: Omit BEDROCK_AWS_PROFILE and Bedrock-specific static credentials
+# to use the AWS SDK default credential provider chain.
+
+# Option 3: Static Bedrock credentials, if profiles or IAM roles are not suitable
+# BEDROCK_AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# BEDROCK_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 # BEDROCK_AWS_SESSION_TOKEN=your-session-token
 
 # Inference Profile ARNs
@@ -334,10 +340,12 @@ In the log output, look for the `modelId` field:
 ```
 
 **Success indicators:**
+
 - `modelId` shows your custom inference profile ARN (contains `application-inference-profile`)
 - `inferenceRegion` may vary (shows cross-region routing is working)
 
 **If mapping isn't working:**
+
 - `modelId` will show the raw model ID instead of the ARN
 
 ### View Logs via AWS Console
@@ -368,13 +376,13 @@ aws cloudwatch list-metrics --namespace AWS/Bedrock --region us-east-1
 
 ### Common Issues
 
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| Model not recognized | Missing model in `models` array | Add the model ID to `models` in librechat.yaml |
-| ARN not being used | Model ID doesn't match | Ensure the model ID in `inferenceProfiles` exactly matches what's in `models` |
-| Env variable not resolved | Typo or not set | Check `.env` file and ensure variable name matches `${VAR_NAME}` |
-| Access Denied | Missing IAM permissions | Add `bedrock:InvokeModel*` permissions for the inference profile ARN |
-| Profile not found | Wrong region | Ensure you're creating/using profiles in the same region |
+| Issue                     | Cause                           | Solution                                                                      |
+| ------------------------- | ------------------------------- | ----------------------------------------------------------------------------- |
+| Model not recognized      | Missing model in `models` array | Add the model ID to `models` in librechat.yaml                                |
+| ARN not being used        | Model ID doesn't match          | Ensure the model ID in `inferenceProfiles` exactly matches what's in `models` |
+| Env variable not resolved | Typo or not set                 | Check `.env` file and ensure variable name matches `${VAR_NAME}`              |
+| Access Denied             | Missing IAM permissions         | Add `bedrock:InvokeModel*` permissions for the inference profile ARN          |
+| Profile not found         | Wrong region                    | Ensure you're creating/using profiles in the same region                      |
 
 ### Debug Checklist
 
@@ -398,26 +406,25 @@ version: 1.3.5
 endpoints:
   bedrock:
     models:
-      - "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-      - "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
-      - "global.anthropic.claude-opus-4-5-20251101-v1:0"
-      - "us.amazon.nova-pro-v1:0"
+      - 'us.anthropic.claude-3-7-sonnet-20250219-v1:0'
+      - 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+      - 'global.anthropic.claude-opus-4-5-20251101-v1:0'
+      - 'us.amazon.nova-pro-v1:0'
     inferenceProfiles:
-      "us.anthropic.claude-3-7-sonnet-20250219-v1:0": "${BEDROCK_CLAUDE_37_PROFILE}"
-      "us.anthropic.claude-sonnet-4-5-20250929-v1:0": "${BEDROCK_SONNET_45_PROFILE}"
-      "global.anthropic.claude-opus-4-5-20251101-v1:0": "${BEDROCK_OPUS_45_PROFILE}"
+      'us.anthropic.claude-3-7-sonnet-20250219-v1:0': '${BEDROCK_CLAUDE_37_PROFILE}'
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0': '${BEDROCK_SONNET_45_PROFILE}'
+      'global.anthropic.claude-opus-4-5-20251101-v1:0': '${BEDROCK_OPUS_45_PROFILE}'
     availableRegions:
-      - "us-east-1"
-      - "us-west-2"
+      - 'us-east-1'
+      - 'us-west-2'
 ```
 
 ### .env
 
 ```bash filename=".env"
 # AWS Bedrock
-BEDROCK_AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
-BEDROCK_AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 BEDROCK_AWS_DEFAULT_REGION=us-east-1
+BEDROCK_AWS_PROFILE=your-profile-name
 
 # Inference Profiles
 BEDROCK_CLAUDE_37_PROFILE=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123


### PR DESCRIPTION
## Summary

I updated the Bedrock documentation to match the credential handling in danny-avila/LibreChat#10504 and the Bedrock API key work in danny-avila/LibreChat#8690.

- Documented `BEDROCK_AWS_PROFILE` as a Bedrock-scoped way to select an AWS shared config profile.
- Clarified how the AWS SDK default credential provider chain works for Bedrock deployments.
- Added static credential precedence and partial-credential guidance.
- Added `BEDROCK_AWS_BEARER_TOKEN` guidance for Bedrock API keys, including the distinction from AWS's raw `AWS_BEARER_TOKEN_BEDROCK` env var.
- Updated the `.env` reference, Bedrock inference profile examples, and YAML object note so the Bedrock auth options agree.
- Updated Bedrock inference profile examples so they do not imply long-lived access keys are required.
- Replaced the outdated YAML object note that said additional authentication forms were still in development.

## Change Type

- [x] Documentation update

## Testing

- Ran `pnpm exec prettier --check content/docs/configuration/pre_configured_ai/bedrock.mdx content/docs/configuration/dotenv.mdx content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx`
- Ran `pnpm lint`

### **Test Configuration**:

- pnpm 9.5.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
