### PR TITLE
🧾 docs: Document v0.8.6 Env, Config, And Changelog

### DIFF
--- a/content/changelog/config_v1.3.12.mdx
+++ b/content/changelog/config_v1.3.12.mdx
@@ -1,0 +1,16 @@
+---
+date: 2026-05-25
+title: ⚙️ Config v1.3.12
+version: '1.3.12'
+---
+
+- Added `interface.retentionMode`
+  - `"temporary"` keeps retention limited to temporary chats
+  - `"all"` applies configured retention to all supported retained data, including persistent agent resource files
+
+- Added `mcpServers.<server>.proxy`
+  - Allows `sse` and `streamable-http` MCP servers to use a per-server outbound proxy
+  - Supports `http://`, `https://`, `socks://`, and `socks5://` proxy URLs
+
+- Added `modelSpecs.list[].hideBadgeRow`
+  - Allows a model spec to hide the tool badge row in the chat composer

--- a/content/changelog/config_v1.3.12.mdx
+++ b/content/changelog/config_v1.3.12.mdx
@@ -1,0 +1,16 @@
+---
+date: 2026-05-25
+title: ⚙️ Config v1.3.12
+version: '1.3.12'
+---
+
+- Added `interface.retentionMode`
+  - `"temporary"` keeps retention limited to temporary chats
+  - `"all"` applies configured retention to all supported conversation data
+
+- Added `mcpServers.<server>.proxy`
+  - Allows `sse` and `streamable-http` MCP servers to use a per-server outbound proxy
+  - Supports `http://`, `https://`, `socks://`, and `socks5://` proxy URLs
+
+- Added `modelSpecs.list[].hideBadgeRow`
+  - Allows a model spec to hide the tool badge row in the chat composer

--- a/content/changelog/v0.8.6.mdx
+++ b/content/changelog/v0.8.6.mdx
@@ -1,0 +1,200 @@
+---
+date: 2026-05-31
+title: 🚀 LibreChat v0.8.6
+description: The v0.8.6 release of LibreChat
+version: '0.8.6'
+---
+
+## What's Changed
+
+## 🏞️ Highlights
+
+- **Agent Skills & Subagents**
+  - Agent Skills package reusable instructions, references, scripts, assets, and permissions into portable capabilities that agents can invoke automatically or on request.
+  - Subagents let agents delegate specialized work to other agents while preserving upload, user, and MCP context with recursion and graph limits.
+- **Code Execution & Artifacts**
+  - Text, source-code, DOCX, CSV, XLSX, and PPTX artifacts can render inline or in the side panel with richer previews.
+  - Artifact editing, Gemini PDF media blocks, model-spec icons, and persistent agent resource files received reliability fixes.
+- **Observability & Operations**
+  - Added Prometheus metrics, backend OpenTelemetry tracing, SSE lifecycle tracing, HyperDX browser RUM, structured logging context, explicit readiness endpoints, file-log controls, and graceful HTTP shutdown.
+- **MCP, Auth, and Admin Hardening**
+  - Improved MCP remote proxy support, OAuth audience handling, JWT expiry fallback, optional OpenID/MCP client-secret flows, multi-audience OpenID validation, trusted registration overrides, admin-panel SSO redirects, streamable HTTP limits, and MCP permission enforcement for agent tools.
+- **Provider and Model Updates**
+  - Added Claude Opus 4.8 support, Gemini 3.5 Flash support, Gemini tool combinations, Gemma 4 thinking-level support, model-aware Google/Gemini max output tokens, Bedrock AWS profile/API key support, and Bedrock guardrail handling.
+- **Reliability and UI Polish**
+  - Hardened retention semantics, user/config response sanitization, configured rich-text rendering, Redis/in-memory generation cleanup, all-data retention for agent files, MCP title rendering, sidebar/chat race handling, hover actions, shared links, generated file chips, and balance script config loading.
+
+For detailed changes in the release candidate, see:
+
+- [v0.8.6-rc1](/changelog/v0.8.6-rc1)
+
+---
+
+## Changes Since v0.8.6-rc1
+
+### ✨ Features
+
+- 🚧 feat: Support Guardrail Config Option `streamProcessingMode` by [@dlew](https://github.com/dlew) in [#12815](https://github.com/danny-avila/LibreChat/pull/12815)
+- 📈 feat: Add Prometheus Metrics Endpoint + AWS Credential Providers by [@danny-avila](https://github.com/danny-avila) in [#13111](https://github.com/danny-avila/LibreChat/pull/13111)
+- 🧾 feat: Add Structured Logging Context by [@danny-avila](https://github.com/danny-avila) in [#13110](https://github.com/danny-avila/LibreChat/pull/13110)
+- 🛡️ feat: Bedrock Guardrail Config Environment Variable Resolution by [@entropic489](https://github.com/entropic489) in [#11717](https://github.com/danny-avila/LibreChat/pull/11717)
+- 📡 feat: Add Backend OpenTelemetry Tracing by [@danny-avila](https://github.com/danny-avila) in [#12909](https://github.com/danny-avila/LibreChat/pull/12909)
+- 🏷️ feat: Hide Model Spec Badge Rows by [@danny-avila](https://github.com/danny-avila) in [#13124](https://github.com/danny-avila/LibreChat/pull/13124)
+- 👟 feat: Enable Eager Execution of Tool Calls by [@danny-avila](https://github.com/danny-avila) in [#13192](https://github.com/danny-avila/LibreChat/pull/13192)
+- 🍪 feat: Add Session Cookie Secure Override by [@danny-avila](https://github.com/danny-avila) in [#13189](https://github.com/danny-avila/LibreChat/pull/13189)
+- 🪂 feat: Graceful HTTP shutdown on SIGTERM/SIGINT by [@pjhampton](https://github.com/pjhampton) in [#13211](https://github.com/danny-avila/LibreChat/pull/13211)
+- 🩺 feat: Add Explicit Readiness Endpoints by [@danny-avila](https://github.com/danny-avila) in [#13212](https://github.com/danny-avila/LibreChat/pull/13212)
+- 🗂️ feat: Allow Disabling File Log Transports by [@danny-avila](https://github.com/danny-avila) in [#13215](https://github.com/danny-avila/LibreChat/pull/13215)
+- ⚡ feat: Add Gemini 3.5 Flash Support by [@danny-avila](https://github.com/danny-avila) in [#13231](https://github.com/danny-avila/LibreChat/pull/13231)
+- 🛣️ feat: Add MCP Remote Proxy Support by [@danny-avila](https://github.com/danny-avila) in [#13076](https://github.com/danny-avila/LibreChat/pull/13076)
+- ⚖️ feat: Add Operational Prometheus Metrics by [@danny-avila](https://github.com/danny-avila) in [#13265](https://github.com/danny-avila/LibreChat/pull/13265)
+- 🖲️ feat: Trace SSE Stream Lifecycle with OTel by [@upman](https://github.com/upman) in [#13266](https://github.com/danny-avila/LibreChat/pull/13266)
+- 📜 feat: Add Explicit new Skill Route from Agent Builder by [@sand116](https://github.com/sand116) in [#13119](https://github.com/danny-avila/LibreChat/pull/13119)
+- 🆔 feat: Built-in Build Metadata for Support Triage by [@danny-avila](https://github.com/danny-avila) in [#12756](https://github.com/danny-avila/LibreChat/pull/12756)
+- 🛂 feat: Add AWS Profile Support for Bedrock Credentials by [@iElsha](https://github.com/iElsha) in [#10504](https://github.com/danny-avila/LibreChat/pull/10504)
+- 🪙 feat: Add AWS Bedrock API key support by [@dustinhealy](https://github.com/dustinhealy) in [#8690](https://github.com/danny-avila/LibreChat/pull/8690)
+- 🛰️ feat: Support Gemini Tool Combinations by [@danny-avila](https://github.com/danny-avila) in [#13273](https://github.com/danny-avila/LibreChat/pull/13273)
+- 🧠 feat: Add Claude Opus 4.8 Support by [@danny-avila](https://github.com/danny-avila) in [#13380](https://github.com/danny-avila/LibreChat/pull/13380)
+- ♊ feat: Model-Aware Max Output Tokens for Google/Gemini by [@danny-avila](https://github.com/danny-avila) in [#13390](https://github.com/danny-avila/LibreChat/pull/13390)
+- 📡 feat: Add Configurable HyperDX Browser Real User Monitoring by [@upman](https://github.com/upman) in [#13287](https://github.com/danny-avila/LibreChat/pull/13287)
+- 🪪 feat: Accept Multiple OpenID JWT Audiences by [@danny-avila](https://github.com/danny-avila) in [#13404](https://github.com/danny-avila/LibreChat/pull/13404)
+- 🪪 feat: MCP OAuth - Support `audience` parameter for Auth0/Cognito-style providers by [@Freudator86](https://github.com/Freudator86) in [#13402](https://github.com/danny-avila/LibreChat/pull/13402)
+- 💠 feat: Extend `thinkingLevel` Support to Gemma 4 Models by [@King-of-Infinite-Space](https://github.com/King-of-Infinite-Space) in [#13088](https://github.com/danny-avila/LibreChat/pull/13088)
+
+### 🐛 Fixes
+
+- 🧰 fix: Scope MCP Registry Initialization To Config Fingerprints by [@danny-avila](https://github.com/danny-avila) in [#13115](https://github.com/danny-avila/LibreChat/pull/13115)
+- 🧹 fix: Reset Redis Reorder State After Last Unsubscribe by [@sand116](https://github.com/sand116) in [#13117](https://github.com/danny-avila/LibreChat/pull/13117)
+- 🏷️ fix: Harden Helm Chart Tag Parsing by [@danny-avila](https://github.com/danny-avila) in [#13123](https://github.com/danny-avila/LibreChat/pull/13123)
+- 🛡️ fix: Sanitize Agent List Skill Scope by [@danny-avila](https://github.com/danny-avila) in [#13122](https://github.com/danny-avila/LibreChat/pull/13122)
+- 🗝️ fix: Protect Model Spec Instructions by [@danny-avila](https://github.com/danny-avila) in [#13125](https://github.com/danny-avila/LibreChat/pull/13125)
+- 🪵 fix: Restore Winston Format Factory Shape In Test Mocks by [@JorgeCosta87](https://github.com/JorgeCosta87) in [#13139](https://github.com/danny-avila/LibreChat/pull/13139)
+- 🛡️ fix: Escape People Picker Search Regex by [@danny-avila](https://github.com/danny-avila) in [#13169](https://github.com/danny-avila/LibreChat/pull/13169)
+- 🤝 fix: Honor OPENID_REUSE_TOKENS in Admin OAuth Exchange by [@jangByeongHui](https://github.com/jangByeongHui) in [#13154](https://github.com/danny-avila/LibreChat/pull/13154)
+- 🪪 fix: Resolve Group-Scoped Config Overrides by [@danny-avila](https://github.com/danny-avila) in [#13176](https://github.com/danny-avila/LibreChat/pull/13176)
+- 🧽 fix: Strip Admin OAuth Redirect Params by [@danny-avila](https://github.com/danny-avila) in [#13181](https://github.com/danny-avila/LibreChat/pull/13181)
+- 🔍 fix: Prefer LibreChat Web Search over Anthropic's when Both Selected by [@danny-avila](https://github.com/danny-avila) in [#13166](https://github.com/danny-avila/LibreChat/pull/13166)
+- 🗂️ fix: Scope Handoff Agent Context Docs by [@danny-avila](https://github.com/danny-avila) in [#13167](https://github.com/danny-avila/LibreChat/pull/13167)
+- 🪪 fix: Scope Message Conversation Access by [@danny-avila](https://github.com/danny-avila) in [#13183](https://github.com/danny-avila/LibreChat/pull/13183)
+- 🧭 fix: Reduce MCP Registry ACL Lookups by [@danny-avila](https://github.com/danny-avila) in [#13195](https://github.com/danny-avila/LibreChat/pull/13195)
+- ⛴️ fix: Stop Double-Wrapping configYamlContent in Helm ConfigMap by [@vdittgen](https://github.com/vdittgen) in [#13198](https://github.com/danny-avila/LibreChat/pull/13198)
+- 📡 fix: Handle Pre-Session 406 for Optional SSE MCP Stream by [@pnancarrow](https://github.com/pnancarrow) in [#13202](https://github.com/danny-avila/LibreChat/pull/13202)
+- 🧯 fix: Harden Data Retention Semantics by [@danny-avila](https://github.com/danny-avila) in [#13049](https://github.com/danny-avila/LibreChat/pull/13049)
+- 🪪 fix: Add Admin Panel SSO URL Config by [@danny-avila](https://github.com/danny-avila) in [#13220](https://github.com/danny-avila/LibreChat/pull/13220)
+- 🦣 fix: Response Size Limits for Streamable HTTP MCP Responses by [@danny-avila](https://github.com/danny-avila) in [#13219](https://github.com/danny-avila/LibreChat/pull/13219)
+- 🏃 fix: Improve OpenID Lookup Planning by [@danny-avila](https://github.com/danny-avila) in [#13229](https://github.com/danny-avila/LibreChat/pull/13229)
+- 🧩 fix: Support DocumentDB Prompt Group Lookup by [@danny-avila](https://github.com/danny-avila) in [#13232](https://github.com/danny-avila/LibreChat/pull/13232)
+- 📡 fix: Respect Custom Endpoint Stream Usage Opt-In by [@danny-avila](https://github.com/danny-avila) in [#13237](https://github.com/danny-avila/LibreChat/pull/13237)
+- 🍞 fix: don't show 'deleting file' toast on attached files by [@dlew](https://github.com/dlew) in [#13239](https://github.com/danny-avila/LibreChat/pull/13239)
+- 🧵 fix: Preserve Streaming Messages During Stale Refetch by [@danny-avila](https://github.com/danny-avila) in [#13247](https://github.com/danny-avila/LibreChat/pull/13247)
+- 🛡️ fix: Harden MCP OAuth Request Handling by [@danny-avila](https://github.com/danny-avila) in [#13264](https://github.com/danny-avila/LibreChat/pull/13264)
+- 🪪 fix: Consolidate MCP OAuth Policy by [@danny-avila](https://github.com/danny-avila) in [#13254](https://github.com/danny-avila/LibreChat/pull/13254)
+- 🪪 fix: Prevent MCP Server Name Collisions by [@danny-avila](https://github.com/danny-avila) in [#13256](https://github.com/danny-avila/LibreChat/pull/13256)
+- ⌛ fix: Use JWT exp claim for MCP when OAuth token omits expires_in by [@devanchohan](https://github.com/devanchohan) in [#13248](https://github.com/danny-avila/LibreChat/pull/13248)
+- 🪪 fix: Support OpenID PKCE Without Client Secret by [@eleite93](https://github.com/eleite93) in [#12364](https://github.com/danny-avila/LibreChat/pull/12364)
+- 🪪 fix: Allow Optional client_secret for MCP OAuth by [@aupuzikov](https://github.com/aupuzikov) in [#12460](https://github.com/danny-avila/LibreChat/pull/12460)
+- 🛂 fix: Detect OAuth Errors From HTTP 400 Responses by [@janluedemann-esome](https://github.com/janluedemann-esome) in [#11961](https://github.com/danny-avila/LibreChat/pull/11961)
+- 🪬 fix: Skip MCP Tools When Required Custom User Vars Are Unset by [@verifizieren](https://github.com/verifizieren) in [#13152](https://github.com/danny-avila/LibreChat/pull/13152)
+- 🪨 fix: Normalize Empty MCP Tool Descriptions to `undefined` for Bedrock Compat. by [@serhiizghama](https://github.com/serhiizghama) in [#13217](https://github.com/danny-avila/LibreChat/pull/13217)
+- 📡 fix: Tighten Streaming Message Cache Preservation by [@danny-avila](https://github.com/danny-avila) in [#13271](https://github.com/danny-avila/LibreChat/pull/13271)
+- 🧷 fix: Harden MCP Proxy SSRF Checks by [@danny-avila](https://github.com/danny-avila) in [#13274](https://github.com/danny-avila/LibreChat/pull/13274)
+- 🧱 fix: Validate Bedrock User Credentials by [@danny-avila](https://github.com/danny-avila) in [#13277](https://github.com/danny-avila/LibreChat/pull/13277)
+- 🧷 fix: Pin MCP OAuth Client Secrets by [@danny-avila](https://github.com/danny-avila) in [#13276](https://github.com/danny-avila/LibreChat/pull/13276)
+- 🏣 fix: Reject System Tenant In Auth Context by [@danny-avila](https://github.com/danny-avila) in [#13278](https://github.com/danny-avila/LibreChat/pull/13278)
+- 🧾 fix: Validate Bedrock User Credentials by [@danny-avila](https://github.com/danny-avila) in [#13279](https://github.com/danny-avila/LibreChat/pull/13279)
+- 🪟 fix: Apply Admin-Panel Config Overrides To YAML-Defined MCP Servers by [@dustinhealy](https://github.com/dustinhealy) in [#13173](https://github.com/danny-avila/LibreChat/pull/13173)
+- 🪡 fix: Prevent Hover Actions Flash While Streaming by [@danny-avila](https://github.com/danny-avila) in [#13285](https://github.com/danny-avila/LibreChat/pull/13285)
+- 🧩 fix: Add REDIS_CLUSTER_SAFE_DELETE Flag for ElastiCache Serverless CROSSSLOT Errors by [@serhiizghama](https://github.com/serhiizghama) in [#13275](https://github.com/danny-avila/LibreChat/pull/13275)
+- 🧵 fix: Prevent Message Loading Race During Streaming by [@danny-avila](https://github.com/danny-avila) in [#13295](https://github.com/danny-avila/LibreChat/pull/13295)
+- ⏭️ fix: Avoid False Resume Submission Stale Detection by [@danny-avila](https://github.com/danny-avila) in [#13297](https://github.com/danny-avila/LibreChat/pull/13297)
+- 🧯 fix: Suppress Google Service Key Noise by [@danny-avila](https://github.com/danny-avila) in [#13322](https://github.com/danny-avila/LibreChat/pull/13322)
+- ✂️ fix: Truncate Long MCP Server Titles In Builder Panel by [@dustinhealy](https://github.com/dustinhealy) in [#13321](https://github.com/danny-avila/LibreChat/pull/13321)
+- 📎 fix: Preserve Gemini PDF Media Blocks by [@danny-avila](https://github.com/danny-avila) in [#13357](https://github.com/danny-avila/LibreChat/pull/13357)
+- 🛡️ fix: Harden Model Spec Icon Rendering by [@danny-avila](https://github.com/danny-avila) in [#13356](https://github.com/danny-avila/LibreChat/pull/13356)
+- 🪡 fix: Artifact Edit Saves by [@danny-avila](https://github.com/danny-avila) in [#13358](https://github.com/danny-avila/LibreChat/pull/13358)
+- 🛡️ fix: Cap Default Limit on Agent List Queries by [@danny-avila](https://github.com/danny-avila) in [#13382](https://github.com/danny-avila/LibreChat/pull/13382)
+- 🪨 fix: Preserve Bedrock Guardrail Config by [@danny-avila](https://github.com/danny-avila) in [#13381](https://github.com/danny-avila/LibreChat/pull/13381)
+- ⚓ fix: Skip Retention for Persistent Agent Resource Files by [@maxesse](https://github.com/maxesse) in [#13394](https://github.com/danny-avila/LibreChat/pull/13394)
+- 🧟 fix: Reap Hung In-Memory Generations for Redis Failsafe Parity by [@danny-avila](https://github.com/danny-avila) in [#13396](https://github.com/danny-avila/LibreChat/pull/13396)
+- 🪃 fix: Retry MCP OAuth Token Refresh Without Scope on Server Rejection by [@danny-avila](https://github.com/danny-avila) in [#13412](https://github.com/danny-avila/LibreChat/pull/13412)
+- 🖼️ fix: Preserve Model Spec Icon URLs by [@danny-avila](https://github.com/danny-avila) in [#13370](https://github.com/danny-avila/LibreChat/pull/13370)
+- 🔑 fix: support 'userinfo' in OPENID_REQUIRED_ROLE_TOKEN_KIND by [@pboers1988](https://github.com/pboers1988) in [#13182](https://github.com/danny-avila/LibreChat/pull/13182)
+- 🪪 fix: Preserve Trusted Registration Provider Overrides by [@danny-avila](https://github.com/danny-avila) in [#13307](https://github.com/danny-avila/LibreChat/pull/13307)
+- 💰 fix: Load app config in `set-balance` script to respect balance settings by [@ucodia](https://github.com/ucodia) in [#12669](https://github.com/danny-avila/LibreChat/pull/12669)
+- 📬 fix: Honor Admin-Panel `allowedDomains` Override at Registration by [@nangelovv](https://github.com/nangelovv) in [#13204](https://github.com/danny-avila/LibreChat/pull/13204)
+- 🔒 fix: Strip post-login fields from unauthenticated /api/config response by [@ChrisJr404](https://github.com/ChrisJr404) in [#13102](https://github.com/danny-avila/LibreChat/pull/13102)
+- 🏟️ fix: Restrict MCP OAuth Audience in User-Managed Configs by [@danny-avila](https://github.com/danny-avila) in [#13418](https://github.com/danny-avila/LibreChat/pull/13418)
+- 🛂 fix: Enforce MCP Permissions for Agent Tools by [@danny-avila](https://github.com/danny-avila) in [#13174](https://github.com/danny-avila/LibreChat/pull/13174)
+- 🧼 fix: Sanitize User Response Fields by [@danny-avila](https://github.com/danny-avila) in [#13421](https://github.com/danny-avila/LibreChat/pull/13421)
+- 🧼 fix: Harden Configured Rich Text Rendering by [@danny-avila](https://github.com/danny-avila) in [#13423](https://github.com/danny-avila/LibreChat/pull/13423)
+- 🪪 fix: Use Shared IdP Avatar Processing by [@danny-avila](https://github.com/danny-avila) in [#13422](https://github.com/danny-avila/LibreChat/pull/13422)
+
+### 🔧 Refactoring
+
+- 📸 refactor: Refresh Shared Links With Latest Snapshot by [@danny-avila](https://github.com/danny-avila) in [#13095](https://github.com/danny-avila/LibreChat/pull/13095)
+- 🗂️ refactor: Collapse Generated File Chips by [@danny-avila](https://github.com/danny-avila) in [#13116](https://github.com/danny-avila/LibreChat/pull/13116)
+- 🛟 refactor: Gracefully Skip Unavailable Web Search Rerankers by [@danny-avila](https://github.com/danny-avila) in [#13191](https://github.com/danny-avila/LibreChat/pull/13191)
+- 🗂️ refactor: Clarify Code Sandbox File Guidance by [@danny-avila](https://github.com/danny-avila) in [#13236](https://github.com/danny-avila/LibreChat/pull/13236)
+- 🧬 refactor: Derive Latest Message From Cache by [@danny-avila](https://github.com/danny-avila) in [#13294](https://github.com/danny-avila/LibreChat/pull/13294)
+- ⏱️ refactor: Optimistically Show New Chats In Sidebar by [@danny-avila](https://github.com/danny-avila) in [#13298](https://github.com/danny-avila/LibreChat/pull/13298)
+- 🧠 refactor: Replay DeepSeek `reasoning_content` via OpenRouter by [@danny-avila](https://github.com/danny-avila) in [#13368](https://github.com/danny-avila/LibreChat/pull/13368)
+- 📤 refactor: Align Mention Options With Model Selector by [@danny-avila](https://github.com/danny-avila) in [#13397](https://github.com/danny-avila/LibreChat/pull/13397)
+- 🧠 refactor: Memoize MCP Permission Checks Per Request by [@danny-avila](https://github.com/danny-avila) in [#13419](https://github.com/danny-avila/LibreChat/pull/13419)
+- 🗄️ refactor: Honor All-Data Retention for Agent Files by [@danny-avila](https://github.com/danny-avila) in [#13424](https://github.com/danny-avila/LibreChat/pull/13424)
+
+### 🧪 Tests
+
+- 🛟 test: Restore Playwright Smoke E2E by [@danny-avila](https://github.com/danny-avila) in [#13020](https://github.com/danny-avila/LibreChat/pull/13020)
+
+### 📦 Dependencies, Chores & CI
+
+- 🧹 chore: Type Agent MCP lean projection in ServerConfigsDB by [@gaurav0107](https://github.com/gaurav0107) in [#13171](https://github.com/danny-avila/LibreChat/pull/13171)
+- 🛡️ chore: Harden CI Supply Chain Workflows by [@danny-avila](https://github.com/danny-avila) in [#13090](https://github.com/danny-avila/LibreChat/pull/13090)
+- 🕵🏻 ci: Improve Flaky Subagents Test by [@dustinhealy](https://github.com/dustinhealy) in [#13185](https://github.com/danny-avila/LibreChat/pull/13185)
+- 📦 chore: npm audit fix, bump otel & `@librechat/agents` by [@danny-avila](https://github.com/danny-avila) in [#13186](https://github.com/danny-avila/LibreChat/pull/13186)
+- 📦 chore: Bump `@librechat/agents` to v3.1.88 by [@danny-avila](https://github.com/danny-avila) in [#13187](https://github.com/danny-avila/LibreChat/pull/13187)
+- 🧪 ci: Stabilize Virtualized Agent Grid Tests by [@danny-avila](https://github.com/danny-avila) in [#13214](https://github.com/danny-avila/LibreChat/pull/13214)
+- 🧵 chore: Raise MCP SSE Line Default by [@danny-avila](https://github.com/danny-avila) in [#13224](https://github.com/danny-avila/LibreChat/pull/13224)
+- 📦 chore: bump `@librechat/agents` to v3.1.90 and npm audit fix by [@danny-avila](https://github.com/danny-avila) in [#13242](https://github.com/danny-avila/LibreChat/pull/13242)
+- 🚦 ci: Enforce ESLint on Package Changes by [@danny-avila](https://github.com/danny-avila) in [#13280](https://github.com/danny-avila/LibreChat/pull/13280)
+- 🎨 chore: prettier --write all workspaces by [@danny-avila](https://github.com/danny-avila) in [#13281](https://github.com/danny-avila/LibreChat/pull/13281)
+- 🎨 ci: Check Prettier Formatting Drift on Package Changes by [@danny-avila](https://github.com/danny-avila) in [#13282](https://github.com/danny-avila/LibreChat/pull/13282)
+- 🪤 chore: Prevent CI Path Argument Injection by [@danny-avila](https://github.com/danny-avila) in [#13284](https://github.com/danny-avila/LibreChat/pull/13284)
+- 🌐 chore: Guard Locize Reviewer Request by [@danny-avila](https://github.com/danny-avila) in [#13286](https://github.com/danny-avila/LibreChat/pull/13286)
+- 📦 chore: bump `@librechat/agents`, `qs`, `langfuse` by [@danny-avila](https://github.com/danny-avila) in [#13299](https://github.com/danny-avila/LibreChat/pull/13299)
+- 🐢 ci: Raise test-packages-api timeout to 20 min by [@danny-avila](https://github.com/danny-avila) in [#13326](https://github.com/danny-avila/LibreChat/pull/13326)
+- 🧮 chore: Update Gemma Context Token Defaults by [@danny-avila](https://github.com/danny-avila) in [#13410](https://github.com/danny-avila/LibreChat/pull/13410)
+- ✂️ chore: Strip Session JWT Forwarding from Browser RUM by [@danny-avila](https://github.com/danny-avila) in [#13414](https://github.com/danny-avila/LibreChat/pull/13414)
+- 📦 chore: Bump `@hyperdx/browser` to v0.24.0 by [@danny-avila](https://github.com/danny-avila) in [#13416](https://github.com/danny-avila/LibreChat/pull/13416)
+- 🔧 chore: Drop duplicate `getAppConfig` import in `set-balance.js` by [@danny-avila](https://github.com/danny-avila) in [#13417](https://github.com/danny-avila/LibreChat/pull/13417)
+
+### 🌍 Internationalization
+
+- 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#13107](https://github.com/danny-avila/LibreChat/pull/13107)
+- 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#13128](https://github.com/danny-avila/LibreChat/pull/13128)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13230](https://github.com/danny-avila/LibreChat/pull/13230)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13283](https://github.com/danny-avila/LibreChat/pull/13283)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13291](https://github.com/danny-avila/LibreChat/pull/13291)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13325](https://github.com/danny-avila/LibreChat/pull/13325)
+
+## New Contributors
+
+- [@entropic489](https://github.com/entropic489) made their first contribution in [#11717](https://github.com/danny-avila/LibreChat/pull/11717)
+- [@sand116](https://github.com/sand116) made their first contribution in [#13117](https://github.com/danny-avila/LibreChat/pull/13117)
+- [@JorgeCosta87](https://github.com/JorgeCosta87) made their first contribution in [#13139](https://github.com/danny-avila/LibreChat/pull/13139)
+- [@jangByeongHui](https://github.com/jangByeongHui) made their first contribution in [#13154](https://github.com/danny-avila/LibreChat/pull/13154)
+- [@pjhampton](https://github.com/pjhampton) made their first contribution in [#13211](https://github.com/danny-avila/LibreChat/pull/13211)
+- [@devanchohan](https://github.com/devanchohan) made their first contribution in [#13248](https://github.com/danny-avila/LibreChat/pull/13248)
+- [@eleite93](https://github.com/eleite93) made their first contribution in [#12364](https://github.com/danny-avila/LibreChat/pull/12364)
+- [@aupuzikov](https://github.com/aupuzikov) made their first contribution in [#12460](https://github.com/danny-avila/LibreChat/pull/12460)
+- [@janluedemann-esome](https://github.com/janluedemann-esome) made their first contribution in [#11961](https://github.com/danny-avila/LibreChat/pull/11961)
+- [@verifizieren](https://github.com/verifizieren) made their first contribution in [#13152](https://github.com/danny-avila/LibreChat/pull/13152)
+- [@serhiizghama](https://github.com/serhiizghama) made their first contribution in [#13217](https://github.com/danny-avila/LibreChat/pull/13217)
+- [@iElsha](https://github.com/iElsha) made their first contribution in [#10504](https://github.com/danny-avila/LibreChat/pull/10504)
+- [@Freudator86](https://github.com/Freudator86) made their first contribution in [#13402](https://github.com/danny-avila/LibreChat/pull/13402)
+- [@pboers1988](https://github.com/pboers1988) made their first contribution in [#13182](https://github.com/danny-avila/LibreChat/pull/13182)
+- [@King-of-Infinite-Space](https://github.com/King-of-Infinite-Space) made their first contribution in [#13088](https://github.com/danny-avila/LibreChat/pull/13088)
+- [@nangelovv](https://github.com/nangelovv) made their first contribution in [#13204](https://github.com/danny-avila/LibreChat/pull/13204)
+- [@ChrisJr404](https://github.com/ChrisJr404) made their first contribution in [#13102](https://github.com/danny-avila/LibreChat/pull/13102)
+
+**Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.8.6-rc1...v0.8.6

--- a/content/changelog/v0.8.6.mdx
+++ b/content/changelog/v0.8.6.mdx
@@ -1,0 +1,158 @@
+---
+date: 2026-05-25
+title: 🚀 LibreChat v0.8.6
+description: The v0.8.6 release of LibreChat
+version: '0.8.6'
+---
+
+## What's Changed
+
+## 🏞️ Highlights
+
+- **Agent Skills & Subagents**
+  - Agent Skills package reusable instructions, references, scripts, assets, and permissions into portable capabilities that agents can invoke automatically or on request.
+  - Subagents let agents delegate specialized work to other agents while preserving upload, user, and MCP context with recursion and graph limits.
+- **Code Execution & Artifacts**
+  - Text, source-code, DOCX, CSV, XLSX, and PPTX artifacts can render inline or in the side panel with richer previews.
+  - Nested artifact paths, Unicode filenames, file metadata encoding, and generated-code context filtering received several hardening passes.
+- **CloudFront + Storage Delivery**
+  - CloudFront file strategy support includes signed cookies, signed downloads, strict signed-access enforcement, region-aware storage keys, and cookie refresh on auth refresh.
+- **Observability & Operations**
+  - Added Prometheus metrics, backend OpenTelemetry tracing, SSE lifecycle tracing, structured logging context, explicit readiness endpoints, and graceful HTTP shutdown.
+- **MCP, Auth, and Security Hardening**
+  - Improved MCP remote proxy support, OAuth policy handling, JWT expiry fallback, optional OpenID/MCP client-secret flows, SSRF checks, streamable HTTP limits, and admin-panel SSO redirects.
+- **Provider and Model Updates**
+  - Added Bedrock AWS profile and API key support, Bedrock guardrail environment resolution, Gemini 3.5 Flash support, Gemini tool combinations, and custom-endpoint stream-usage opt-in handling.
+
+For detailed changes in the release candidate, see:
+
+- [v0.8.6-rc1](/changelog/v0.8.6-rc1)
+
+---
+
+## Changes Since v0.8.6-rc1
+
+### ✨ Features
+
+- 🚧 feat: Support Guardrail Config Option `streamProcessingMode` by [@dlew](https://github.com/dlew) in [#12815](https://github.com/danny-avila/LibreChat/pull/12815)
+- 📈 feat: Add Prometheus Metrics Endpoint + AWS Credential Providers by [@danny-avila](https://github.com/danny-avila) in [#13111](https://github.com/danny-avila/LibreChat/pull/13111)
+- 🧾 feat: Add Structured Logging Context by [@danny-avila](https://github.com/danny-avila) in [#13110](https://github.com/danny-avila/LibreChat/pull/13110)
+- 🛡️ feat: Bedrock Guardrail Config Environment Variable Resolution by [@entropic489](https://github.com/entropic489) in [#11717](https://github.com/danny-avila/LibreChat/pull/11717)
+- 📡 feat: Add Backend OpenTelemetry Tracing by [@danny-avila](https://github.com/danny-avila) in [#12909](https://github.com/danny-avila/LibreChat/pull/12909)
+- 🏷️ feat: Hide Model Spec Badge Rows by [@danny-avila](https://github.com/danny-avila) in [#13124](https://github.com/danny-avila/LibreChat/pull/13124)
+- 👟 feat: Enable Eager Execution of Tool Calls by [@danny-avila](https://github.com/danny-avila) in [#13192](https://github.com/danny-avila/LibreChat/pull/13192)
+- 🍪 feat: Add Session Cookie Secure Override by [@danny-avila](https://github.com/danny-avila) in [#13189](https://github.com/danny-avila/LibreChat/pull/13189)
+- 🪂 feat: Graceful HTTP shutdown on SIGTERM/SIGINT by [@pjhampton](https://github.com/pjhampton) in [#13211](https://github.com/danny-avila/LibreChat/pull/13211)
+- 🩺 feat: Add Explicit Readiness Endpoints by [@danny-avila](https://github.com/danny-avila) in [#13212](https://github.com/danny-avila/LibreChat/pull/13212)
+- 🗂️ feat: Allow Disabling File Log Transports by [@danny-avila](https://github.com/danny-avila) in [#13215](https://github.com/danny-avila/LibreChat/pull/13215)
+- ⚡ feat: Add Gemini 3.5 Flash Support by [@danny-avila](https://github.com/danny-avila) in [#13231](https://github.com/danny-avila/LibreChat/pull/13231)
+- 🛣️ feat: Add MCP Remote Proxy Support by [@danny-avila](https://github.com/danny-avila) in [#13076](https://github.com/danny-avila/LibreChat/pull/13076)
+- ⚖️ feat: Add Operational Prometheus Metrics by [@danny-avila](https://github.com/danny-avila) in [#13265](https://github.com/danny-avila/LibreChat/pull/13265)
+- 🖲️ feat: Trace SSE Stream Lifecycle with OTel by [@upman](https://github.com/upman) in [#13266](https://github.com/danny-avila/LibreChat/pull/13266)
+- 📜 feat: Add Explicit new Skill Route from Agent Builder by [@sand116](https://github.com/sand116) in [#13119](https://github.com/danny-avila/LibreChat/pull/13119)
+- 🆔 feat: Built-in Build Metadata for Support Triage by [@danny-avila](https://github.com/danny-avila) in [#12756](https://github.com/danny-avila/LibreChat/pull/12756)
+- 🛂 feat: Add AWS Profile Support for Bedrock Credentials by [@iElsha](https://github.com/iElsha) in [#10504](https://github.com/danny-avila/LibreChat/pull/10504)
+- 🪙 feat: Add AWS Bedrock API key support by [@dustinhealy](https://github.com/dustinhealy) in [#8690](https://github.com/danny-avila/LibreChat/pull/8690)
+- 🛰️ feat: Support Gemini Tool Combinations by [@danny-avila](https://github.com/danny-avila) in [#13273](https://github.com/danny-avila/LibreChat/pull/13273)
+
+### 🐛 Fixes
+
+- 🧰 fix: Scope MCP Registry Initialization To Config Fingerprints by [@danny-avila](https://github.com/danny-avila) in [#13115](https://github.com/danny-avila/LibreChat/pull/13115)
+- 🧹 fix: Reset Redis Reorder State After Last Unsubscribe by [@sand116](https://github.com/sand116) in [#13117](https://github.com/danny-avila/LibreChat/pull/13117)
+- 🏷️ fix: Harden Helm Chart Tag Parsing by [@danny-avila](https://github.com/danny-avila) in [#13123](https://github.com/danny-avila/LibreChat/pull/13123)
+- 🛡️ fix: Sanitize Agent List Skill Scope by [@danny-avila](https://github.com/danny-avila) in [#13122](https://github.com/danny-avila/LibreChat/pull/13122)
+- 🗝️ fix: Protect Model Spec Instructions by [@danny-avila](https://github.com/danny-avila) in [#13125](https://github.com/danny-avila/LibreChat/pull/13125)
+- 🪵 fix: Restore Winston Format Factory Shape In Test Mocks by [@JorgeCosta87](https://github.com/JorgeCosta87) in [#13139](https://github.com/danny-avila/LibreChat/pull/13139)
+- 🛡️ fix: Escape People Picker Search Regex by [@danny-avila](https://github.com/danny-avila) in [#13169](https://github.com/danny-avila/LibreChat/pull/13169)
+- 🤝 fix: Honor OPENID_REUSE_TOKENS in Admin OAuth Exchange by [@jangByeongHui](https://github.com/jangByeongHui) in [#13154](https://github.com/danny-avila/LibreChat/pull/13154)
+- 🪪 fix: Resolve Group-Scoped Config Overrides by [@danny-avila](https://github.com/danny-avila) in [#13176](https://github.com/danny-avila/LibreChat/pull/13176)
+- 🧽 fix: Strip Admin OAuth Redirect Params by [@danny-avila](https://github.com/danny-avila) in [#13181](https://github.com/danny-avila/LibreChat/pull/13181)
+- 🔍 fix: Prefer LibreChat Web Search over Anthropic's when Both Selected by [@danny-avila](https://github.com/danny-avila) in [#13166](https://github.com/danny-avila/LibreChat/pull/13166)
+- 🗂️ fix: Scope Handoff Agent Context Docs by [@danny-avila](https://github.com/danny-avila) in [#13167](https://github.com/danny-avila/LibreChat/pull/13167)
+- 🪪 fix: Scope Message Conversation Access by [@danny-avila](https://github.com/danny-avila) in [#13183](https://github.com/danny-avila/LibreChat/pull/13183)
+- 🧭 fix: Reduce MCP Registry ACL Lookups by [@danny-avila](https://github.com/danny-avila) in [#13195](https://github.com/danny-avila/LibreChat/pull/13195)
+- ⛴️ fix: Stop Double-Wrapping configYamlContent in Helm ConfigMap by [@vdittgen](https://github.com/vdittgen) in [#13198](https://github.com/danny-avila/LibreChat/pull/13198)
+- 📡 fix: Handle Pre-Session 406 for Optional SSE MCP Stream by [@pnancarrow](https://github.com/pnancarrow) in [#13202](https://github.com/danny-avila/LibreChat/pull/13202)
+- 🧯 fix: Harden Data Retention Semantics by [@danny-avila](https://github.com/danny-avila) in [#13049](https://github.com/danny-avila/LibreChat/pull/13049)
+- 🪪 fix: Add Admin Panel SSO URL Config by [@danny-avila](https://github.com/danny-avila) in [#13220](https://github.com/danny-avila/LibreChat/pull/13220)
+- 🦣 fix: Response Size Limits for Streamable HTTP MCP Responses by [@danny-avila](https://github.com/danny-avila) in [#13219](https://github.com/danny-avila/LibreChat/pull/13219)
+- 🏃 fix: Improve OpenID Lookup Planning by [@danny-avila](https://github.com/danny-avila) in [#13229](https://github.com/danny-avila/LibreChat/pull/13229)
+- 🧩 fix: Support DocumentDB Prompt Group Lookup by [@danny-avila](https://github.com/danny-avila) in [#13232](https://github.com/danny-avila/LibreChat/pull/13232)
+- 📡 fix: Respect Custom Endpoint Stream Usage Opt-In by [@danny-avila](https://github.com/danny-avila) in [#13237](https://github.com/danny-avila/LibreChat/pull/13237)
+- 🍞 fix: don't show 'deleting file' toast on attached files by [@dlew](https://github.com/dlew) in [#13239](https://github.com/danny-avila/LibreChat/pull/13239)
+- 🧵 fix: Preserve Streaming Messages During Stale Refetch by [@danny-avila](https://github.com/danny-avila) in [#13247](https://github.com/danny-avila/LibreChat/pull/13247)
+- 🛡️ fix: Harden MCP OAuth Request Handling by [@danny-avila](https://github.com/danny-avila) in [#13264](https://github.com/danny-avila/LibreChat/pull/13264)
+- 🪪 fix: Consolidate MCP OAuth Policy by [@danny-avila](https://github.com/danny-avila) in [#13254](https://github.com/danny-avila/LibreChat/pull/13254)
+- 🪪 fix: Prevent MCP Server Name Collisions by [@danny-avila](https://github.com/danny-avila) in [#13256](https://github.com/danny-avila/LibreChat/pull/13256)
+- ⌛ fix: Use JWT exp claim for MCP when OAuth token omits expires_in by [@devanchohan](https://github.com/devanchohan) in [#13248](https://github.com/danny-avila/LibreChat/pull/13248)
+- 🪪 fix: Support OpenID PKCE Without Client Secret by [@eleite93](https://github.com/eleite93) in [#12364](https://github.com/danny-avila/LibreChat/pull/12364)
+- 🪪 fix: Allow Optional client_secret for MCP OAuth by [@aupuzikov](https://github.com/aupuzikov) in [#12460](https://github.com/danny-avila/LibreChat/pull/12460)
+- 🛂 fix: Detect OAuth Errors From HTTP 400 Responses by [@janluedemann-esome](https://github.com/janluedemann-esome) in [#11961](https://github.com/danny-avila/LibreChat/pull/11961)
+- 🪬 fix: Skip MCP Tools When Required Custom User Vars Are Unset by [@verifizieren](https://github.com/verifizieren) in [#13152](https://github.com/danny-avila/LibreChat/pull/13152)
+- 🪨 fix: Normalize Empty MCP Tool Descriptions to `undefined` for Bedrock Compat. by [@serhiizghama](https://github.com/serhiizghama) in [#13217](https://github.com/danny-avila/LibreChat/pull/13217)
+- 📡 fix: Tighten Streaming Message Cache Preservation by [@danny-avila](https://github.com/danny-avila) in [#13271](https://github.com/danny-avila/LibreChat/pull/13271)
+- 🧷 fix: Harden MCP Proxy SSRF Checks by [@danny-avila](https://github.com/danny-avila) in [#13274](https://github.com/danny-avila/LibreChat/pull/13274)
+- 🧱 fix: Validate Bedrock User Credentials by [@danny-avila](https://github.com/danny-avila) in [#13277](https://github.com/danny-avila/LibreChat/pull/13277)
+- 🧷 fix: Pin MCP OAuth Client Secrets by [@danny-avila](https://github.com/danny-avila) in [#13276](https://github.com/danny-avila/LibreChat/pull/13276)
+- 🏣 fix: Reject System Tenant In Auth Context by [@danny-avila](https://github.com/danny-avila) in [#13278](https://github.com/danny-avila/LibreChat/pull/13278)
+- 🧾 fix: Validate Bedrock User Credentials by [@danny-avila](https://github.com/danny-avila) in [#13279](https://github.com/danny-avila/LibreChat/pull/13279)
+- 🪟 fix: Apply Admin-Panel Config Overrides To YAML-Defined MCP Servers by [@dustinhealy](https://github.com/dustinhealy) in [#13173](https://github.com/danny-avila/LibreChat/pull/13173)
+- 🪡 fix: Prevent Hover Actions Flash While Streaming by [@danny-avila](https://github.com/danny-avila) in [#13285](https://github.com/danny-avila/LibreChat/pull/13285)
+- 🧩 fix: Add REDIS_CLUSTER_SAFE_DELETE Flag for ElastiCache Serverless CROSSSLOT Errors by [@serhiizghama](https://github.com/serhiizghama) in [#13275](https://github.com/danny-avila/LibreChat/pull/13275)
+- 🧵 fix: Prevent Message Loading Race During Streaming by [@danny-avila](https://github.com/danny-avila) in [#13295](https://github.com/danny-avila/LibreChat/pull/13295)
+- ⏭️ fix: Avoid False Resume Submission Stale Detection by [@danny-avila](https://github.com/danny-avila) in [#13297](https://github.com/danny-avila/LibreChat/pull/13297)
+
+### 🔧 Refactoring
+
+- 📸 refactor: Refresh Shared Links With Latest Snapshot by [@danny-avila](https://github.com/danny-avila) in [#13095](https://github.com/danny-avila/LibreChat/pull/13095)
+- 🗂️ refactor: Collapse Generated File Chips by [@danny-avila](https://github.com/danny-avila) in [#13116](https://github.com/danny-avila/LibreChat/pull/13116)
+- 🛟 refactor: Gracefully Skip Unavailable Web Search Rerankers by [@danny-avila](https://github.com/danny-avila) in [#13191](https://github.com/danny-avila/LibreChat/pull/13191)
+- 🗂️ refactor: Clarify Code Sandbox File Guidance by [@danny-avila](https://github.com/danny-avila) in [#13236](https://github.com/danny-avila/LibreChat/pull/13236)
+- 🧬 refactor: Derive Latest Message From Cache by [@danny-avila](https://github.com/danny-avila) in [#13294](https://github.com/danny-avila/LibreChat/pull/13294)
+- ⏱️ refactor: Optimistically Show New Chats In Sidebar by [@danny-avila](https://github.com/danny-avila) in [#13298](https://github.com/danny-avila/LibreChat/pull/13298)
+
+### 🧪 Tests
+
+- 🛟 test: Restore Playwright Smoke E2E by [@danny-avila](https://github.com/danny-avila) in [#13020](https://github.com/danny-avila/LibreChat/pull/13020)
+
+### 📦 Dependencies, Chores & CI
+
+- 🧹 chore: Type Agent MCP lean projection in ServerConfigsDB by [@gaurav0107](https://github.com/gaurav0107) in [#13171](https://github.com/danny-avila/LibreChat/pull/13171)
+- 🛡️ chore: Harden CI Supply Chain Workflows by [@danny-avila](https://github.com/danny-avila) in [#13090](https://github.com/danny-avila/LibreChat/pull/13090)
+- 🕵🏻 ci: Improve Flaky Subagents Test by [@dustinhealy](https://github.com/dustinhealy) in [#13185](https://github.com/danny-avila/LibreChat/pull/13185)
+- 📦 chore: npm audit fix, bump otel & `@librechat/agents` by [@danny-avila](https://github.com/danny-avila) in [#13186](https://github.com/danny-avila/LibreChat/pull/13186)
+- 📦 chore: Bump `@librechat/agents` to v3.1.88 by [@danny-avila](https://github.com/danny-avila) in [#13187](https://github.com/danny-avila/LibreChat/pull/13187)
+- 🧪 ci: Stabilize Virtualized Agent Grid Tests by [@danny-avila](https://github.com/danny-avila) in [#13214](https://github.com/danny-avila/LibreChat/pull/13214)
+- 🧵 chore: Raise MCP SSE Line Default by [@danny-avila](https://github.com/danny-avila) in [#13224](https://github.com/danny-avila/LibreChat/pull/13224)
+- 📦 chore: bump `@librechat/agents` to v3.1.90 and npm audit fix by [@danny-avila](https://github.com/danny-avila) in [#13242](https://github.com/danny-avila/LibreChat/pull/13242)
+- 🚦 ci: Enforce ESLint on Package Changes by [@danny-avila](https://github.com/danny-avila) in [#13280](https://github.com/danny-avila/LibreChat/pull/13280)
+- 🎨 chore: prettier --write all workspaces by [@danny-avila](https://github.com/danny-avila) in [#13281](https://github.com/danny-avila/LibreChat/pull/13281)
+- 🎨 ci: Check Prettier Formatting Drift on Package Changes by [@danny-avila](https://github.com/danny-avila) in [#13282](https://github.com/danny-avila/LibreChat/pull/13282)
+- 🪤 chore: Prevent CI Path Argument Injection by [@danny-avila](https://github.com/danny-avila) in [#13284](https://github.com/danny-avila/LibreChat/pull/13284)
+- 🌐 chore: Guard Locize Reviewer Request by [@danny-avila](https://github.com/danny-avila) in [#13286](https://github.com/danny-avila/LibreChat/pull/13286)
+- 📦 chore: bump `@librechat/agents`, `qs`, `langfuse` by [@danny-avila](https://github.com/danny-avila) in [#13299](https://github.com/danny-avila/LibreChat/pull/13299)
+
+### 🌍 Internationalization
+
+- 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#13107](https://github.com/danny-avila/LibreChat/pull/13107)
+- 🌍 i18n: Update translation.json with latest translations by [@github-actions[bot]](https://github.com/apps/github-actions) in [#13128](https://github.com/danny-avila/LibreChat/pull/13128)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13230](https://github.com/danny-avila/LibreChat/pull/13230)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13283](https://github.com/danny-avila/LibreChat/pull/13283)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13291](https://github.com/danny-avila/LibreChat/pull/13291)
+
+## New Contributors
+
+- [@entropic489](https://github.com/entropic489) made their first contribution in [#11717](https://github.com/danny-avila/LibreChat/pull/11717)
+- [@sand116](https://github.com/sand116) made their first contribution in [#13117](https://github.com/danny-avila/LibreChat/pull/13117)
+- [@JorgeCosta87](https://github.com/JorgeCosta87) made their first contribution in [#13139](https://github.com/danny-avila/LibreChat/pull/13139)
+- [@jangByeongHui](https://github.com/jangByeongHui) made their first contribution in [#13154](https://github.com/danny-avila/LibreChat/pull/13154)
+- [@pjhampton](https://github.com/pjhampton) made their first contribution in [#13211](https://github.com/danny-avila/LibreChat/pull/13211)
+- [@devanchohan](https://github.com/devanchohan) made their first contribution in [#13248](https://github.com/danny-avila/LibreChat/pull/13248)
+- [@eleite93](https://github.com/eleite93) made their first contribution in [#12364](https://github.com/danny-avila/LibreChat/pull/12364)
+- [@aupuzikov](https://github.com/aupuzikov) made their first contribution in [#12460](https://github.com/danny-avila/LibreChat/pull/12460)
+- [@janluedemann-esome](https://github.com/janluedemann-esome) made their first contribution in [#11961](https://github.com/danny-avila/LibreChat/pull/11961)
+- [@verifizieren](https://github.com/verifizieren) made their first contribution in [#13152](https://github.com/danny-avila/LibreChat/pull/13152)
+- [@serhiizghama](https://github.com/serhiizghama) made their first contribution in [#13217](https://github.com/danny-avila/LibreChat/pull/13217)
+- [@iElsha](https://github.com/iElsha) made their first contribution in [#10504](https://github.com/danny-avila/LibreChat/pull/10504)
+
+**Full Changelog**: https://github.com/danny-avila/LibreChat/compare/v0.8.6-rc1...v0.8.6

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -258,6 +258,12 @@ To configure LibreChat for local use or custom domain deployment, set the follow
       'Specifies the server-side domain.',
       'DOMAIN_SERVER=http://localhost:3080',
     ],
+    [
+      'ADMIN_PANEL_URL',
+      'string',
+      'External admin panel base URL used for admin OAuth/SSO redirects when the admin panel is hosted separately. Do not include a trailing slash.',
+      'ADMIN_PANEL_URL=https://admin.example.com/admin',
+    ],
   ]}
 />
 
@@ -302,6 +308,12 @@ LibreChat has built-in central logging, see [Logging System](/docs/configuration
       'boolean',
       'Enable verbose console/stdout logs in the same format as file debug logs.',
       'DEBUG_CONSOLE=false',
+    ],
+    [
+      'LOG_TO_FILE',
+      'boolean',
+      'Set to false to disable file-backed Winston transports while keeping console logging available.',
+      'LOG_TO_FILE=true',
     ],
     [
       'CONSOLE_JSON',
@@ -353,6 +365,65 @@ Note: `DEBUG_CONSOLE` is not recommended, as the outputs can be quite verbose, a
   options={[
     ['UID', 'number', 'The user ID.', '# UID=1000'],
     ['GID', 'number', 'The group ID.', '# GID=1000'],
+  ]}
+/>
+
+### OpenTelemetry Tracing
+
+LibreChat can emit backend OpenTelemetry traces for general API, HTTP, MongoDB, Mongoose, Redis, and outbound request visibility. Use Langfuse for GenAI-specific prompt/model observability.
+
+<OptionTable
+  options={[
+    [
+      'OTEL_TRACING_ENABLED',
+      'boolean',
+      'Enable backend OpenTelemetry tracing. Tracing remains disabled when OTEL_SDK_DISABLED=true.',
+      '# OTEL_TRACING_ENABLED=false',
+    ],
+    [
+      'OTEL_SERVICE_NAME',
+      'string',
+      'Service name reported to OpenTelemetry. Default: librechat.',
+      '# OTEL_SERVICE_NAME=librechat',
+    ],
+    [
+      'OTEL_SERVICE_VERSION',
+      'string',
+      'Service version reported to OpenTelemetry. Defaults to the package version when unset.',
+      '# OTEL_SERVICE_VERSION=',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_ENDPOINT',
+      'string',
+      'Base OTLP exporter endpoint.',
+      '# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+      'string',
+      'Trace-specific OTLP endpoint. Overrides the base endpoint for traces when set.',
+      '# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_HEADERS',
+      'string',
+      'Comma-separated OTLP exporter headers, such as authorization metadata.',
+      '# OTEL_EXPORTER_OTLP_HEADERS=',
+    ],
+    ['OTEL_TRACES_EXPORTER', 'string', 'Trace exporter selection.', '# OTEL_TRACES_EXPORTER=otlp'],
+    [
+      'OTEL_TRACES_SAMPLER',
+      'string',
+      'OpenTelemetry trace sampler. Default example: parentbased_always_on.',
+      '# OTEL_TRACES_SAMPLER=parentbased_always_on',
+    ],
+    ['OTEL_LOG_LEVEL', 'string', 'OpenTelemetry SDK log level.', '# OTEL_LOG_LEVEL=INFO'],
+    [
+      'OTEL_SDK_DISABLED',
+      'boolean',
+      'Disable the OpenTelemetry SDK even if tracing is enabled.',
+      '# OTEL_SDK_DISABLED=false',
+    ],
   ]}
 />
 
@@ -431,7 +502,12 @@ Uncomment `ENDPOINTS` to customize the available endpoints in LibreChat.
       'Comma-separated list of available endpoints.',
       '# ENDPOINTS=openAI,agents,assistants,gptPlugins,azureOpenAI,google,anthropic,bingAI,custom',
     ],
-    ['PROXY', 'string', 'Proxy setting for all endpoints.', 'PROXY='],
+    [
+      'PROXY',
+      'string',
+      'Outbound proxy for server-side requests, including endpoint calls and remote MCP HTTP/SSE transports. Remote MCP transports also honor HTTP_PROXY, HTTPS_PROXY, and NO_PROXY when PROXY is unset.',
+      'PROXY=',
+    ],
     ['TITLE_CONVO', 'boolean', 'Enable titling for all endpoints.', 'TITLE_CONVO=true'],
   ]}
 />
@@ -1754,6 +1830,12 @@ see: **[Authentication System](/docs/configuration/authentication)**
       'Refresh token expiry time.',
       'REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7',
     ],
+    [
+      'SESSION_COOKIE_SECURE',
+      'boolean',
+      'Overrides the Secure attribute for session/auth cookies. Leave unset to use the default NODE_ENV/DOMAIN_SERVER heuristic.',
+      '# SESSION_COOKIE_SECURE=false',
+    ],
   ]}
 />
 
@@ -1995,7 +2077,7 @@ For more information:
     [
       'OPENID_USE_PKCE',
       'boolean',
-      'Use PKCE (Proof Key for Code Exchange) for OpenID authentication.',
+      'Use PKCE (Proof Key for Code Exchange) for OpenID authentication. For public clients without a client secret, leave OPENID_CLIENT_SECRET empty and set this to true.',
       '# OPENID_USE_PKCE=true',
     ],
     [
@@ -2693,6 +2775,18 @@ Configure Model Context Protocol settings for enhanced server management and OAu
       'boolean',
       'Skip code challenge method validation. When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration',
       'MCP_SKIP_CODE_CHALLENGE_CHECK=false',
+    ],
+    [
+      'MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES',
+      'number',
+      'Maximum bytes allowed in a non-GET streamable HTTP MCP response before rejecting it. Set to 0 to disable. Default: 16777216 (16 MiB).',
+      '# MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES=16777216',
+    ],
+    [
+      'MCP_STREAMABLE_HTTP_MAX_LINE_BYTES',
+      'number',
+      'Maximum bytes allowed in one SSE line for non-GET streamable HTTP MCP responses. Set to 0 to disable. Default: 5242880 (5 MiB).',
+      '# MCP_STREAMABLE_HTTP_MAX_LINE_BYTES=5242880',
     ],
   ]}
 />

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -2736,6 +2736,12 @@ For detailed configuration and examples, see: **[Redis Configuration Guide](/doc
       '# USE_REDIS_CLUSTER="true"',
     ],
     [
+      'REDIS_CLUSTER_SAFE_DELETE',
+      'boolean',
+      'Delete Redis cache keys individually to avoid CROSSSLOT errors on single-endpoint managed Redis services that shard keys internally.',
+      '# REDIS_CLUSTER_SAFE_DELETE=true',
+    ],
+    [
       'REDIS_USERNAME',
       'string',
       'Redis username for authentication. Overrides username in URI if both provided.',
@@ -2796,6 +2802,7 @@ Notes:
 
 - When `USE_REDIS=true`, you must provide `REDIS_URI` or the application will throw an error.
 - For Redis Cluster mode, provide multiple URIs: `redis://node1:7001,redis://node2:7002,redis://node3:7003` (cluster mode is auto-detected).
+- For single-endpoint managed Redis services that shard keys internally, keep `USE_REDIS_CLUSTER=false` and set `REDIS_CLUSTER_SAFE_DELETE=true` if cache clears fail with `CROSSSLOT` errors.
 - Use `rediss://` protocol for TLS connections and set `REDIS_CA` if your CA is not publicly trusted.
 - `REDIS_KEY_PREFIX_VAR` and `REDIS_KEY_PREFIX` are mutually exclusive.
 - **AWS Elasticache with TLS**: Elasticache may need to use an alternate dnsLookup for TLS connections. Set `REDIS_USE_ALTERNATIVE_DNS_LOOKUP=true` if using Elasticache with TLS. See [ioredis documentation](https://www.npmjs.com/package/ioredis) for more details.

--- a/content/docs/configuration/librechat_yaml/example.mdx
+++ b/content/docs/configuration/librechat_yaml/example.mdx
@@ -10,7 +10,7 @@ icon: FileCode
 This example config includes all documented endpoints (Except Azure, LiteLLM, MLX, and Ollama, which all require additional configurations)
 
 ```yaml filename="librechat.yaml"
-version: 1.3.11
+version: 1.3.12
 
 cache: true
 
@@ -273,7 +273,7 @@ This example configuration file sets up LibreChat with detailed options across s
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.11
+version: 1.3.12
 
 # Cache settings: Set to true to enable caching
 cache: true

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -22,6 +22,7 @@ These are fields under `interface`:
   - `agents`
   - `temporaryChat`
   - `temporaryChatRetention`
+  - `retentionMode`
   - `autoSubmitFromUrl`
   - `customWelcome`
   - `runCode`
@@ -491,6 +492,7 @@ The `temporaryChatRetention` configuration allows you to customize how long temp
 ```yaml filename="interface / temporaryChatRetention"
 interface:
   temporaryChatRetention: 168  # Retain temporary chats for 7 days
+  retentionMode: "temporary"
 ```
 
 **Common Retention Periods:**
@@ -499,6 +501,30 @@ interface:
 - **168 hours**: `temporaryChatRetention: 168` (1 week)
 - **720 hours**: `temporaryChatRetention: 720` (30 days - default)
 - **8760 hours**: `temporaryChatRetention: 8760` (1 year - maximum)
+
+## retentionMode
+
+Controls which data receives retention deadlines.
+
+**Key:**
+<OptionTable
+  options={[
+    ['retentionMode', 'String', 'Set to "temporary" to apply retention only to temporary chats, or "all" to apply retention to all supported retained data, including persistent agent resource files.', 'retentionMode: "temporary"'],
+  ]}
+/>
+
+**Default:** `temporary`
+
+<Callout type="warning">
+`retentionMode: "all"` applies retention deadlines beyond temporary chats, including persistent agent resource files. Confirm your retention policy before enabling it.
+</Callout>
+
+**Example:**
+```yaml filename="interface / retentionMode"
+interface:
+  temporaryChatRetention: 168
+  retentionMode: "all"
+```
 
 ## autoSubmitFromUrl
 
@@ -622,7 +648,7 @@ Controls the global availability of file citations functionality. When disabled,
 
 > **Deprecated for permission management.** Seeds/globally gates the `FILE_CITATIONS` role permission at startup. Prefer the [Admin Panel](/docs/features/admin_panel) for managing citations permissions per role/group/user.
 
-**Note:** 
+**Note:**
 - This setting acts as a global toggle for the `FILE_CITATIONS` permission system-wide.
 - When set to `false`, no users will see file citations, even if they have been granted the permission through roles.
 - File citations require the `fileSearch` feature to be enabled.

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Interface Object Structure"
+title: 'Interface Object Structure'
 icon: LayoutDashboard
 ---
 
@@ -9,27 +9,28 @@ The `interface` object allows for customization of various user interface elemen
 
 These are fields under `interface`:
 
-  - `mcpServers`
-  - `privacyPolicy`
-  - `termsOfService`
-  - `modelSelect`
-  - `parameters`
-  - `presets`
-  - `prompts`
-  - `bookmarks`
-  - `memories`
-  - `multiConvo`
-  - `agents`
-  - `temporaryChat`
-  - `temporaryChatRetention`
-  - `autoSubmitFromUrl`
-  - `customWelcome`
-  - `runCode`
-  - `webSearch`
-  - `fileSearch`
-  - `fileCitations`
-  - `peoplePicker`
-  - `marketplace`
+- `mcpServers`
+- `privacyPolicy`
+- `termsOfService`
+- `modelSelect`
+- `parameters`
+- `presets`
+- `prompts`
+- `bookmarks`
+- `memories`
+- `multiConvo`
+- `agents`
+- `temporaryChat`
+- `temporaryChatRetention`
+- `retentionMode`
+- `autoSubmitFromUrl`
+- `customWelcome`
+- `runCode`
+- `webSearch`
+- `fileSearch`
+- `fileCitations`
+- `peoplePicker`
+- `marketplace`
 
 **Notes:**
 
@@ -43,6 +44,7 @@ Several fields below (`mcpServers`, `prompts`, `bookmarks`, `memories`, `multiCo
 For ongoing management, use the [**LibreChat Admin Panel**](/docs/features/admin_panel), which edits the permission matrix directly on each role (including custom roles). These YAML fields remain supported for bootstrapping a fresh instance or fully file-driven deployments, but should no longer be used as the primary way to manage feature permissions.
 
 See [Access Control](/docs/features/access_control) for the full permission model.
+
 </Callout>
 
 ## Example
@@ -50,22 +52,22 @@ See [Access Control](/docs/features/access_control) for the full permission mode
 ```yaml filename="interface"
 interface:
   mcpServers:
-    placeholder: "MCP Servers"
+    placeholder: 'MCP Servers'
     use: true
     create: true
     share: false
     public: false
     trustCheckbox:
-      label: "I trust this server"
-      subLabel: "Only enable servers you trust"
+      label: 'I trust this server'
+      subLabel: 'Only enable servers you trust'
   privacyPolicy:
-    externalUrl: "https://example.com/privacy"
+    externalUrl: 'https://example.com/privacy'
     openNewTab: true
   termsOfService:
-    externalUrl: "https://example.com/terms"
+    externalUrl: 'https://example.com/terms'
     openNewTab: true
     modalAcceptance: true
-    modalTitle: "Terms of Service"
+    modalTitle: 'Terms of Service'
     modalContent: |
       # Terms of Service
       ## Introduction
@@ -85,7 +87,7 @@ interface:
     create: true
     share: true
     public: false
-  customWelcome: "Hey {{user.name}}! Welcome to LibreChat"
+  customWelcome: 'Hey {{user.name}}! Welcome to LibreChat'
   runCode: true
   webSearch: true
   fileSearch: true
@@ -97,59 +99,115 @@ interface:
 > **Deprecated for permission management.** The `use`, `create`, `share`, and `public` sub-keys seed role permissions at startup. Prefer the [Admin Panel](/docs/features/admin_panel) for managing MCP server permissions per role/group/user. The `placeholder` and `trustCheckbox` sub-keys are unaffected.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['mcpServers', 'Object', 'Contains settings related to the MCP (Model Context Protocol) server selection interface and access control.', 'Allows for customization of the placeholder text, user permissions, and trust checkbox labels.'],
+    [
+      'mcpServers',
+      'Object',
+      'Contains settings related to the MCP (Model Context Protocol) server selection interface and access control.',
+      'Allows for customization of the placeholder text, user permissions, and trust checkbox labels.',
+    ],
   ]}
 />
 
 **Sub-keys:**
+
 <OptionTable
   options={[
-    ['placeholder', 'String', 'The placeholder text displayed in the MCP server selection dropdown when no server is selected.', 'MCP Servers'],
-    ['use', 'Boolean', 'Controls whether users have permission to use existing MCP servers.', 'true'],
-    ['create', 'Boolean', 'Controls whether users have permission to create new MCP servers.', 'true'],
-    ['share', 'Boolean', 'Controls whether users have permission to share MCP servers with other users.', 'false'],
-    ['public', 'Boolean', 'Controls whether users can share MCP servers publicly (visible to all users).', 'false'],
-    ['trustCheckbox', 'Object', 'Customizable labels for the trust checkbox in the MCP server dialog. Supports simple strings or language-keyed objects for internationalization.', 'See below'],
+    [
+      'placeholder',
+      'String',
+      'The placeholder text displayed in the MCP server selection dropdown when no server is selected.',
+      'MCP Servers',
+    ],
+    [
+      'use',
+      'Boolean',
+      'Controls whether users have permission to use existing MCP servers.',
+      'true',
+    ],
+    [
+      'create',
+      'Boolean',
+      'Controls whether users have permission to create new MCP servers.',
+      'true',
+    ],
+    [
+      'share',
+      'Boolean',
+      'Controls whether users have permission to share MCP servers with other users.',
+      'false',
+    ],
+    [
+      'public',
+      'Boolean',
+      'Controls whether users can share MCP servers publicly (visible to all users).',
+      'false',
+    ],
+    [
+      'trustCheckbox',
+      'Object',
+      'Customizable labels for the trust checkbox in the MCP server dialog. Supports simple strings or language-keyed objects for internationalization.',
+      'See below',
+    ],
   ]}
 />
 
 **trustCheckbox Sub-keys:**
+
 <OptionTable
   options={[
-    ['label', 'String or Object', 'The main label for the trust checkbox. Can be a simple string or a language-keyed object (e.g., { en: "I trust this server", es: "Confío en este servidor" }).', ''],
-    ['subLabel', 'String or Object', 'The sub-label (help text) for the trust checkbox. Can be a simple string or a language-keyed object for internationalization.', ''],
+    [
+      'label',
+      'String or Object',
+      'The main label for the trust checkbox. Can be a simple string or a language-keyed object (e.g., { en: "I trust this server", es: "Confío en este servidor" }).',
+      '',
+    ],
+    [
+      'subLabel',
+      'String or Object',
+      'The sub-label (help text) for the trust checkbox. Can be a simple string or a language-keyed object for internationalization.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml filename="interface / mcpServers"
 interface:
   mcpServers:
-    placeholder: "Select MCP Server"
+    placeholder: 'Select MCP Server'
     use: true
     create: true
     share: false
     trustCheckbox:
       label:
-        en: "I trust this server"
-        es: "Confío en este servidor"
+        en: 'I trust this server'
+        es: 'Confío en este servidor'
       subLabel:
-        en: "Only enable servers you trust"
-        es: "Solo habilite servidores en los que confíe"
+        en: 'Only enable servers you trust'
+        es: 'Solo habilite servidores en los que confíe'
 ```
 
 ## privacyPolicy
 
 **Key:**
+
 <OptionTable
   options={[
-    ['privacyPolicy', 'Object', 'Contains settings related to the privacy policy link provided in the user interface.', 'Allows for the specification of a custom URL and the option to open it in a new tab.'],
+    [
+      'privacyPolicy',
+      'Object',
+      'Contains settings related to the privacy policy link provided in the user interface.',
+      'Allows for the specification of a custom URL and the option to open it in a new tab.',
+    ],
   ]}
 />
 
 **Sub-keys:**
+
 <OptionTable
   options={[
     ['externalUrl', 'String (URL)', 'The URL pointing to the privacy policy document.', ''],
@@ -160,39 +218,74 @@ interface:
 ## termsOfService
 
 **Key:**
+
 <OptionTable
   options={[
-    ['termsOfService', 'Object', 'Contains settings related to the terms of service link provided in the user interface.', 'Allows for the specification of a custom URL and the option to open it in a new tab, as well as a modal acceptance dialog for the terms of service.'],
+    [
+      'termsOfService',
+      'Object',
+      'Contains settings related to the terms of service link provided in the user interface.',
+      'Allows for the specification of a custom URL and the option to open it in a new tab, as well as a modal acceptance dialog for the terms of service.',
+    ],
   ]}
 />
 
 **Sub-keys:**
+
 <OptionTable
   options={[
-    ['externalUrl', 'String (URL)', 'The URL pointing to the terms of service document.', 'https://librechat.ai/tos'],
+    [
+      'externalUrl',
+      'String (URL)',
+      'The URL pointing to the terms of service document.',
+      'https://librechat.ai/tos',
+    ],
     ['openNewTab', 'Boolean', 'Specifies whether the link should open in a new tab.', 'true'],
-    ['modalAcceptance', 'Boolean', 'Specifies whether to show a modal terms and conditions dialog for users to accept in order to be able to use LibreChat.', 'true'],
-    ['modalTitle', 'String', 'Specifies a custom title for the modal terms and conditions dialog (optional).', 'Terms of Service'],
-    ['modalContent', 'String', 'Specifies the content of the modal terms and conditions dialog in MarkDown format.', 'See librechat.yaml.example for how to correctly format the multi-line parameter.'],
+    [
+      'modalAcceptance',
+      'Boolean',
+      'Specifies whether to show a modal terms and conditions dialog for users to accept in order to be able to use LibreChat.',
+      'true',
+    ],
+    [
+      'modalTitle',
+      'String',
+      'Specifies a custom title for the modal terms and conditions dialog (optional).',
+      'Terms of Service',
+    ],
+    [
+      'modalContent',
+      'String',
+      'Specifies the content of the modal terms and conditions dialog in MarkDown format.',
+      'See librechat.yaml.example for how to correctly format the multi-line parameter.',
+    ],
   ]}
 />
 
 ## modelSelect
 
 **Key:**
+
 <OptionTable
   options={[
-    ['modelSelect', 'Boolean', 'Determines whether the model selection feature is available in the UI.', 'Enabling this feature allows users to select different models directly from the interface.'],
+    [
+      'modelSelect',
+      'Boolean',
+      'Determines whether the model selection feature is available in the UI.',
+      'Enabling this feature allows users to select different models directly from the interface.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Notes:**
+
 - This is required to be `true` if using [`modelSpecs.addedEndpoints`](/docs/configuration/librechat_yaml/object_structure/model_specs#addedendpoints).
 - If `modelSpecs.addedEndpoints` is used and `interface.modelSelect` is not explicitly set, it defaults to `true`.
 
 **Example:**
+
 ```yaml filename="interface / modelSelect"
 interface:
   modelSelect: true
@@ -201,15 +294,22 @@ interface:
 ## parameters
 
 **Key:**
+
 <OptionTable
   options={[
-    ['parameters', 'Boolean', 'Toggles the visibility of parameter configuration options within the interface.', 'This setting is crucial for users who need to adjust parameters for specific functionalities within the application.'],
+    [
+      'parameters',
+      'Boolean',
+      'Toggles the visibility of parameter configuration options within the interface.',
+      'This setting is crucial for users who need to adjust parameters for specific functionalities within the application.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / parameters"
 interface:
   parameters: false
@@ -218,15 +318,22 @@ interface:
 ## presets
 
 **Key:**
+
 <OptionTable
   options={[
-    ['presets', 'Boolean', 'Enables or disables the use of presets in the application\'s UI.', 'Presets can simplify user interactions by providing pre-configured settings or operations, enhancing user experience and efficiency.'],
+    [
+      'presets',
+      'Boolean',
+      "Enables or disables the use of presets in the application's UI.",
+      'Presets can simplify user interactions by providing pre-configured settings or operations, enhancing user experience and efficiency.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / presets"
 interface:
   presets: true
@@ -237,9 +344,15 @@ interface:
 > **Deprecated for permission management.** Seeds the `PROMPTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel) for managing prompt permissions per role/group/user.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['prompts', 'Boolean or Object', 'Controls prompt-related features for all users. Can be a boolean for simple enable/disable, or an object for granular control over use, creation, sharing, and public visibility.', 'When set to `false`, users will not have access to create, edit, or use custom prompts.'],
+    [
+      'prompts',
+      'Boolean or Object',
+      'Controls prompt-related features for all users. Can be a boolean for simple enable/disable, or an object for granular control over use, creation, sharing, and public visibility.',
+      'When set to `false`, users will not have access to create, edit, or use custom prompts.',
+    ],
   ]}
 />
 
@@ -254,31 +367,45 @@ interface:
 When using the object structure:
 
 **Sub-keys:**
+
 <OptionTable
   options={[
     ['use', 'Boolean', 'Controls whether users can use prompts.', 'true'],
     ['create', 'Boolean', 'Controls whether users can create new prompts.', 'true'],
-    ['share', 'Boolean', 'Controls whether users can share prompts with specific users/groups.', 'false'],
-    ['public', 'Boolean', 'Controls whether users can share prompts publicly (visible to all users).', 'false'],
+    [
+      'share',
+      'Boolean',
+      'Controls whether users can share prompts with specific users/groups.',
+      'false',
+    ],
+    [
+      'public',
+      'Boolean',
+      'Controls whether users can share prompts publicly (visible to all users).',
+      'false',
+    ],
   ]}
 />
 
 **Example (boolean - simple feature toggle):**
+
 ```yaml filename="interface / prompts (boolean)"
 interface:
-  prompts: true  # Only updates USE; create/share/public remain unchanged
+  prompts: true # Only updates USE; create/share/public remain unchanged
 ```
 
 **Example (object - granular control):**
+
 ```yaml filename="interface / prompts (object)"
 interface:
   prompts:
     use: true
-    create: false  # Disable creation while allowing use
+    create: false # Disable creation while allowing use
     # share and public not specified - preserves existing values
 ```
 
 **Example (object - full control):**
+
 ```yaml filename="interface / prompts (object)"
 interface:
   prompts:
@@ -293,15 +420,22 @@ interface:
 > **Deprecated for permission management.** Seeds the `BOOKMARKS` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
-    ['bookmarks', 'Boolean', 'Enables or disables all bookmarks-related features for all users.', 'When disabled, users will not be able to create, manage, or access bookmarks within the application.'],
+    [
+      'bookmarks',
+      'Boolean',
+      'Enables or disables all bookmarks-related features for all users.',
+      'When disabled, users will not be able to create, manage, or access bookmarks within the application.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / bookmarks"
 interface:
   bookmarks: true
@@ -312,9 +446,15 @@ interface:
 > **Deprecated for permission management.** Seeds the `MEMORIES` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel). Note this toggle is separate from the [`memory`](/docs/configuration/librechat_yaml/object_structure/memory) behavior configuration.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['memories', 'Boolean', 'Enables or disables the memories feature for all users in the interface.', 'When disabled, users will not have access to the memories panel or memory-related features.'],
+    [
+      'memories',
+      'Boolean',
+      'Enables or disables the memories feature for all users in the interface.',
+      'When disabled, users will not have access to the memories panel or memory-related features.',
+    ],
   ]}
 />
 
@@ -323,6 +463,7 @@ interface:
 **Note:** This controls the UI visibility of the memories feature. For detailed memory behavior configuration (token limits, personalization, agent settings), see the [Memory Configuration](/docs/configuration/librechat_yaml/object_structure/memory).
 
 **Example:**
+
 ```yaml filename="interface / memories"
 interface:
   memories: true
@@ -333,15 +474,22 @@ interface:
 > **Deprecated for permission management.** Seeds the `MULTI_CONVO` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
-    ['multiConvo', 'Boolean', 'Enables or disables all "multiConvo", AKA multiple response streaming, related features for all users.', 'When disabled, users will not be able to stream responses from 2 AI models at the same time.'],
+    [
+      'multiConvo',
+      'Boolean',
+      'Enables or disables all "multiConvo", AKA multiple response streaming, related features for all users.',
+      'When disabled, users will not be able to stream responses from 2 AI models at the same time.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / multiConvo"
 interface:
   multiConvo: true
@@ -354,9 +502,15 @@ More info on [Agents](/docs/features/agents)
 > **Deprecated for permission management.** Seeds the `AGENTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel) for managing agent permissions per role/group/user.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['agents', 'Boolean or Object', 'Controls agent-related features for all users. Can be a boolean for simple enable/disable, or an object for granular control over use, creation, sharing, and public visibility.', 'When set to `false`, users will not have access to agents.'],
+    [
+      'agents',
+      'Boolean or Object',
+      'Controls agent-related features for all users. Can be a boolean for simple enable/disable, or an object for granular control over use, creation, sharing, and public visibility.',
+      'When set to `false`, users will not have access to agents.',
+    ],
   ]}
 />
 
@@ -371,31 +525,45 @@ More info on [Agents](/docs/features/agents)
 When using the object structure:
 
 **Sub-keys:**
+
 <OptionTable
   options={[
     ['use', 'Boolean', 'Controls whether users can use agents.', 'true'],
     ['create', 'Boolean', 'Controls whether users can create new agents.', 'true'],
-    ['share', 'Boolean', 'Controls whether users can share agents with specific users/groups.', 'false'],
-    ['public', 'Boolean', 'Controls whether users can share agents publicly (visible to all users).', 'false'],
+    [
+      'share',
+      'Boolean',
+      'Controls whether users can share agents with specific users/groups.',
+      'false',
+    ],
+    [
+      'public',
+      'Boolean',
+      'Controls whether users can share agents publicly (visible to all users).',
+      'false',
+    ],
   ]}
 />
 
 **Example (boolean - simple feature toggle):**
+
 ```yaml filename="interface / agents (boolean)"
 interface:
-  agents: true  # Only updates USE; create/share/public remain unchanged
+  agents: true # Only updates USE; create/share/public remain unchanged
 ```
 
 **Example (object - granular control):**
+
 ```yaml filename="interface / agents (object)"
 interface:
   agents:
     use: true
-    create: false  # Disable creation while allowing use
+    create: false # Disable creation while allowing use
     # share and public not specified - preserves existing values
 ```
 
 **Example (object - full control):**
+
 ```yaml filename="interface / agents (object)"
 interface:
   agents:
@@ -412,13 +580,20 @@ Controls access to the Agents API (OpenAI-compatible and Open Responses API endp
 > **Deprecated for permission management.** Seeds the `REMOTE_AGENTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
-    ['remoteAgents', 'Object', 'Configuration for remote agent API access control. All fields default to `false`.', ''],
+    [
+      'remoteAgents',
+      'Object',
+      'Configuration for remote agent API access control. All fields default to `false`.',
+      '',
+    ],
   ]}
 />
 
 **Sub-keys:**
+
 <OptionTable
   options={[
     ['use', 'Boolean', 'Controls whether users can access the remote agents API.', 'false'],
@@ -431,6 +606,7 @@ Controls access to the Agents API (OpenAI-compatible and Open Responses API endp
 **Default:** All fields default to `false` (disabled).
 
 **Example:**
+
 ```yaml filename="interface / remoteAgents"
 interface:
   remoteAgents:
@@ -449,9 +625,15 @@ Controls whether the temporary chat feature is available to users. Temporary cha
 > **Deprecated for permission management.** Seeds the `TEMPORARY_CHAT` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel). `temporaryChatRetention` below is not a permission and remains the recommended way to configure retention.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['temporaryChat', 'Boolean', 'Enables or disables the temporary chat feature.', 'When set to `false`, users will not see the option to start temporary chats.'],
+    [
+      'temporaryChat',
+      'Boolean',
+      'Enables or disables the temporary chat feature.',
+      'When set to `false`, users will not see the option to start temporary chats.',
+    ],
   ]}
 />
 
@@ -460,6 +642,7 @@ Controls whether the temporary chat feature is available to users. Temporary cha
 **Note:** The retention period for temporary chats can be configured using `temporaryChatRetention`.
 
 **Example:**
+
 ```yaml filename="interface / temporaryChat"
 interface:
   temporaryChat: true
@@ -470,35 +653,83 @@ interface:
 The `temporaryChatRetention` configuration allows you to customize how long temporary chats are retained before being automatically deleted.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['temporaryChatRetention', 'Number', 'Sets the retention period for temporary chats in hours.', 'temporaryChatRetention: 168'],
+    [
+      'temporaryChatRetention',
+      'Number',
+      'Sets the retention period for temporary chats in hours.',
+      'temporaryChatRetention: 168',
+    ],
   ]}
 />
 
 **Validation Rules:**
+
 - **Minimum**: 1 hour (prevents immediate deletion)
 - **Maximum**: 8760 hours (1 year maximum retention)
 - **Default**: 720 hours (30 days)
 
 **Configuration Methods:**
+
 1. **LibreChat.yaml** (recommended): `interface.temporaryChatRetention: 168`
 2. **Environment Variable** (deprecated): `TEMP_CHAT_RETENTION_HOURS=168`
 
 > **Note:** The environment variable `TEMP_CHAT_RETENTION_HOURS` is deprecated. Please use the `interface.temporaryChatRetention` config option in `librechat.yaml` instead. The config file value takes precedence over the environment variable.
 
 **Example:**
+
 ```yaml filename="interface / temporaryChatRetention"
 interface:
-  temporaryChatRetention: 168  # Retain temporary chats for 7 days
+  temporaryChatRetention: 168 # Retain temporary chats for 7 days
+  retentionMode: 'temporary'
 ```
 
 **Common Retention Periods:**
+
 - **1 hour**: `temporaryChatRetention: 1` (minimal retention)
 - **24 hours**: `temporaryChatRetention: 24` (1 day)
 - **168 hours**: `temporaryChatRetention: 168` (1 week)
 - **720 hours**: `temporaryChatRetention: 720` (30 days - default)
 - **8760 hours**: `temporaryChatRetention: 8760` (1 year - maximum)
+
+## retentionMode
+
+Controls which data receives retention deadlines.
+
+**Key:**
+
+<OptionTable
+  options={[
+    [
+      'retentionMode',
+      'String',
+      'Set to "temporary" to apply retention only to temporary chats, or "all" to apply retention to all supported conversation data.',
+      'retentionMode: "temporary"',
+    ],
+  ]}
+/>
+
+**Default:** `"temporary"`
+
+**Allowed values:**
+
+- `"temporary"`: only temporary chats receive retention deadlines.
+- `"all"`: all supported conversation data receives retention deadlines.
+
+<Callout type="warning" title="Switching modes">
+  Before switching from `"all"` back to `"temporary"`, remove retention deadlines from non-temporary
+  data that should stop expiring.
+</Callout>
+
+**Example:**
+
+```yaml filename="interface / retentionMode"
+interface:
+  temporaryChatRetention: 168
+  retentionMode: 'all'
+```
 
 ## autoSubmitFromUrl
 
@@ -509,20 +740,28 @@ When `/c/new?prompt=…&submit=true` is opened by an authenticated user, LibreCh
 For deployments where users may receive crafted links from external sources — and where memory- or tool-enabled models could leak sensitive context if a prompt-injection payload reaches the model — operators can disable auto-submission. With the flag set to `false`, the prompt is still pre-filled in the composer but the user must press **Send** explicitly.
 
 **Key:**
+
 <OptionTable
   options={[
-    ['autoSubmitFromUrl', 'Boolean', 'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model.', 'When `false`, the prompt is pre-filled in the composer but not submitted.'],
+    [
+      'autoSubmitFromUrl',
+      'Boolean',
+      'Controls whether `/c/new?prompt=…&submit=true` auto-submits to the model.',
+      'When `false`, the prompt is pre-filled in the composer but not submitted.',
+    ],
   ]}
 />
 
 **Default:** `true` (existing behavior is preserved unless explicitly disabled).
 
 **Notes:**
+
 - This setting does not affect URL-driven model spec selection or other URL-driven settings — only the auto-submission step.
 - The query parameter accepts both `prompt` and `q` as the prompt source, with `prompt` taking precedence. `submit=true` is the trigger.
 - Recommended for instances handling sensitive memory or tool data, where a 1-click prompt-injection vector should require explicit user confirmation.
 
 **Example:**
+
 ```yaml filename="interface / autoSubmitFromUrl"
 interface:
   autoSubmitFromUrl: false
@@ -531,18 +770,24 @@ interface:
 ## customWelcome
 
 **Key:**
+
 <OptionTable
   options={[
-    ['customWelcome', 'String', 'Allows administrators to define a custom welcome message for the chat interface, with the option to personalize it using the {{user.name}} parameter.'],
+    [
+      'customWelcome',
+      'String',
+      'Allows administrators to define a custom welcome message for the chat interface, with the option to personalize it using the {{user.name}} parameter.',
+    ],
   ]}
 />
 
 **Default:** _None (if not specified, a default greeting is used)_
 
 **Example:**
+
 ```yaml filename="interface / customWelcome"
 interface:
-    customWelcome: "Hey {{user.name}}! Welcome to LibreChat"
+  customWelcome: 'Hey {{user.name}}! Welcome to LibreChat'
 ```
 
 **Note:** You can use `{{user.name}}` within the `customWelcome` message to dynamically insert the user's name for a personalized greeting experience.
@@ -556,6 +801,7 @@ Enables/disables the "Run Code" button for Markdown Code Blocks. More info on th
 > **Deprecated for permission management.** Seeds the `RUN_CODE` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
     ['runCode', 'Boolean', 'Enables or disables the "Run Code" button for Markdown Code Blocks.'],
@@ -565,6 +811,7 @@ Enables/disables the "Run Code" button for Markdown Code Blocks. More info on th
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / runCode"
 interface:
   runCode: true
@@ -579,6 +826,7 @@ Enables/disables the web search button in the chat interface. More info on [Web 
 > **Deprecated for permission management.** Seeds the `WEB_SEARCH` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
     ['webSearch', 'Boolean', 'Enables or disables the web search button in the chat interface.'],
@@ -588,6 +836,7 @@ Enables/disables the web search button in the chat interface. More info on [Web 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / webSearch"
 interface:
   webSearch: true
@@ -602,6 +851,7 @@ Enables/disables the file search (for RAG API usage via tool) button in the chat
 > **Deprecated for permission management.** Seeds the `FILE_SEARCH` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
     ['fileSearch', 'Boolean', 'Enables or disables the file search button in the chat interface.'],
@@ -611,6 +861,7 @@ Enables/disables the file search (for RAG API usage via tool) button in the chat
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / fileSearch"
 interface:
   fileSearch: true
@@ -622,22 +873,29 @@ Controls the global availability of file citations functionality. When disabled,
 
 > **Deprecated for permission management.** Seeds/globally gates the `FILE_CITATIONS` role permission at startup. Prefer the [Admin Panel](/docs/features/admin_panel) for managing citations permissions per role/group/user.
 
-**Note:** 
+**Note:**
+
 - This setting acts as a global toggle for the `FILE_CITATIONS` permission system-wide.
 - When set to `false`, no users will see file citations, even if they have been granted the permission through roles.
 - File citations require the `fileSearch` feature to be enabled.
 - When using agents with file search capability, citation behavior (quantity and quality) can be configured through the [Agents endpoint configuration](/docs/configuration/librechat_yaml/object_structure/agents#file-citation-configuration-examples).
 
 **Key:**
+
 <OptionTable
   options={[
-    ['fileCitations', 'Boolean', 'Globally enables or disables the FILE_CITATIONS permission for all users, controlling whether file search results can include source citations.'],
+    [
+      'fileCitations',
+      'Boolean',
+      'Globally enables or disables the FILE_CITATIONS permission for all users, controlling whether file search results can include source citations.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="interface / fileCitations"
 interface:
   fileCitations: true
@@ -650,9 +908,14 @@ Controls which principal types (users, groups, roles) are available for selectio
 > **Deprecated for permission management.** Seeds the `PEOPLE_PICKER` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
   options={[
-    ['peoplePicker', 'Object', 'Configuration for which principal types are available in the people picker interface.'],
+    [
+      'peoplePicker',
+      'Object',
+      'Configuration for which principal types are available in the people picker interface.',
+    ],
   ]}
 />
 
@@ -667,6 +930,7 @@ Controls which principal types (users, groups, roles) are available for selectio
 />
 
 **Default:**
+
 ```yaml
 peoplePicker:
   users: true
@@ -675,12 +939,13 @@ peoplePicker:
 ```
 
 **Example:**
+
 ```yaml filename="interface / peoplePicker"
 interface:
   peoplePicker:
     users: true
     groups: true
-    roles: false  # Disable role selection in people picker
+    roles: false # Disable role selection in people picker
 ```
 
 ## marketplace
@@ -690,29 +955,28 @@ Enables/disables access to the Agent Marketplace.
 > **Deprecated for permission management.** Seeds the `MARKETPLACE` role permission at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 
 **Key:**
+
 <OptionTable
-  options={[
-    ['marketplace', 'Object', 'Configuration for Agent Marketplace access control.'],
-  ]}
+  options={[['marketplace', 'Object', 'Configuration for Agent Marketplace access control.']]}
 />
 
 **Sub-keys:**
 
 <OptionTable
-  options={[
-    ['use', 'Boolean', 'Enables or disables marketplace access. Default: false'],
-  ]}
+  options={[['use', 'Boolean', 'Enables or disables marketplace access. Default: false']]}
 />
 
 **Default:**
+
 ```yaml
 marketplace:
   use: false
 ```
 
 **Example:**
+
 ```yaml filename="interface / marketplace"
 interface:
   marketplace:
-    use: true  # Enable marketplace access
+    use: true # Enable marketplace access
 ```

--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -44,6 +44,7 @@ mcpServers:
   streamable-http-server:
     type: streamable-http
     url: https://example.com/api/
+    proxy: "${MCP_PROXY_URL}"
   per-user-credentials-example:
     type: streamable-http
     url: "https://example.com/api/"
@@ -84,6 +85,7 @@ mcpServers:
     ['command', 'String', '(For `stdio` type) The command or executable to run to start the MCP server.', 'command: "npx"'],
     ['args', 'Array of Strings', '(For `stdio` type) Command line arguments to pass to the `command`.', 'args: ["-y", "@modelcontextprotocol/server-puppeteer"]'],
     ['url', 'String', '(For `websocket`, `streamable-http`, or `sse` type) The URL to connect to the MCP server.', 'url: "http://localhost:3001/sse"'],
+    ['proxy', 'String', '(Optional, for `sse` and `streamable-http` types) Outbound proxy URL for this remote MCP server. Supports `http://`, `https://`, `socks://`, and `socks5://` URLs.', 'proxy: "${MCP_PROXY_URL}"'],
     ['headers', 'Object', '(Optional, for `sse` and `streamable-http` types) Custom headers to send with the request. Supports dynamic user field substitution with `{{LIBRECHAT_USER_*}}` placeholders and environment variables with `${ENV_VAR}`.', 'headers:\n  X-User-ID: "{{LIBRECHAT_USER_ID}}"\n  X-API-Key: "${SOME_API_KEY}"'],
     ['apiKey', 'Object', '(Optional, for `sse` and `streamable-http` types) API key authentication configuration for the MCP server.', 'See apiKey section below'],
     ['iconPath', 'String', '(Optional) Defines the tool\'s display icon shown in the tool selection dialog.', 'iconPath: "/path/to/icon.svg"'],
@@ -149,6 +151,21 @@ mcpServers:
   - For `sse` type, the URL must start with `http://` or `https://`.
   - For `streamable-http` type, the URL must start with `http://` or `https://`.
   - For `websocket` type, the URL must start with `ws://` or `wss://`.
+
+#### `proxy`
+
+- **Type:** String (Optional, for `sse` and `streamable-http` types)
+- **Description:** Outbound proxy URL for this remote MCP server. The value can reference environment variables with `${ENV_VAR}`.
+- **Supported protocols:** `http://`, `https://`, `socks://`, and `socks5://`
+- **Security note:** `proxy` is admin-controlled. It resolves environment variables, but does not resolve user-controlled placeholders such as `{{LIBRECHAT_USER_ID}}` or `customUserVars`.
+- **Example:**
+  ```yaml
+  mcpServers:
+    remote-api:
+      type: streamable-http
+      url: https://api.example.com/mcp
+      proxy: "${MCP_PROXY_URL}"
+  ```
 
 #### `headers`
 
@@ -254,13 +271,13 @@ mcpServers:
   ```yaml
   # Use server-provided instructions
   serverInstructions: true
-  
+
   # Use custom instructions
   serverInstructions: |
     When using this filesystem server:
     1. Always use absolute paths for file operations
     2. Check file permissions before attempting write operations
-  
+
   # Explicitly disable instructions
   serverInstructions: false
   ```
@@ -350,7 +367,7 @@ mcpServers:
 - **Description:** OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow before the MCP server can be used. If no client id & client secret is provided, Dynamic Client Registration (DCR) will be used.
 - **Required Subkeys:**
   - `authorization_url`: String - The OAuth authorization endpoint URL
-  - `token_url`: String - The OAuth token endpoint URL  
+  - `token_url`: String - The OAuth token endpoint URL
   - `client_id`: String - OAuth client identifier
   - `client_secret`: String - OAuth client secret
   - `redirect_uri`: String - [OAuth redirect URI](/docs/features/mcp#oauth-callback-url) (eg. `http://localhost:3080/api/mcp/${serverName}/oauth/callback`)
@@ -426,7 +443,7 @@ mcpServers:
     type: streamable-http
     url: http://172.24.1.165:8000/mcp
     timeout: 120000
-  
+
   test-mcp:
     type: streamable-http
     url: http://mcp-prod:8001/mcp

--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCP Servers Object Structure"
+title: 'MCP Servers Object Structure'
 icon: Blocks
 ---
 
@@ -16,22 +16,22 @@ mcpServers:
     url: https://mcp.composio.dev/googlesheets/some-endpoint
     requiresOAuth: true
     headers:
-      X-User-ID: "{{LIBRECHAT_USER_ID}}"
-      X-API-Key: "${SOME_API_KEY}"
-    serverInstructions: true  # Use server-provided instructions
+      X-User-ID: '{{LIBRECHAT_USER_ID}}'
+      X-API-Key: '${SOME_API_KEY}'
+    serverInstructions: true # Use server-provided instructions
   puppeteer:
     type: stdio
     command: npx
     args:
       - -y
-      - "@modelcontextprotocol/server-puppeteer"
-    serverInstructions: "Do not access any local files or local/internal IP addresses"
+      - '@modelcontextprotocol/server-puppeteer'
+    serverInstructions: 'Do not access any local files or local/internal IP addresses'
   filesystem:
     # type: stdio
     command: npx
     args:
       - -y
-      - "@modelcontextprotocol/server-filesystem"
+      - '@modelcontextprotocol/server-filesystem'
       - /home/user/LibreChat/
     iconPath: /home/user/LibreChat/client/public/assets/logo.svg
     # The “wrench” icon shows up if no icon is provided as it is the default rendering.
@@ -39,19 +39,20 @@ mcpServers:
     command: npx
     args:
       - -y
-      - "mcp-obsidian"
+      - 'mcp-obsidian'
       - /path/to/obsidian/vault
   streamable-http-server:
     type: streamable-http
     url: https://example.com/api/
+    proxy: '${MCP_PROXY_URL}'
   per-user-credentials-example:
     type: streamable-http
-    url: "https://example.com/api/"
+    url: 'https://example.com/api/'
     headers:
-      X-Auth-Token: "{{MY_SERVICE_API_KEY}}"
+      X-Auth-Token: '{{MY_SERVICE_API_KEY}}'
     customUserVars:
       MY_SERVICE_API_KEY:
-        title: "My Service API Key"
+        title: 'My Service API Key'
         description: "Enter your personal API key for the service. You can generate one at <a href='https://myservice.example.com/developer/keys' target='_blank'>Service Developer Portal</a>."
   oauth-example:
     type: streamable-http
@@ -62,15 +63,21 @@ mcpServers:
       client_id: your_client_id
       client_secret: your_client_secret
       redirect_uri: http://localhost:3080/api/mcp/oauth-example/oauth/callback
-      scope: "read execute"
+      scope: 'read execute'
 ```
 
 ## `<serverName>`
 
 **Key:**
+
 <OptionTable
   options={[
-    ['<serverName>', 'Object', 'Each key under `mcpServers` represents an individual MCP server configuration, identified by a unique name. This name is used to reference the server configuration within the application.', ''],
+    [
+      '<serverName>',
+      'Object',
+      'Each key under `mcpServers` represents an individual MCP server configuration, identified by a unique name. This name is used to reference the server configuration within the application.',
+      '',
+    ],
   ]}
 />
 
@@ -78,25 +85,126 @@ mcpServers:
 
 <OptionTable
   options={[
-    ['title', 'String', '(Optional) Custom display name for the MCP server in the UI. If not specified, the server key name is used.', 'title: "My Custom Server"'],
-    ['description', 'String', '(Optional) Description of the MCP server, displayed in the UI to help users understand its purpose.', 'description: "Provides file system access"'],
-    ['type', 'String', 'Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, `"streamable-http"`, or `"sse"`. If omitted, it defaults based on the presence and format of `url` or `command`.', 'type: "stdio"'],
-    ['command', 'String', '(For `stdio` type) The command or executable to run to start the MCP server.', 'command: "npx"'],
-    ['args', 'Array of Strings', '(For `stdio` type) Command line arguments to pass to the `command`.', 'args: ["-y", "@modelcontextprotocol/server-puppeteer"]'],
-    ['url', 'String', '(For `websocket`, `streamable-http`, or `sse` type) The URL to connect to the MCP server.', 'url: "http://localhost:3001/sse"'],
-    ['headers', 'Object', '(Optional, for `sse` and `streamable-http` types) Custom headers to send with the request. Supports dynamic user field substitution with `{{LIBRECHAT_USER_*}}` placeholders and environment variables with `${ENV_VAR}`.', 'headers:\n  X-User-ID: "{{LIBRECHAT_USER_ID}}"\n  X-API-Key: "${SOME_API_KEY}"'],
-    ['apiKey', 'Object', '(Optional, for `sse` and `streamable-http` types) API key authentication configuration for the MCP server.', 'See apiKey section below'],
-    ['iconPath', 'String', '(Optional) Defines the tool\'s display icon shown in the tool selection dialog.', 'iconPath: "/path/to/icon.svg"'],
-    ['chatMenu', 'Boolean', '(Optional) When set to `false`, excludes the MCP server from the chatarea dropdown (MCPSelect) for quick and easy access. Defaults to `true`.', 'chatMenu: false'],
-    ['serverInstructions', 'Boolean or String', '(Optional) Controls how MCP server instructions are injected into agent context. Server instructions provide high-level usage guidance for the entire MCP server, complementing individual tool descriptions.', 'serverInstructions: true\n# or\nserverInstructions: "Custom instructions"'],
-    ['timeout', 'Integer', '(Optional) Timeout in milliseconds for MCP server requests. Must be a non-negative integer.', 'timeout: 30000'],
-    ['initTimeout', 'Integer', '(Optional) Timeout in milliseconds for MCP server initialization. Must be a non-negative integer.', 'initTimeout: 10000'],
-    ['env', 'Object', '(Optional, `stdio` type only) Environment variables to use when spawning the process.', 'env:\n  NODE_ENV: "production"'],
-    ['requiresOAuth', 'Boolean', '(Optional, `sse` type only) Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it\'s best to set this value explicitly if you know whether the server requires OAuth or not.', 'requiresOAuth: true'],
-    ['stderr', 'String or Integer', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Options: `"pipe"`, `"ignore"`, `"inherit"`, or a non-negative integer (file descriptor). Defaults to `"inherit"`.', 'stderr: "inherit"'],
-    ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
-    ['oauth', 'Object', '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.', 'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"'],
-    ['startup', 'Boolean', '(Optional) When set to false, this MCP server will not be connected at application startup.', 'startup: false'],
+    [
+      'title',
+      'String',
+      '(Optional) Custom display name for the MCP server in the UI. If not specified, the server key name is used.',
+      'title: "My Custom Server"',
+    ],
+    [
+      'description',
+      'String',
+      '(Optional) Description of the MCP server, displayed in the UI to help users understand its purpose.',
+      'description: "Provides file system access"',
+    ],
+    [
+      'type',
+      'String',
+      'Specifies the connection type to the MCP server. Valid options are `"stdio"`, `"websocket"`, `"streamable-http"`, or `"sse"`. If omitted, it defaults based on the presence and format of `url` or `command`.',
+      'type: "stdio"',
+    ],
+    [
+      'command',
+      'String',
+      '(For `stdio` type) The command or executable to run to start the MCP server.',
+      'command: "npx"',
+    ],
+    [
+      'args',
+      'Array of Strings',
+      '(For `stdio` type) Command line arguments to pass to the `command`.',
+      'args: ["-y", "@modelcontextprotocol/server-puppeteer"]',
+    ],
+    [
+      'url',
+      'String',
+      '(For `websocket`, `streamable-http`, or `sse` type) The URL to connect to the MCP server.',
+      'url: "http://localhost:3001/sse"',
+    ],
+    [
+      'proxy',
+      'String',
+      '(Optional, for `sse` and `streamable-http` types) Outbound proxy URL for this remote MCP server. Supports `http://`, `https://`, `socks://`, and `socks5://` URLs.',
+      'proxy: "${MCP_PROXY_URL}"',
+    ],
+    [
+      'headers',
+      'Object',
+      '(Optional, for `sse` and `streamable-http` types) Custom headers to send with the request. Supports dynamic user field substitution with `{{LIBRECHAT_USER_*}}` placeholders and environment variables with `${ENV_VAR}`.',
+      'headers:\n  X-User-ID: "{{LIBRECHAT_USER_ID}}"\n  X-API-Key: "${SOME_API_KEY}"',
+    ],
+    [
+      'apiKey',
+      'Object',
+      '(Optional, for `sse` and `streamable-http` types) API key authentication configuration for the MCP server.',
+      'See apiKey section below',
+    ],
+    [
+      'iconPath',
+      'String',
+      "(Optional) Defines the tool's display icon shown in the tool selection dialog.",
+      'iconPath: "/path/to/icon.svg"',
+    ],
+    [
+      'chatMenu',
+      'Boolean',
+      '(Optional) When set to `false`, excludes the MCP server from the chatarea dropdown (MCPSelect) for quick and easy access. Defaults to `true`.',
+      'chatMenu: false',
+    ],
+    [
+      'serverInstructions',
+      'Boolean or String',
+      '(Optional) Controls how MCP server instructions are injected into agent context. Server instructions provide high-level usage guidance for the entire MCP server, complementing individual tool descriptions.',
+      'serverInstructions: true\n# or\nserverInstructions: "Custom instructions"',
+    ],
+    [
+      'timeout',
+      'Integer',
+      '(Optional) Timeout in milliseconds for MCP server requests. Must be a non-negative integer.',
+      'timeout: 30000',
+    ],
+    [
+      'initTimeout',
+      'Integer',
+      '(Optional) Timeout in milliseconds for MCP server initialization. Must be a non-negative integer.',
+      'initTimeout: 10000',
+    ],
+    [
+      'env',
+      'Object',
+      '(Optional, `stdio` type only) Environment variables to use when spawning the process.',
+      'env:\n  NODE_ENV: "production"',
+    ],
+    [
+      'requiresOAuth',
+      'Boolean',
+      "(Optional, `sse` type only) Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it's best to set this value explicitly if you know whether the server requires OAuth or not.",
+      'requiresOAuth: true',
+    ],
+    [
+      'stderr',
+      'String or Integer',
+      '(Optional, `stdio` type only) How to handle `stderr` of the child process. Options: `"pipe"`, `"ignore"`, `"inherit"`, or a non-negative integer (file descriptor). Defaults to `"inherit"`.',
+      'stderr: "inherit"',
+    ],
+    [
+      'customUserVars',
+      'Object',
+      '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.',
+      'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."',
+    ],
+    [
+      'oauth',
+      'Object',
+      '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.',
+      'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"',
+    ],
+    [
+      'startup',
+      'Boolean',
+      '(Optional) When set to false, this MCP server will not be connected at application startup.',
+      'startup: false',
+    ],
   ]}
 />
 
@@ -107,9 +215,9 @@ mcpServers:
 - **Example:**
   ```yaml
   my-server:
-    title: "File System Access"
+    title: 'File System Access'
     command: npx
-    args: ["-y", "@modelcontextprotocol/server-filesystem"]
+    args: ['-y', '@modelcontextprotocol/server-filesystem']
   ```
 
 #### `description`
@@ -119,10 +227,10 @@ mcpServers:
 - **Example:**
   ```yaml
   my-server:
-    title: "File System Access"
-    description: "Provides read/write access to local files and directories"
+    title: 'File System Access'
+    description: 'Provides read/write access to local files and directories'
     command: npx
-    args: ["-y", "@modelcontextprotocol/server-filesystem"]
+    args: ['-y', '@modelcontextprotocol/server-filesystem']
   ```
 
 #### `type`
@@ -150,6 +258,22 @@ mcpServers:
   - For `streamable-http` type, the URL must start with `http://` or `https://`.
   - For `websocket` type, the URL must start with `ws://` or `wss://`.
 
+#### `proxy`
+
+- **Type:** String (Optional, for `sse` and `streamable-http` types)
+- **Description:** Outbound proxy URL for this remote MCP server. The value can reference environment variables with `${ENV_VAR}`.
+- **Supported protocols:** `http://`, `https://`, `socks://`, and `socks5://`
+- **Security note:** `proxy` is admin-controlled. It resolves environment variables, but does not resolve user-controlled placeholders such as `{{LIBRECHAT_USER_ID}}` or `customUserVars`.
+
+- **Example:**
+  ```yaml
+  mcpServers:
+    remote-api:
+      type: streamable-http
+      url: https://api.example.com/mcp
+      proxy: '${MCP_PROXY_URL}'
+  ```
+
 #### `headers`
 
 - **Type:** Object (Optional, for `sse` and `streamable-http` types)
@@ -162,35 +286,35 @@ mcpServers:
 
 **Available User Field Placeholders:**
 
-| Placeholder | User Field | Type | Description |
-|------------|------------|------|-------------|
-| `{{LIBRECHAT_USER_NAME}}` | `name` | String | User's display name |
-| `{{LIBRECHAT_USER_USERNAME}}` | `username` | String | User's username |
-| `{{LIBRECHAT_USER_EMAIL}}` | `email` | String | User's email address |
-| `{{LIBRECHAT_USER_PROVIDER}}` | `provider` | String | Authentication provider (e.g., "email", "google", "github") |
-| `{{LIBRECHAT_USER_ROLE}}` | `role` | String | User's role (e.g., "user", "admin") |
-| `{{LIBRECHAT_USER_GOOGLEID}}` | `googleId` | String | Google account ID |
-| `{{LIBRECHAT_USER_FACEBOOKID}}` | `facebookId` | String | Facebook account ID |
-| `{{LIBRECHAT_USER_OPENIDID}}` | `openidId` | String | OpenID account ID |
-| `{{LIBRECHAT_USER_SAMLID}}` | `samlId` | String | SAML account ID |
-| `{{LIBRECHAT_USER_LDAPID}}` | `ldapId` | String | LDAP account ID |
-| `{{LIBRECHAT_USER_GITHUBID}}` | `githubId` | String | GitHub account ID |
-| `{{LIBRECHAT_USER_DISCORDID}}` | `discordId` | String | Discord account ID |
-| `{{LIBRECHAT_USER_APPLEID}}` | `appleId` | String | Apple account ID |
-| `{{LIBRECHAT_USER_EMAILVERIFIED}}` | `emailVerified` | Boolean → String | Email verification status ("true" or "false") |
-| `{{LIBRECHAT_USER_TWOFACTORENABLED}}` | `twoFactorEnabled` | Boolean → String | 2FA status ("true" or "false") |
-| `{{LIBRECHAT_USER_TERMSACCEPTED}}` | `termsAccepted` | Boolean → String | Terms acceptance status ("true" or "false") |
+| Placeholder                           | User Field         | Type             | Description                                                 |
+| ------------------------------------- | ------------------ | ---------------- | ----------------------------------------------------------- |
+| `{{LIBRECHAT_USER_NAME}}`             | `name`             | String           | User's display name                                         |
+| `{{LIBRECHAT_USER_USERNAME}}`         | `username`         | String           | User's username                                             |
+| `{{LIBRECHAT_USER_EMAIL}}`            | `email`            | String           | User's email address                                        |
+| `{{LIBRECHAT_USER_PROVIDER}}`         | `provider`         | String           | Authentication provider (e.g., "email", "google", "github") |
+| `{{LIBRECHAT_USER_ROLE}}`             | `role`             | String           | User's role (e.g., "user", "admin")                         |
+| `{{LIBRECHAT_USER_GOOGLEID}}`         | `googleId`         | String           | Google account ID                                           |
+| `{{LIBRECHAT_USER_FACEBOOKID}}`       | `facebookId`       | String           | Facebook account ID                                         |
+| `{{LIBRECHAT_USER_OPENIDID}}`         | `openidId`         | String           | OpenID account ID                                           |
+| `{{LIBRECHAT_USER_SAMLID}}`           | `samlId`           | String           | SAML account ID                                             |
+| `{{LIBRECHAT_USER_LDAPID}}`           | `ldapId`           | String           | LDAP account ID                                             |
+| `{{LIBRECHAT_USER_GITHUBID}}`         | `githubId`         | String           | GitHub account ID                                           |
+| `{{LIBRECHAT_USER_DISCORDID}}`        | `discordId`        | String           | Discord account ID                                          |
+| `{{LIBRECHAT_USER_APPLEID}}`          | `appleId`          | String           | Apple account ID                                            |
+| `{{LIBRECHAT_USER_EMAILVERIFIED}}`    | `emailVerified`    | Boolean → String | Email verification status ("true" or "false")               |
+| `{{LIBRECHAT_USER_TWOFACTORENABLED}}` | `twoFactorEnabled` | Boolean → String | 2FA status ("true" or "false")                              |
+| `{{LIBRECHAT_USER_TERMSACCEPTED}}`    | `termsAccepted`    | Boolean → String | Terms acceptance status ("true" or "false")                 |
 
 **Note:** Missing fields will be replaced with empty strings.
 
 - **Example:**
   ```yaml
   headers:
-    X-User-ID: "{{LIBRECHAT_USER_ID}}"
-    X-User-Email: "{{LIBRECHAT_USER_EMAIL}}"
-    X-User-Role: "{{LIBRECHAT_USER_ROLE}}"
-    X-API-Key: "${SOME_API_KEY}"
-    Authorization: "Bearer ${SOME_AUTH_TOKEN}"
+    X-User-ID: '{{LIBRECHAT_USER_ID}}'
+    X-User-Email: '{{LIBRECHAT_USER_EMAIL}}'
+    X-User-Role: '{{LIBRECHAT_USER_ROLE}}'
+    X-API-Key: '${SOME_API_KEY}'
+    Authorization: 'Bearer ${SOME_AUTH_TOKEN}'
   ```
 
 #### `apiKey`
@@ -207,23 +331,24 @@ mcpServers:
     - `"custom"`: Sent in a custom header (requires `custom_header`)
   - `custom_header`: String - (Required when `authorization_type` is `"custom"`) The header name to use for the API key
 - **Example:**
+
   ```yaml
   # Admin-provided API key with Bearer auth
   my-server:
     type: streamable-http
     url: https://api.example.com/mcp
     apiKey:
-      source: "admin"
-      authorization_type: "bearer"
+      source: 'admin'
+      authorization_type: 'bearer'
 
   # User-provided API key with custom header
   another-server:
     type: sse
     url: https://api.example.com/sse
     apiKey:
-      source: "user"
-      authorization_type: "custom"
-      custom_header: "X-API-Key"
+      source: 'user'
+      authorization_type: 'custom'
+      custom_header: 'X-API-Key'
   ```
 
 #### `iconPath`
@@ -251,16 +376,17 @@ mcpServers:
   - Instructions are automatically injected when `serverInstructions` is configured and the server's tools are available to the agent
   - Multiple servers can each contribute instructions to the agent context
 - **Example:**
+
   ```yaml
   # Use server-provided instructions
   serverInstructions: true
-  
+
   # Use custom instructions
   serverInstructions: |
     When using this filesystem server:
     1. Always use absolute paths for file operations
     2. Check file permissions before attempting write operations
-  
+
   # Explicitly disable instructions
   serverInstructions: false
   ```
@@ -317,31 +443,43 @@ mcpServers:
   - Once defined under `customUserVars`, these variables can be referenced in the `headers` (for `sse` and `streamable-http` types) or `env` (for `stdio` type) sections using the `{{VARIABLE_NAME}}` syntax.
   - Users provide these values through the UI. These settings can be accessed in two ways:
     - **From Assistant Chat Input**: When selecting MCP tools for an assistant, a settings icon will appear next to configurable MCP servers in the tool selection dropdown. Clicking this icon opens a dialog to manage credentials for that server.
-    <img src="/images/mcp/mcp_per_user_vars_assistant.png" alt="MCP Per-User Variables Configuration - Assistant Access" width={600} />
-    <img src="/images/mcp/mcp_per_user_vars_assistant_dialog.png" alt="MCP Per-User Variables Configuration - Assistant Access Dialog" width={800} />
+      <img
+        src="/images/mcp/mcp_per_user_vars_assistant.png"
+        alt="MCP Per-User Variables Configuration - Assistant Access"
+        width={600}
+      />
+      <img
+        src="/images/mcp/mcp_per_user_vars_assistant_dialog.png"
+        alt="MCP Per-User Variables Configuration - Assistant Access Dialog"
+        width={800}
+      />
     - **From Settings Panel**: A dedicated "MCP Settings" section in the right panel lists all MCP servers with definable custom variables. Users can click on a server to open the configuration dialog to set or update their credentials for that specific MCP server.
-    <img src="/images/mcp/mcp_per_user_vars_side_panel.png" alt="MCP Per-User Variables Configuration - Settings Panel Access" width={300} />
+      <img
+        src="/images/mcp/mcp_per_user_vars_side_panel.png"
+        alt="MCP Per-User Variables Configuration - Settings Panel Access"
+        width={300}
+      />
   - These user-provided values are stored securely, associated with the individual user and the specific MCP server, and substituted at runtime.
 - **Example:**
   ```yaml
   customUserVars:
     MY_SERVICE_API_KEY:
-      title: "My Service API Key"
+      title: 'My Service API Key'
       description: "Your personal API access key for My Service. Find it at <a href='https://myservice.example.com/settings/api' target='_blank'>My Service API Settings</a>."
     SOME_OTHER_VAR:
-      title: "Some Other Variable"
-      description: "The specific value for some other configuration (e.g., a specific path or identifier)."
+      title: 'Some Other Variable'
+      description: 'The specific value for some other configuration (e.g., a specific path or identifier).'
   ```
   Usage in `headers`:
   ```yaml
   headers:
-    X-Auth-Token: "{{MY_SERVICE_API_KEY}}"
-    X-Some-Other-Config: "{{SOME_OTHER_VAR}}"
+    X-Auth-Token: '{{MY_SERVICE_API_KEY}}'
+    X-Some-Other-Config: '{{SOME_OTHER_VAR}}'
   ```
   Usage in `env` (for `stdio` type):
   ```yaml
   env:
-    API_KEY: "{{MY_SERVICE_API_KEY}}"
+    API_KEY: '{{MY_SERVICE_API_KEY}}'
   ```
 
 #### `oauth`
@@ -350,7 +488,7 @@ mcpServers:
 - **Description:** OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow before the MCP server can be used. If no client id & client secret is provided, Dynamic Client Registration (DCR) will be used.
 - **Required Subkeys:**
   - `authorization_url`: String - The OAuth authorization endpoint URL
-  - `token_url`: String - The OAuth token endpoint URL  
+  - `token_url`: String - The OAuth token endpoint URL
   - `client_id`: String - OAuth client identifier
   - `client_secret`: String - OAuth client secret
   - `redirect_uri`: String - [OAuth redirect URI](/docs/features/mcp#oauth-callback-url) (eg. `http://localhost:3080/api/mcp/${serverName}/oauth/callback`)
@@ -369,11 +507,11 @@ mcpServers:
     client_id: your_client_id
     client_secret: your_client_secret
     redirect_uri: http://localhost:3080/api/mcp/oauth-api-server/oauth/callback
-    scope: "read execute"
-    grant_types_supported: ["authorization_code", "refresh_token"]
-    token_endpoint_auth_methods_supported: ["client_secret_post"]
-    response_types_supported: ["code"]
-    code_challenge_methods_supported: ["S256", "plain"]
+    scope: 'read execute'
+    grant_types_supported: ['authorization_code', 'refresh_token']
+    token_endpoint_auth_methods_supported: ['client_secret_post']
+    response_types_supported: ['code']
+    code_challenge_methods_supported: ['S256', 'plain']
   ```
 
 #### `startup`
@@ -386,7 +524,7 @@ mcpServers:
   mcpServers:
     my-mcp-server:
       type: streamable-http
-      url: "https://api.example.com/mcp/"
+      url: 'https://api.example.com/mcp/'
       startup: false
   ```
 
@@ -416,9 +554,9 @@ When using internal/local MCP servers and no strict domain whitelist is needed, 
 # MCP Settings - Required for internal/local addresses
 mcpSettings:
   allowedAddresses:
-    - "172.24.1.165:8000"         # Internal IP and port
-    - "mcp-prod:8001"             # Docker container and port
-    - "host.docker.internal:8080" # Docker host and port
+    - '172.24.1.165:8000' # Internal IP and port
+    - 'mcp-prod:8001' # Docker container and port
+    - 'host.docker.internal:8080' # Docker host and port
 
 # MCP Servers - Individual configurations
 mcpServers:
@@ -426,7 +564,7 @@ mcpServers:
     type: streamable-http
     url: http://172.24.1.165:8000/mcp
     timeout: 120000
-  
+
   test-mcp:
     type: streamable-http
     url: http://mcp-prod:8001/mcp
@@ -441,13 +579,13 @@ puppeteer:
   command: npx
   args:
     - -y
-    - "@modelcontextprotocol/server-puppeteer"
+    - '@modelcontextprotocol/server-puppeteer'
   timeout: 30000
   initTimeout: 10000
   env:
-    NODE_ENV: "production"
-    USER_EMAIL: "{{LIBRECHAT_USER_EMAIL}}"
-    USER_ROLE: "{{LIBRECHAT_USER_ROLE}}"
+    NODE_ENV: 'production'
+    USER_EMAIL: '{{LIBRECHAT_USER_EMAIL}}'
+    USER_ROLE: '{{LIBRECHAT_USER_ROLE}}'
   stderr: inherit
 ```
 
@@ -457,8 +595,8 @@ puppeteer:
 everything:
   url: http://localhost:3001/sse
   headers:
-    X-User-ID: "{{LIBRECHAT_USER_ID}}"
-    X-API-Key: "${SOME_API_KEY}"
+    X-User-ID: '{{LIBRECHAT_USER_ID}}'
+    X-API-Key: '${SOME_API_KEY}'
 ```
 
 ### `websocket` MCP Server
@@ -475,8 +613,8 @@ streamable-http-server:
   type: streamable-http
   url: https://example.com/api/
   headers:
-    X-User-ID: "{{LIBRECHAT_USER_ID}}"
-    X-API-Key: "${SOME_API_KEY}"
+    X-User-ID: '{{LIBRECHAT_USER_ID}}'
+    X-API-Key: '${SOME_API_KEY}'
 ```
 
 ### MCP Server with Dynamic User Fields
@@ -486,11 +624,11 @@ user-aware-server:
   type: sse
   url: https://api.example.com/users/{{LIBRECHAT_USER_USERNAME}}/stream
   headers:
-    X-User-ID: "{{LIBRECHAT_USER_ID}}"
-    X-User-Email: "{{LIBRECHAT_USER_EMAIL}}"
-    X-User-Role: "{{LIBRECHAT_USER_ROLE}}"
-    X-Email-Verified: "{{LIBRECHAT_USER_EMAILVERIFIED}}"
-    Authorization: "Bearer ${API_TOKEN}"
+    X-User-ID: '{{LIBRECHAT_USER_ID}}'
+    X-User-Email: '{{LIBRECHAT_USER_EMAIL}}'
+    X-User-Role: '{{LIBRECHAT_USER_ROLE}}'
+    X-Email-Verified: '{{LIBRECHAT_USER_EMAILVERIFIED}}'
+    Authorization: 'Bearer ${API_TOKEN}'
 ```
 
 ### MCP Server with Per-User Credentials via `customUserVars`
@@ -498,16 +636,16 @@ user-aware-server:
 ```yaml filename="MCP Server with customUserVars"
 my-mcp-server:
   type: streamable-http
-  url: "https://api.example-service.com/api/" # Example URL
+  url: 'https://api.example-service.com/api/' # Example URL
   headers:
-    X-Auth-Token: "{{API_KEY}}" # Uses the API_KEY defined below
+    X-Auth-Token: '{{API_KEY}}' # Uses the API_KEY defined below
   customUserVars:
     API_KEY: # This key will be used as {{API_KEY}} in headers/url
-      title: "API Key" # This is the label shown above the input field
+      title: 'API Key' # This is the label shown above the input field
       description: "Get your API key <a href='https://example.com/api-keys' target='_blank'>here</a>." # This description appears below the input
 ```
 
- **NOTE** See [MCP Server Initialization](/docs/features/mcp#server-initialization) for more information about UI based server initialization.
+**NOTE** See [MCP Server Initialization](/docs/features/mcp#server-initialization) for more information about UI based server initialization.
 
 ### MCP Server with Custom Icon
 
@@ -516,10 +654,10 @@ filesystem:
   command: npx
   args:
     - -y
-    - "@modelcontextprotocol/server-filesystem"
+    - '@modelcontextprotocol/server-filesystem'
     - /home/user/LibreChat/
   iconPath: /home/user/LibreChat/client/public/assets/logo.svg
-  chatMenu: false  # Exclude from chatarea dropdown
+  chatMenu: false # Exclude from chatarea dropdown
 ```
 
 ### MCP Server with OAuth Authentication
@@ -534,7 +672,7 @@ oauth-api-server:
     client_id: your_client_id
     client_secret: your_client_secret
     redirect_uri: http://localhost:3080/api/mcp/oauth-api-server/oauth/callback
-    scope: "read execute"
+    scope: 'read execute'
 ```
 
 ### MCP Server with Server Instructions
@@ -551,7 +689,7 @@ filesystem:
   command: npx
   args:
     - -y
-    - "@modelcontextprotocol/server-filesystem"
+    - '@modelcontextprotocol/server-filesystem'
     - /home/user/documents/
   serverInstructions: false
 
@@ -561,14 +699,14 @@ puppeteer:
   command: npx
   args:
     - -y
-    - "@modelcontextprotocol/server-puppeteer"
+    - '@modelcontextprotocol/server-puppeteer'
   serverInstructions: |
-      Browser automation security and best practices:
-      1. Be cautious with local file access and internal IP addresses
-      2. Take screenshots to verify successful page interactions
-      3. Wait for page elements to load before interacting with them
-      4. Use specific CSS selectors for reliable element targeting
-      5. Check console logs for JavaScript errors when troubleshooting
+    Browser automation security and best practices:
+    1. Be cautious with local file access and internal IP addresses
+    2. Take screenshots to verify successful page interactions
+    3. Wait for page elements to load before interacting with them
+    4. Use specific CSS selectors for reliable element targeting
+    5. Check console logs for JavaScript errors when troubleshooting
 ```
 
 ### OAuth-Enabled MCP Server (Legacy requiresOAuth)
@@ -579,13 +717,14 @@ composio-googlesheets:
   url: https://mcp.composio.dev/googlesheets/sse-endpoint
   requiresOAuth: true
   headers:
-    X-User-ID: "{{LIBRECHAT_USER_ID}}"
-    X-API-Key: "${COMPOSIO_API_KEY}"
+    X-User-ID: '{{LIBRECHAT_USER_ID}}'
+    X-API-Key: '${COMPOSIO_API_KEY}'
   timeout: 45000
   initTimeout: 15000
 ```
 
 **Related Environment Variables (Optional):**
+
 ```bash
 # OAuth configuration for MCP servers
 MCP_OAUTH_ON_AUTH_ERROR=true

--- a/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Model Specs Object Structure"
+title: 'Model Specs Object Structure'
 icon: Braces
 ---
 
@@ -9,19 +9,19 @@ The `modelSpecs` object helps you provide a simpler UI experience for AI models 
 
 There are 3 main fields under `modelSpecs`:
 
-  - `enforce` (optional; default: false)
-  - `prioritize` (optional; default: true)
-  - `list` (required)
-  - `addedEndpoints` (optional)
+- `enforce` (optional; default: false)
+- `prioritize` (optional; default: true)
+- `list` (required)
+- `addedEndpoints` (optional)
 
 **Notes:**
 
-- If `enforce` is set to true, model specifications can potentially conflict with other interface settings such as  `modelSelect`, `presets`, and `parameters`.
+- If `enforce` is set to true, model specifications can potentially conflict with other interface settings such as `modelSelect`, `presets`, and `parameters`.
 - The `list` array contains detailed configurations for each model, including presets that dictate specific behaviors, appearances, and capabilities.
 - If [interface](interface.mdx) fields are not specified in the configuration, having a list of model specs will disable the following interface elements:
-    - `modelSelect`
-    - `parameters`
-    - `presets`
+  - `modelSelect`
+  - `parameters`
+  - `presets`
 - If you would like to enable these interface elements along with model specs, you can set them to `true` in the `interface` object.
 
 ## Example
@@ -31,18 +31,19 @@ modelSpecs:
   enforce: true
   prioritize: true
   list:
-    - name: "meeting-notes-gpt4"
-      label: "Meeting Notes Assistant (GPT4)"
+    - name: 'meeting-notes-gpt4'
+      label: 'Meeting Notes Assistant (GPT4)'
       default: true
-      description: "Generate meeting notes by simply pasting in the transcript from a Teams recording."
-      iconURL: "https://example.com/icon.png"
+      description: 'Generate meeting notes by simply pasting in the transcript from a Teams recording.'
+      iconURL: 'https://example.com/icon.png'
+      hideBadgeRow: true
       preset:
-        endpoint: "azureOpenAI"
-        model: "gpt-4-turbo-1106-preview"
+        endpoint: 'azureOpenAI'
+        model: 'gpt-4-turbo-1106-preview'
         maxContextTokens: 128000 # Maximum context tokens
         max_tokens: 4096 # Maximum output tokens
         temperature: 0.2
-        modelLabel: "Meeting Summarizer"
+        modelLabel: 'Meeting Summarizer'
         greeting: |
           This assistant creates meeting notes based on transcripts of Teams recordings.
           To start, simply paste the transcript into the chat box.
@@ -70,13 +71,19 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['enforce', 'Boolean', 'Determines whether the model specifications should strictly override other configuration settings.', 'Setting this to `true` can lead to conflicts with interface options if not managed carefully.'],
+    [
+      'enforce',
+      'Boolean',
+      'Determines whether the model specifications should strictly override other configuration settings.',
+      'Setting this to `true` can lead to conflicts with interface options if not managed carefully.',
+    ],
   ]}
 />
 
 **Default:** `false`
 
 **Example:**
+
 ```yaml filename="modelSpecs / enforce"
 modelSpecs:
   enforce: true
@@ -88,13 +95,19 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['prioritize', 'Boolean', 'Specifies if model specifications should take priority over the default configuration when both are applicable.', 'When set to `true`, it ensures that a modelSpec is always selected in the UI. Doing this may prevent users from selecting different endpoints for the selected spec.'],
+    [
+      'prioritize',
+      'Boolean',
+      'Specifies if model specifications should take priority over the default configuration when both are applicable.',
+      'When set to `true`, it ensures that a modelSpec is always selected in the UI. Doing this may prevent users from selecting different endpoints for the selected spec.',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="modelSpecs / prioritize"
 modelSpecs:
   prioritize: false
@@ -106,16 +119,23 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['addedEndpoints', 'Array of Strings', 'Allows specific endpoints (e.g., "openAI", "google") to be selectable in the UI alongside the defined model specs.', 'Requires `interface.modelSelect` to be `true`. If this field is used and `interface.modelSelect` is not explicitly set, `modelSelect` will default to `true`.'],
+    [
+      'addedEndpoints',
+      'Array of Strings',
+      'Allows specific endpoints (e.g., "openAI", "google") to be selectable in the UI alongside the defined model specs.',
+      'Requires `interface.modelSelect` to be `true`. If this field is used and `interface.modelSelect` is not explicitly set, `modelSelect` will default to `true`.',
+    ],
   ]}
 />
 
 **Default:** `[]` (empty list)
 
 **Note:** Must be one of the following:
+
 - `openAI, azureOpenAI, google, anthropic, assistants, azureAssistants, bedrock`
 
 **Example:**
+
 ```yaml filename="modelSpecs / addedEndpoints"
 modelSpecs:
   # ... other modelSpecs fields
@@ -132,7 +152,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['list', 'Array of Objects', 'Contains a list of individual model specifications detailing various configurations and behaviors.', 'Each object in the list details the configuration for a specific model, including its behaviors, appearance, and capabilities related to the application\'s functionality.'],
+    [
+      'list',
+      'Array of Objects',
+      'Contains a list of individual model specifications detailing various configurations and behaviors.',
+      "Each object in the list details the configuration for a specific model, including its behaviors, appearance, and capabilities related to the application's functionality.",
+    ],
   ]}
 />
 
@@ -159,7 +184,12 @@ Unique identifier for the model.
 
 <OptionTable
   options={[
-    ['label', 'String', 'A user-friendly name or label for the model, shown in the header dropdown.', 'No default. Optional.'],
+    [
+      'label',
+      'String',
+      'A user-friendly name or label for the model, shown in the header dropdown.',
+      'No default. Optional.',
+    ],
   ]}
 />
 
@@ -172,7 +202,12 @@ A user-friendly name or label for the model, shown in the header dropdown.
 
 <OptionTable
   options={[
-    ['default', 'Boolean', 'Specifies if this model spec is the default selection, to be auto-selected on every new chat.', ''],
+    [
+      'default',
+      'Boolean',
+      'Specifies if this model spec is the default selection, to be auto-selected on every new chat.',
+      '',
+    ],
   ]}
 />
 
@@ -185,7 +220,12 @@ Specifies if this model spec is the default selection, to be auto-selected on ev
 
 <OptionTable
   options={[
-    ['iconURL', 'String', 'URL or a predefined endpoint name for the model\'s icon.', 'No default. Optional.'],
+    [
+      'iconURL',
+      'String',
+      "URL or a predefined endpoint name for the model's icon.",
+      'No default. Optional.',
+    ],
   ]}
 />
 
@@ -198,7 +238,12 @@ URL or a predefined endpoint name for the model's icon.
 
 <OptionTable
   options={[
-    ['description', 'String', 'A brief description of the model and its intended use or role, shown in the header dropdown menu.', 'No default. Optional.'],
+    [
+      'description',
+      'String',
+      'A brief description of the model and its intended use or role, shown in the header dropdown menu.',
+      'No default. Optional.',
+    ],
   ]}
 />
 
@@ -211,8 +256,18 @@ A brief description of the model and its intended use or role, shown in the head
 
 <OptionTable
   options={[
-    ['group', 'String', 'Optional group name for organizing model specs in the UI selector. Controls where the spec appears in the menu hierarchy.', 'No default. Optional.'],
-    ['groupIcon', 'String', 'Optional icon for custom groups. Can be a URL or a built-in endpoint key (e.g., "openAI", "groq"). Only the first spec with a groupIcon in each group is used.', 'No default. Optional.'],
+    [
+      'group',
+      'String',
+      'Optional group name for organizing model specs in the UI selector. Controls where the spec appears in the menu hierarchy.',
+      'No default. Optional.',
+    ],
+    [
+      'groupIcon',
+      'String',
+      'Optional icon for custom groups. Can be a URL or a built-in endpoint key (e.g., "openAI", "groq"). Only the first spec with a groupIcon in each group is used.',
+      'No default. Optional.',
+    ],
   ]}
 />
 
@@ -225,6 +280,40 @@ Optional group name for organizing model specs in the UI selector. The `group` f
 
 This feature is particularly useful when you want to add descriptions to models without losing the organizational structure of the selector menu.
 
+---
+
+### hideBadgeRow
+
+<OptionTable
+  options={[
+    [
+      'hideBadgeRow',
+      'Boolean',
+      'Hides the tool badge row for this model spec in the chat composer.',
+      'hideBadgeRow: true',
+    ],
+  ]}
+/>
+
+**Default:** `false`
+
+Use this when a curated model spec should not show the row of tool/capability badges beneath the composer.
+
+**Example:**
+
+```yaml filename="modelSpecs / hideBadgeRow"
+modelSpecs:
+  list:
+    - name: 'general-assistant'
+      label: 'General Assistant'
+      hideBadgeRow: true
+      preset:
+        endpoint: 'openAI'
+        model: 'gpt-4o-mini'
+```
+
+---
+
 **Example:**
 
 ```yaml filename="modelSpecs with group field examples"
@@ -232,52 +321,52 @@ modelSpecs:
   list:
     # Example 1: Nested under an endpoint
     # When group matches an endpoint name, the spec appears under that endpoint
-    - name: "gpt-4o-optimized"
-      label: "GPT-4 Optimized"
-      description: "Most capable GPT-4 model with multimodal support"
-      group: "openAI"  # Appears nested under the OpenAI endpoint
+    - name: 'gpt-4o-optimized'
+      label: 'GPT-4 Optimized'
+      description: 'Most capable GPT-4 model with multimodal support'
+      group: 'openAI' # Appears nested under the OpenAI endpoint
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 
     # Example 2: Custom group section with icon
     # When group is a custom name, it creates a separate collapsible section
-    - name: "coding-assistant"
-      label: "Coding Assistant"
-      description: "Specialized for coding tasks"
-      group: "My Assistants"
-      groupIcon: "https://example.com/icons/assistants.png"  # Custom icon for the group
+    - name: 'coding-assistant'
+      label: 'Coding Assistant'
+      description: 'Specialized for coding tasks'
+      group: 'My Assistants'
+      groupIcon: 'https://example.com/icons/assistants.png' # Custom icon for the group
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 
     # Multiple specs with the same group name are grouped together
-    - name: "writing-assistant"
-      label: "Writing Assistant"
-      description: "Specialized for creative writing"
-      group: "My Assistants"  # Grouped with coding-assistant, uses its icon
+    - name: 'writing-assistant'
+      label: 'Writing Assistant'
+      description: 'Specialized for creative writing'
+      group: 'My Assistants' # Grouped with coding-assistant, uses its icon
       preset:
-        endpoint: "anthropic"
-        model: "claude-sonnet-4"
+        endpoint: 'anthropic'
+        model: 'claude-sonnet-4'
 
     # Example 3: Custom group using built-in icon
-    - name: "fast-model"
-      label: "Fast Model"
-      group: "Fast Models"
-      groupIcon: "groq"  # Uses built-in Groq icon
+    - name: 'fast-model'
+      label: 'Fast Model'
+      group: 'Fast Models'
+      groupIcon: 'groq' # Uses built-in Groq icon
       preset:
-        endpoint: "groq"
-        model: "llama3-8b-8192"
+        endpoint: 'groq'
+        model: 'llama3-8b-8192'
 
     # Example 4: Standalone (no group)
     # When group is omitted, the spec appears at the top level
-    - name: "general-assistant"
-      label: "General Assistant"
-      description: "General purpose assistant"
+    - name: 'general-assistant'
+      label: 'General Assistant'
+      description: 'General purpose assistant'
       # No group field - appears as standalone item at top level
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o-mini"
+        endpoint: 'openAI'
+        model: 'gpt-4o-mini'
 ```
 
 ---
@@ -286,7 +375,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['showIconInMenu', 'Boolean', 'Controls whether the model\'s icon appears in the header dropdown menu.', ''],
+    [
+      'showIconInMenu',
+      'Boolean',
+      "Controls whether the model's icon appears in the header dropdown menu.",
+      '',
+    ],
   ]}
 />
 
@@ -299,7 +393,12 @@ Controls whether the model's icon appears in the header dropdown menu. Defaults 
 
 <OptionTable
   options={[
-    ['showIconInHeader', 'Boolean', 'Controls whether the model\'s icon appears in the header dropdown button, left of its name.', ''],
+    [
+      'showIconInHeader',
+      'Boolean',
+      "Controls whether the model's icon appears in the header dropdown button, left of its name.",
+      '',
+    ],
   ]}
 />
 
@@ -312,7 +411,12 @@ Controls whether the model's icon appears in the header dropdown button, left of
 
 <OptionTable
   options={[
-    ['authType', 'String', 'Authentication type required for the model spec.', 'Optional. Possible values: "override_auth", "user_provided", "system_defined"'],
+    [
+      'authType',
+      'String',
+      'Authentication type required for the model spec.',
+      'Optional. Possible values: "override_auth", "user_provided", "system_defined"',
+    ],
   ]}
 />
 
@@ -325,7 +429,12 @@ Authentication type required for the model spec. Determines whether authenticati
 
 <OptionTable
   options={[
-    ['webSearch', 'Boolean', 'Enables web search capability for this model spec.', 'When true, the model can perform web searches.'],
+    [
+      'webSearch',
+      'Boolean',
+      'Enables web search capability for this model spec.',
+      'When true, the model can perform web searches.',
+    ],
   ]}
 />
 
@@ -333,15 +442,16 @@ Authentication type required for the model spec. Determines whether authenticati
 Enables web search capability for this model spec. When set to `true`, the model can perform web searches to retrieve current information.
 
 **Example:**
+
 ```yaml filename="modelSpecs / webSearch"
 modelSpecs:
   list:
-    - name: "research-assistant"
-      label: "Research Assistant"
+    - name: 'research-assistant'
+      label: 'Research Assistant'
       webSearch: true
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 ```
 
 ---
@@ -350,7 +460,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['fileSearch', 'Boolean', 'Enables file search capability for this model spec.', 'When true, the model can search through uploaded files.'],
+    [
+      'fileSearch',
+      'Boolean',
+      'Enables file search capability for this model spec.',
+      'When true, the model can search through uploaded files.',
+    ],
   ]}
 />
 
@@ -358,15 +473,16 @@ modelSpecs:
 Enables file search capability for this model spec. When set to `true`, the model can search through and reference uploaded files.
 
 **Example:**
+
 ```yaml filename="modelSpecs / fileSearch"
 modelSpecs:
   list:
-    - name: "document-analyst"
-      label: "Document Analyst"
+    - name: 'document-analyst'
+      label: 'Document Analyst'
       fileSearch: true
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 ```
 
 ---
@@ -375,7 +491,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['executeCode', 'Boolean', 'Enables code execution capability for this model spec.', 'When true, the model can execute code.'],
+    [
+      'executeCode',
+      'Boolean',
+      'Enables code execution capability for this model spec.',
+      'When true, the model can execute code.',
+    ],
   ]}
 />
 
@@ -383,15 +504,16 @@ modelSpecs:
 Enables code execution capability for this model spec. When set to `true`, the model can execute code in a sandboxed environment.
 
 **Example:**
+
 ```yaml filename="modelSpecs / executeCode"
 modelSpecs:
   list:
-    - name: "code-assistant"
-      label: "Code Assistant"
+    - name: 'code-assistant'
+      label: 'Code Assistant'
       executeCode: true
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 ```
 
 ---
@@ -400,7 +522,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['mcpServers', 'Array of Strings', 'List of Model Context Protocol (MCP) server names to enable for this model spec.', 'Each string should match a configured MCP server name.'],
+    [
+      'mcpServers',
+      'Array of Strings',
+      'List of Model Context Protocol (MCP) server names to enable for this model spec.',
+      'Each string should match a configured MCP server name.',
+    ],
   ]}
 />
 
@@ -408,18 +535,19 @@ modelSpecs:
 List of Model Context Protocol (MCP) server names to enable for this model spec. MCP servers extend the model's capabilities with custom tools and resources.
 
 **Example:**
+
 ```yaml filename="modelSpecs / mcpServers"
 modelSpecs:
   list:
-    - name: "enhanced-assistant"
-      label: "Enhanced Assistant"
+    - name: 'enhanced-assistant'
+      label: 'Enhanced Assistant'
       mcpServers:
-        - "filesystem"
-        - "sequential-thinking"
-        - "fetch"
+        - 'filesystem'
+        - 'sequential-thinking'
+        - 'fetch'
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 ```
 
 ---
@@ -428,7 +556,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['artifacts', 'String | Boolean', 'Enables the Artifacts capability for this model spec and optionally sets the artifact mode.', 'Set to `true` to enable with the default mode, `false` or omit to disable, or a specific mode string (e.g., `"default"`) to enable with that mode.'],
+    [
+      'artifacts',
+      'String | Boolean',
+      'Enables the Artifacts capability for this model spec and optionally sets the artifact mode.',
+      'Set to `true` to enable with the default mode, `false` or omit to disable, or a specific mode string (e.g., `"default"`) to enable with that mode.',
+    ],
   ]}
 />
 
@@ -436,15 +569,16 @@ modelSpecs:
 Enables the Artifacts capability for this model spec, allowing the model to generate and display interactive artifacts such as React components, HTML, and Mermaid diagrams. When set to `true`, the default artifact mode is used. You can also specify a mode string directly.
 
 **Example:**
+
 ```yaml filename="modelSpecs / artifacts"
 modelSpecs:
   list:
-    - name: "artifact-assistant"
-      label: "Artifact Assistant"
+    - name: 'artifact-assistant'
+      label: 'Artifact Assistant'
       artifacts: true
       preset:
-        endpoint: "openAI"
-        model: "gpt-4o"
+        endpoint: 'openAI'
+        model: 'gpt-4o'
 ```
 
 ---
@@ -453,7 +587,12 @@ modelSpecs:
 
 <OptionTable
   options={[
-    ['preset', 'Object', 'Detailed preset configurations that define the behavior and capabilities of the model.', 'See "Preset Object Structure" below.'],
+    [
+      'preset',
+      'Object',
+      'Detailed preset configurations that define the behavior and capabilities of the model.',
+      'See "Preset Object Structure" below.',
+    ],
   ]}
 />
 
@@ -473,6 +612,7 @@ The `preset` field for a `modelSpecs.list` item is made up of a comprehensive co
 **Required**
 
 **Accepted Values:**
+
 - `openAI`
 - `azureOpenAI`
 - `google`
@@ -486,14 +626,20 @@ The `preset` field for a `modelSpecs.list` item is made up of a comprehensive co
 
 <OptionTable
   options={[
-    ['endpoint', 'Enum (EModelEndpoint) or String (nullable)', 'Specifies the endpoint the model communicates with to execute operations. This setting determines the external or internal service that the model interfaces with.', ''],
+    [
+      'endpoint',
+      'Enum (EModelEndpoint) or String (nullable)',
+      'Specifies the endpoint the model communicates with to execute operations. This setting determines the external or internal service that the model interfaces with.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / endpoint"
 preset:
-  endpoint: "openAI"
+  endpoint: 'openAI'
 ```
 
 ---
@@ -502,16 +648,22 @@ preset:
 
 <OptionTable
   options={[
-    ['modelLabel', 'String (nullable)', 'The label used to identify the model in user interfaces or logs. It provides a human-readable name for the model, which is displayed in the UI, as well as made aware to the AI.', 'None'],
+    [
+      'modelLabel',
+      'String (nullable)',
+      'The label used to identify the model in user interfaces or logs. It provides a human-readable name for the model, which is displayed in the UI, as well as made aware to the AI.',
+      'None',
+    ],
   ]}
 />
 
 **Default:** `None`
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / modelLabel"
 preset:
-  modelLabel: "Customer Support Bot"
+  modelLabel: 'Customer Support Bot'
 ```
 
 ---
@@ -520,16 +672,22 @@ preset:
 
 <OptionTable
   options={[
-    ['greeting', 'String', 'A predefined message that is visible in the UI before a new chat is started. This is a good way to provide instructions to the user, or to make the interface seem more friendly and accessible.', ''],
+    [
+      'greeting',
+      'String',
+      'A predefined message that is visible in the UI before a new chat is started. This is a good way to provide instructions to the user, or to make the interface seem more friendly and accessible.',
+      '',
+    ],
   ]}
 />
 
 **Default:** `None`
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / greeting"
 preset:
-  greeting: "This assistant creates meeting notes based on transcripts of Teams recordings. To start, simply paste the transcript into the chat box."
+  greeting: 'This assistant creates meeting notes based on transcripts of Teams recordings. To start, simply paste the transcript into the chat box.'
 ```
 
 ---
@@ -538,19 +696,26 @@ preset:
 
 <OptionTable
   options={[
-    ['promptPrefix', 'String (nullable)', 'A static text prepended to every prompt sent to the model, setting a consistent context for responses.', 'When using "assistants" as the endpoint, this becomes the OpenAI field `additional_instructions`.'],
+    [
+      'promptPrefix',
+      'String (nullable)',
+      'A static text prepended to every prompt sent to the model, setting a consistent context for responses.',
+      'When using "assistants" as the endpoint, this becomes the OpenAI field `additional_instructions`.',
+    ],
   ]}
 />
 
 **Default:** `None`
 
 **Example 1:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / promptPrefix"
 preset:
-  promptPrefix: "As a financial advisor, ..."
+  promptPrefix: 'As a financial advisor, ...'
 ```
 
 **Example 2:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / promptPrefix"
 preset:
   promptPrefix: |
@@ -575,13 +740,19 @@ preset:
 
 <OptionTable
   options={[
-    ['resendFiles', 'Boolean', 'Indicates whether files should be resent in scenarios where persistent sessions are not maintained.', ''],
+    [
+      'resendFiles',
+      'Boolean',
+      'Indicates whether files should be resent in scenarios where persistent sessions are not maintained.',
+      '',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / resendFiles"
 preset:
   resendFiles: true
@@ -592,22 +763,29 @@ preset:
 #### imageDetail
 
 **Accepted Values:**
+
 - low
 - auto
 - high
 
 <OptionTable
   options={[
-    ['imageDetail', 'Enum (eImageDetailSchema)', 'Specifies the level of detail required in image analysis tasks, applicable to models with vision capabilities (OpenAI spec).', ''],
+    [
+      'imageDetail',
+      'Enum (eImageDetailSchema)',
+      'Specifies the level of detail required in image analysis tasks, applicable to models with vision capabilities (OpenAI spec).',
+      '',
+    ],
   ]}
 />
 
 **Default:** `"auto"`
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / imageDetail"
 preset:
-  imageDetail: "high"
+  imageDetail: 'high'
 ```
 
 ---
@@ -616,11 +794,17 @@ preset:
 
 <OptionTable
   options={[
-    ['maxContextTokens', 'Number', 'The maximum number of context tokens to provide to the model.', 'Useful if you want to limit the maximum context for this preset.'],
+    [
+      'maxContextTokens',
+      'Number',
+      'The maximum number of context tokens to provide to the model.',
+      'Useful if you want to limit the maximum context for this preset.',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / maxContextTokens"
 preset:
   maxContextTokens: 4096
@@ -638,22 +822,20 @@ You should exclude any model options and defer to the agent's configuration as d
 As of v0.8.0, LibreChat uses an ACL (Access Control List) based permissions system for agents. When model specs are configured to use agents, any agents that the user doesn't have access to will be automatically filtered out, even if they are configured in the model spec. This ensures users only see and can use agents they have proper permissions for.
 
 For more information about the ACL permissions system, see the [Agents documentation](/docs/features/agents#migration-required-v080-rc3).
+
 </Callout>
 
 ---
 
 #### agent_id
 
-<OptionTable
-  options={[
-    ['agent_id', 'String', 'Identification of an assistant.', ''],
-  ]}
-/>
+<OptionTable options={[['agent_id', 'String', 'Identification of an assistant.', '']]} />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / agent_id"
 preset:
-  agent_id: "agent_someUniqueId"
+  agent_id: 'agent_someUniqueId'
 ```
 
 ---
@@ -668,16 +850,13 @@ Similar to [Agents](#agent-options), you should exclude any model options and de
 
 #### assistant_id
 
-<OptionTable
-  options={[
-    ['assistant_id', 'String', 'Identification of an assistant.', ''],
-  ]}
-/>
+<OptionTable options={[['assistant_id', 'String', 'Identification of an assistant.', '']]} />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / assistant_id"
 preset:
-  assistant_id: "asst_someUniqueId"
+  assistant_id: 'asst_someUniqueId'
 ```
 
 ---
@@ -696,15 +875,14 @@ More information:
 - https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-additional_instructions
 
 <OptionTable
-  options={[
-    ['instructions', 'String', 'Overrides the assistant\'s default instructions.', ''],
-  ]}
+  options={[['instructions', 'String', "Overrides the assistant's default instructions.", '']]}
 />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / instructions"
 preset:
-  instructions: "Please handle customer queries regarding order status."
+  instructions: 'Please handle customer queries regarding order status.'
 ```
 
 ---
@@ -715,11 +893,17 @@ Adds the current date and time to `additional_instructions` for each run. Does n
 
 <OptionTable
   options={[
-    ['append_current_datetime', 'Boolean', 'Adds the current date and time to `additional_instructions` as defined by `promptPrefix`', ''],
+    [
+      'append_current_datetime',
+      'Boolean',
+      'Adds the current date and time to `additional_instructions` as defined by `promptPrefix`',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml filename="modelSpecs / list / {spec_item} / preset / append_current_datetime"
 preset:
   append_current_datetime: true
@@ -733,7 +917,7 @@ preset:
 > **OpenAI / AzureOpenAI / Custom** typically support `temperature`, `presence_penalty`, `frequency_penalty`, `stop`, `top_p`, `max_tokens`.  
 > **Google / Anthropic** typically support `topP`, `topK`, `maxOutputTokens`.  
 > **Anthropic / Bedrock (Anthropic and Nova models)** support `promptCache`.  
-> **Bedrock** supports `region`, `maxTokens`, and a few others.  
+> **Bedrock** supports `region`, `maxTokens`, and a few others.
 
 #### model
 
@@ -741,31 +925,43 @@ preset:
 
 <OptionTable
   options={[
-    ['model', 'String (nullable)', 'The model name to use for the preset, matching a configured model under the chosen endpoint.', 'None'],
+    [
+      'model',
+      'String (nullable)',
+      'The model name to use for the preset, matching a configured model under the chosen endpoint.',
+      'None',
+    ],
   ]}
 />
 
 **Default:** `None`
 
 **Example:**
+
 ```yaml
 preset:
-  model: "gpt-4-turbo"
+  model: 'gpt-4-turbo'
 ```
 
 ---
 
 #### temperature
 
-> **Supported by:** `openAI`, `azureOpenAI`, `google` (as `temperature`), `anthropic` (as `temperature`), and custom (OpenAI-like)  
+> **Supported by:** `openAI`, `azureOpenAI`, `google` (as `temperature`), `anthropic` (as `temperature`), and custom (OpenAI-like)
 
 <OptionTable
   options={[
-    ['temperature', 'Number', 'Controls how deterministic or “creative” the model responses are.', ''],
+    [
+      'temperature',
+      'Number',
+      'Controls how deterministic or “creative” the model responses are.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   temperature: 0.7
@@ -776,15 +972,21 @@ preset:
 #### presence_penalty
 
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)  
-> *Not typically used by Google/Anthropic/Bedrock*
+> _Not typically used by Google/Anthropic/Bedrock_
 
 <OptionTable
   options={[
-    ['presence_penalty', 'Number', 'Penalty for repetitive tokens, encouraging exploration of new topics.', ''],
+    [
+      'presence_penalty',
+      'Number',
+      'Penalty for repetitive tokens, encouraging exploration of new topics.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   presence_penalty: 0.3
@@ -795,15 +997,21 @@ preset:
 #### frequency_penalty
 
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)  
-> *Not typically used by Google/Anthropic/Bedrock*
+> _Not typically used by Google/Anthropic/Bedrock_
 
 <OptionTable
   options={[
-    ['frequency_penalty', 'Number', 'Penalty for repeated tokens, reducing redundancy in responses.', ''],
+    [
+      'frequency_penalty',
+      'Number',
+      'Penalty for repeated tokens, reducing redundancy in responses.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   frequency_penalty: 0.5
@@ -814,20 +1022,26 @@ preset:
 #### stop
 
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)  
-> *Not typically used by Google/Anthropic/Bedrock*
+> _Not typically used by Google/Anthropic/Bedrock_
 
 <OptionTable
   options={[
-    ['stop', 'Array of Strings', 'Stop tokens for the model, instructing it to end its response if encountered.', ''],
+    [
+      'stop',
+      'Array of Strings',
+      'Stop tokens for the model, instructing it to end its response if encountered.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   stop:
-    - "END"
-    - "STOP"
+    - 'END'
+    - 'STOP'
 ```
 
 ---
@@ -839,11 +1053,17 @@ preset:
 
 <OptionTable
   options={[
-    ['top_p', 'Number', 'Nucleus sampling parameter (0-1), controlling the randomness of tokens.', ''],
+    [
+      'top_p',
+      'Number',
+      'Nucleus sampling parameter (0-1), controlling the randomness of tokens.',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   top_p: 0.9
@@ -857,12 +1077,11 @@ preset:
 > (similar purpose to `top_p`, but named differently in those APIs)
 
 <OptionTable
-  options={[
-    ['topP', 'Number', 'Nucleus sampling parameter for Google/Anthropic endpoints.', ''],
-  ]}
+  options={[['topP', 'Number', 'Nucleus sampling parameter for Google/Anthropic endpoints.', '']]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   topP: 0.8
@@ -876,12 +1095,11 @@ preset:
 > (k-sampling limit on the next token distribution)
 
 <OptionTable
-  options={[
-    ['topK', 'Number', 'Limits the next token selection to the top K tokens.', ''],
-  ]}
+  options={[['topK', 'Number', 'Limits the next token selection to the top K tokens.', '']]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   topK: 40
@@ -892,15 +1110,14 @@ preset:
 #### max_tokens
 
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)  
-> *For Google/Anthropic, use `maxOutputTokens` or `maxTokens` (depending on the endpoint).*
+> _For Google/Anthropic, use `maxOutputTokens` or `maxTokens` (depending on the endpoint)._
 
 <OptionTable
-  options={[
-    ['max_tokens', 'Number', 'The maximum number of tokens in the model response.', ''],
-  ]}
+  options={[['max_tokens', 'Number', 'The maximum number of tokens in the model response.', '']]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   max_tokens: 4096
@@ -911,15 +1128,21 @@ preset:
 #### maxOutputTokens
 
 > **Supported by:** `google`, `anthropic`  
-> *Equivalent to `max_tokens` for these providers.*
+> _Equivalent to `max_tokens` for these providers._
 
 <OptionTable
   options={[
-    ['maxOutputTokens', 'Number', 'The maximum number of tokens in the response (Google/Anthropic).', ''],
+    [
+      'maxOutputTokens',
+      'Number',
+      'The maximum number of tokens in the response (Google/Anthropic).',
+      '',
+    ],
   ]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   maxOutputTokens: 2048
@@ -941,6 +1164,7 @@ preset:
 **Default:** `true`
 
 **Example:**
+
 ```yaml
 preset:
   promptCache: true
@@ -953,6 +1177,7 @@ preset:
 #### reasoning_effort
 
 **Accepted Values:**
+
 - `""` (empty string — unset, uses API default)
 - `"none"`
 - `"minimal"`
@@ -965,16 +1190,22 @@ preset:
 
 <OptionTable
   options={[
-    ['reasoning_effort', 'String', 'Controls the reasoning effort level for the model. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning. The `xhigh` option provides maximum reasoning capability for complex problems. For Bedrock, accepted values are `low`, `medium`, `high`.', ''],
+    [
+      'reasoning_effort',
+      'String',
+      'Controls the reasoning effort level for the model. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning. The `xhigh` option provides maximum reasoning capability for complex problems. For Bedrock, accepted values are `low`, `medium`, `high`.',
+      '',
+    ],
   ]}
 />
 
 **Default:** `""` (unset)
 
 **Example:**
+
 ```yaml
 preset:
-  reasoning_effort: "low"
+  reasoning_effort: 'low'
 ```
 
 ---
@@ -982,6 +1213,7 @@ preset:
 #### reasoning_summary
 
 **Accepted Values:**
+
 - `""` (empty string — disables reasoning summaries)
 - `"auto"`
 - `"concise"`
@@ -998,9 +1230,10 @@ preset:
 **Default:** `""` (disabled)
 
 **Example:**
+
 ```yaml
 preset:
-  reasoning_summary: "detailed"
+  reasoning_summary: 'detailed'
 ```
 
 ---
@@ -1018,6 +1251,7 @@ preset:
 **Default:** `false`
 
 **Example:**
+
 ```yaml
 preset:
   useResponsesApi: true
@@ -1028,6 +1262,7 @@ preset:
 #### verbosity
 
 **Accepted Values:**
+
 - `""` (empty string — unset, uses API default)
 - `"low"`
 - `"medium"`
@@ -1036,17 +1271,16 @@ preset:
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
 
 <OptionTable
-  options={[
-    ['verbosity', 'String', 'Controls the verbosity level of model responses.', ''],
-  ]}
+  options={[['verbosity', 'String', 'Controls the verbosity level of model responses.', '']]}
 />
 
 **Default:** `""` (unset)
 
 **Example:**
+
 ```yaml
 preset:
-  verbosity: "low"
+  verbosity: 'low'
 ```
 
 ---
@@ -1066,6 +1300,7 @@ preset:
 **Note:** For Google endpoints, this parameter appears as `Grounding with Google Search` in the actual panel but controls `web_search` in the implementation.
 
 **Example:**
+
 ```yaml
 preset:
   web_search: true
@@ -1078,14 +1313,13 @@ preset:
 > **Supported by:** `openAI`, `azureOpenAI`, custom (OpenAI-like)
 
 <OptionTable
-  options={[
-    ['disableStreaming', 'Boolean', 'Disables streaming responses from the model.', ''],
-  ]}
+  options={[['disableStreaming', 'Boolean', 'Disables streaming responses from the model.', '']]}
 />
 
 **Default:** `false`
 
 **Example:**
+
 ```yaml
 preset:
   disableStreaming: true
@@ -1099,16 +1333,22 @@ preset:
 
 <OptionTable
   options={[
-    ['thinkingBudget', 'Number or String', 'Controls the number of thinking tokens the model can use for internal reasoning. Larger budgets can improve response quality for complex problems.', ''],
+    [
+      'thinkingBudget',
+      'Number or String',
+      'Controls the number of thinking tokens the model can use for internal reasoning. Larger budgets can improve response quality for complex problems.',
+      '',
+    ],
   ]}
 />
 
 **Default:** `"Auto (-1)"` (Google), `2000` (Anthropic, Bedrock (Anthropic models))
 
 **Example:**
+
 ```yaml
 preset:
-  thinkingBudget: "2000"
+  thinkingBudget: '2000'
 ```
 
 ---
@@ -1119,11 +1359,17 @@ preset:
 
 <OptionTable
   options={[
-    ['thinkingLevel', 'String', 'Controls the thinking effort level for Gemini 3+ models. Gemini 2.5 models use `thinkingBudget` instead.', ''],
+    [
+      'thinkingLevel',
+      'String',
+      'Controls the thinking effort level for Gemini 3+ models. Gemini 2.5 models use `thinkingBudget` instead.',
+      '',
+    ],
   ]}
 />
 
 **Accepted Values:**
+
 - `""` (unset/auto)
 - `"minimal"`
 - `"low"`
@@ -1133,9 +1379,10 @@ preset:
 **Default:** `""` (unset — model decides)
 
 **Example:**
+
 ```yaml
 preset:
-  thinkingLevel: "medium"
+  thinkingLevel: 'medium'
 ```
 
 ---
@@ -1146,7 +1393,12 @@ preset:
 
 <OptionTable
   options={[
-    ['effort', 'String', 'Controls the Adaptive Thinking effort level for supported Anthropic models (e.g., Claude Opus 4.6+). Higher effort levels allocate more thinking tokens for complex problems.', ''],
+    [
+      'effort',
+      'String',
+      'Controls the Adaptive Thinking effort level for supported Anthropic models (e.g., Claude Opus 4.6+). Higher effort levels allocate more thinking tokens for complex problems.',
+      '',
+    ],
   ]}
 />
 
@@ -1155,9 +1407,10 @@ preset:
 **Default:** `""` (unset — model decides)
 
 **Example:**
+
 ```yaml
 preset:
-  effort: "high"
+  effort: 'high'
 ```
 
 ---
@@ -1168,7 +1421,12 @@ preset:
 
 <OptionTable
   options={[
-    ['thinkingDisplay', 'String', 'Controls whether reasoning content is returned in model responses. Claude Opus 4.7+ omits thinking content by default; this setting lets you opt in to reasoning summaries or explicitly suppress them.', ''],
+    [
+      'thinkingDisplay',
+      'String',
+      'Controls whether reasoning content is returned in model responses. Claude Opus 4.7+ omits thinking content by default; this setting lets you opt in to reasoning summaries or explicitly suppress them.',
+      '',
+    ],
   ]}
 />
 
@@ -1181,9 +1439,10 @@ preset:
 **Default:** `"auto"`
 
 **Example:**
+
 ```yaml
 preset:
-  thinkingDisplay: "summarized"
+  thinkingDisplay: 'summarized'
 ```
 
 ---
@@ -1194,13 +1453,19 @@ preset:
 
 <OptionTable
   options={[
-    ['thinking', 'Boolean', 'Indicates whether the model should spend time thinking before generating a response.', ''],
+    [
+      'thinking',
+      'Boolean',
+      'Indicates whether the model should spend time thinking before generating a response.',
+      '',
+    ],
   ]}
 />
 
 **Default:** `true`
 
 **Example:**
+
 ```yaml
 preset:
   thinking: true
@@ -1213,16 +1478,13 @@ preset:
 > **Supported by:** `bedrock`  
 > (Used to specify an AWS region for Amazon Bedrock)
 
-<OptionTable
-  options={[
-    ['region', 'String', 'AWS region for Amazon Bedrock endpoints.', ''],
-  ]}
-/>
+<OptionTable options={[['region', 'String', 'AWS region for Amazon Bedrock endpoints.', '']]} />
 
 **Example:**
+
 ```yaml
 preset:
-  region: "us-east-1"
+  region: 'us-east-1'
 ```
 
 ---
@@ -1233,12 +1495,11 @@ preset:
 > (Used in place of `max_tokens`)
 
 <OptionTable
-  options={[
-    ['maxTokens', 'Number', 'Maximum output tokens for Amazon Bedrock endpoints.', ''],
-  ]}
+  options={[['maxTokens', 'Number', 'Maximum output tokens for Amazon Bedrock endpoints.', '']]}
 />
 
 **Example:**
+
 ```yaml
 preset:
   maxTokens: 1024

--- a/content/docs/configuration/logging.mdx
+++ b/content/docs/configuration/logging.mdx
@@ -98,3 +98,75 @@ By default, the JSON string length is truncated to 255 characters. You can confi
     ],
   ]}
 />
+
+- File-backed log transports are enabled by default. Set `LOG_TO_FILE=false` if your deployment should only emit logs to stdout/stderr.
+
+<OptionTable
+  options={[
+    [
+      'LOG_TO_FILE',
+      'boolean',
+      'Set to false to disable file-backed Winston transports.',
+      'LOG_TO_FILE=true',
+    ],
+  ]}
+/>
+
+### OpenTelemetry Tracing
+
+LibreChat can emit backend OpenTelemetry traces for server, database, Redis, and outbound HTTP visibility. This is separate from Langfuse, which remains the recommended option for GenAI-specific prompt and model observability.
+
+<OptionTable
+  options={[
+    [
+      'OTEL_TRACING_ENABLED',
+      'boolean',
+      'Enable backend OpenTelemetry tracing.',
+      '# OTEL_TRACING_ENABLED=false',
+    ],
+    [
+      'OTEL_SERVICE_NAME',
+      'string',
+      'Service name reported to OpenTelemetry. Default: librechat.',
+      '# OTEL_SERVICE_NAME=librechat',
+    ],
+    [
+      'OTEL_SERVICE_VERSION',
+      'string',
+      'Service version reported to OpenTelemetry.',
+      '# OTEL_SERVICE_VERSION=',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_ENDPOINT',
+      'string',
+      'Base OTLP exporter endpoint.',
+      '# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+      'string',
+      'Trace-specific OTLP endpoint.',
+      '# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=',
+    ],
+    [
+      'OTEL_EXPORTER_OTLP_HEADERS',
+      'string',
+      'OTLP exporter headers.',
+      '# OTEL_EXPORTER_OTLP_HEADERS=',
+    ],
+    ['OTEL_TRACES_EXPORTER', 'string', 'Trace exporter selection.', '# OTEL_TRACES_EXPORTER=otlp'],
+    [
+      'OTEL_TRACES_SAMPLER',
+      'string',
+      'OpenTelemetry trace sampler.',
+      '# OTEL_TRACES_SAMPLER=parentbased_always_on',
+    ],
+    ['OTEL_LOG_LEVEL', 'string', 'OpenTelemetry SDK log level.', '# OTEL_LOG_LEVEL=INFO'],
+    [
+      'OTEL_SDK_DISABLED',
+      'boolean',
+      'Disable the OpenTelemetry SDK even when tracing is enabled.',
+      '# OTEL_SDK_DISABLED=false',
+    ],
+  ]}
+/>

--- a/content/docs/configuration/redis.mdx
+++ b/content/docs/configuration/redis.mdx
@@ -61,6 +61,21 @@ REDIS_URI=redis://127.0.0.1:7001
 USE_REDIS_CLUSTER=true
 ```
 
+### Single-Endpoint Managed Redis Services
+
+Some managed Redis services, including AWS ElastiCache Serverless and Redis Enterprise Cloud on AWS, expose a single connection endpoint while sharding keys internally. In that setup, keep LibreChat in single-node connection mode, but enable cluster-safe deletes if cache clears fail with `CROSSSLOT Keys in request don't hash to the same slot`.
+
+```bash
+USE_REDIS=true
+REDIS_URI=rediss://your-managed-redis-endpoint:6379
+USE_REDIS_CLUSTER=false
+REDIS_CLUSTER_SAFE_DELETE=true
+```
+
+`REDIS_CLUSTER_SAFE_DELETE=true` makes LibreChat delete matching cache keys one at a time instead of sending multi-key `DEL` commands. This avoids `CROSSSLOT` errors without changing how LibreChat connects to Redis.
+
+Use `USE_REDIS_CLUSTER=true` only when LibreChat should create a Redis Cluster client. For single-endpoint managed services, `REDIS_CLUSTER_SAFE_DELETE=true` is the safer option.
+
 ### Redis with TLS/SSL
 
 For secure Redis connections:
@@ -104,9 +119,10 @@ REDIS_URI=rediss://your-redis-host:6380
 # Provide CA certificate for verification
 REDIS_CA=/path/to/your/ca-certificate.pem
 ```
+
 ### TLS with Elasticache
 
-Elasticache may need to use an alternate dnsLookup for TLS connections.  see "Special Note: Aws Elasticache Clusters with TLS" on this webpage: https://www.npmjs.com/package/ioredis
+Elasticache may need to use an alternate dnsLookup for TLS connections. see "Special Note: Aws Elasticache Clusters with TLS" on this webpage: https://www.npmjs.com/package/ioredis
 
 ```bash
 # Enable redis alternate dnsLookup
@@ -153,11 +169,13 @@ REDIS_KEY_PREFIX=dev-john-local
 **Important**: You cannot set both `REDIS_KEY_PREFIX_VAR` and `REDIS_KEY_PREFIX` simultaneously.
 
 **Examples of contamination without prefixing**:
+
 - Production cache overwritten by staging deployment
 - Feature branch tests corrupting main branch cache
 - Old deployment versions serving stale cached data
 
 **Key prefixing format**:
+
 - IoRedis client: `{prefix}::{key}`
 - Keyv client: Handled by the store layer
 
@@ -183,6 +201,7 @@ REDIS_PING_INTERVAL=300
 ```
 
 **Important**:
+
 - Setting `REDIS_PING_INTERVAL=0` or omitting it disables pinging entirely
 - Only set a positive value (in seconds) if you experience connection timeout issues
 - The interval is specified in seconds and applies to both IoRedis and Keyv Redis clients
@@ -199,33 +218,34 @@ FORCED_IN_MEMORY_CACHE_NAMESPACES=ROLES,MESSAGES
 
 Valid cache keys (from the `CacheKeys` enum in `librechat-data-provider`):
 
-| Key | Description |
-|---|---|
-| `CONFIG_STORE` | Configuration store |
-| `ROLES` | User roles |
-| `PLUGINS` | Plugins data |
-| `GEN_TITLE` | Generated titles |
-| `TOOLS` | Tools data |
-| `MODELS_CONFIG` | Models configuration |
-| `MODEL_QUERIES` | Model queries |
-| `STARTUP_CONFIG` | Startup configuration |
-| `ENDPOINT_CONFIG` | Endpoint configuration |
-| `TOKEN_CONFIG` | Token configuration |
-| `APP_CONFIG` | Application configuration |
-| `ABORT_KEYS` | Abort keys |
-| `BANS` | Ban data |
-| `ENCODED_DOMAINS` | Encoded domains |
-| `AUDIO_RUNS` | Audio processing runs |
-| `MESSAGES` | Messages |
-| `FLOWS` | Flows data |
-| `PENDING_REQ` | Pending requests |
-| `S3_EXPIRY_INTERVAL` | S3 expiry intervals |
-| `OPENID_EXCHANGED_TOKENS` | OpenID exchanged tokens |
-| `OPENID_SESSION` | OpenID sessions |
-| `SAML_SESSION` | SAML sessions |
+| Key                       | Description               |
+| ------------------------- | ------------------------- |
+| `CONFIG_STORE`            | Configuration store       |
+| `ROLES`                   | User roles                |
+| `PLUGINS`                 | Plugins data              |
+| `GEN_TITLE`               | Generated titles          |
+| `TOOLS`                   | Tools data                |
+| `MODELS_CONFIG`           | Models configuration      |
+| `MODEL_QUERIES`           | Model queries             |
+| `STARTUP_CONFIG`          | Startup configuration     |
+| `ENDPOINT_CONFIG`         | Endpoint configuration    |
+| `TOKEN_CONFIG`            | Token configuration       |
+| `APP_CONFIG`              | Application configuration |
+| `ABORT_KEYS`              | Abort keys                |
+| `BANS`                    | Ban data                  |
+| `ENCODED_DOMAINS`         | Encoded domains           |
+| `AUDIO_RUNS`              | Audio processing runs     |
+| `MESSAGES`                | Messages                  |
+| `FLOWS`                   | Flows data                |
+| `PENDING_REQ`             | Pending requests          |
+| `S3_EXPIRY_INTERVAL`      | S3 expiry intervals       |
+| `OPENID_EXCHANGED_TOKENS` | OpenID exchanged tokens   |
+| `OPENID_SESSION`          | OpenID sessions           |
+| `SAML_SESSION`            | SAML sessions             |
 
 <Callout type="warn" title="Invalid keys">
-Using an invalid key (e.g., the deprecated `STATIC_CONFIG`) will cause a startup error. Only use keys from the table above.
+  Using an invalid key (e.g., the deprecated `STATIC_CONFIG`) will cause a startup error. Only use
+  keys from the table above.
 </Callout>
 
 ## Performance Tuning
@@ -233,6 +253,7 @@ Using an invalid key (e.g., the deprecated `STATIC_CONFIG`) will cause a startup
 ### Connection Keep-Alive
 
 The application implements configurable connection keep-alive:
+
 - Ping intervals are controlled by `REDIS_PING_INTERVAL` environment variable
 - Default behavior: No pinging (recommended for most deployments)
 - When enabled, pings both IoRedis and Keyv Redis clients at the specified interval
@@ -241,6 +262,7 @@ The application implements configurable connection keep-alive:
 ### Cache Strategy
 
 The application uses a dual-client approach:
+
 - **IoRedis client**: Primary Redis operations with automatic prefixing
 - **Keyv Redis client**: Store-layer operations with prefix handling in `cacheFactory.js`
 

--- a/content/docs/features/admin_panel.mdx
+++ b/content/docs/features/admin_panel.mdx
@@ -9,7 +9,10 @@ description: A standalone web UI for managing LibreChat users, groups, roles, co
 The **LibreChat Admin Panel** is a standalone browser-based management interface for LibreChat. It connects to the same database as LibreChat itself and provides a GUI for the administrative tasks that power [granular access control](/docs/features/access_control): user and group administration, role management, configuration overrides scoped to roles or groups, and system-level capability grants.
 
 <Callout type="info" title="Status: Preview">
-The admin panel is available for testing now and is the upcoming management surface that builds on the admin APIs introduced in [LibreChat v0.8.5](/changelog/v0.8.5). Source, issues, and releases live at [github.com/ClickHouse/librechat-admin-panel](https://github.com/ClickHouse/librechat-admin-panel).
+  The admin panel is available for testing now and is the upcoming management surface that builds on
+  the admin APIs introduced in [LibreChat v0.8.5](/changelog/v0.8.5). Source, issues, and releases
+  live at
+  [github.com/ClickHouse/librechat-admin-panel](https://github.com/ClickHouse/librechat-admin-panel).
 </Callout>
 
 ## What It Does
@@ -42,15 +45,15 @@ The admin panel runs as a separate service; it does not share a process with Lib
 
 The admin API surface exposed by LibreChat is:
 
-| Mount | Purpose |
-| --- | --- |
-| `POST /api/admin/login` &nbsp; `/oauth/*` | Admin-specific authentication endpoints (local + SSO) |
-| `GET /api/admin/verify` | Validates the admin session |
-| `/api/admin/users` | User listing and search |
-| `/api/admin/groups` | Group CRUD + member management |
-| `/api/admin/roles` | Custom role CRUD + permission editing + member management |
-| `/api/admin/grants` | System capability grants (assign/revoke/list) |
-| `/api/admin/config` | Base + per-principal configuration overrides |
+| Mount                                     | Purpose                                                   |
+| ----------------------------------------- | --------------------------------------------------------- |
+| `POST /api/admin/login` &nbsp; `/oauth/*` | Admin-specific authentication endpoints (local + SSO)     |
+| `GET /api/admin/verify`                   | Validates the admin session                               |
+| `/api/admin/users`                        | User listing and search                                   |
+| `/api/admin/groups`                       | Group CRUD + member management                            |
+| `/api/admin/roles`                        | Custom role CRUD + permission editing + member management |
+| `/api/admin/grants`                       | System capability grants (assign/revoke/list)             |
+| `/api/admin/config`                       | Base + per-principal configuration overrides              |
 
 ## Getting Started
 
@@ -88,7 +91,10 @@ docker run -p 3000:3000 \
 ```
 
 <Callout type="warning" title="Docker Networking">
-Inside a container, `localhost` refers to the container itself, not your host. When LibreChat runs on the same host, point `VITE_API_BASE_URL` at `http://host.docker.internal:3080` (Linux: add `--add-host=host.docker.internal:host-gateway`). In production, use the public/internal DNS name of your LibreChat API.
+  Inside a container, `localhost` refers to the container itself, not your host. When LibreChat runs
+  on the same host, point `VITE_API_BASE_URL` at `http://host.docker.internal:3080` (Linux: add
+  `--add-host=host.docker.internal:host-gateway`). In production, use the public/internal DNS name
+  of your LibreChat API.
 </Callout>
 
 ### Run Locally for Development
@@ -103,28 +109,45 @@ bun dev                 # http://localhost:3000
 
 ## Environment Variables
 
-| Variable | Required | Default | Description |
-| --- | --- | --- | --- |
-| `SESSION_SECRET` | **Yes** in production | Hardcoded dev fallback when running `bun dev`; **no default** in the Docker image | Session encryption key. Must be at least 32 characters. |
-| `VITE_API_BASE_URL` | **Yes** in Docker | `http://localhost:3080` (local dev only) | Browser-facing URL of the LibreChat API server, used for OAuth redirects. |
-| `API_SERVER_URL` | No | Falls back to `VITE_API_BASE_URL` | Server-side URL for LibreChat API calls. Useful when the admin-panel server reaches LibreChat on a different URL than the browser (e.g. internal Kubernetes service vs. public hostname). |
-| `PORT` | No | `3000` | Port the admin panel listens on. |
-| `ADMIN_SSO_ONLY` | No | `false` | Hide the email/password form, forcing SSO-only login. |
-| `ADMIN_SESSION_IDLE_TIMEOUT_MS` | No | `1800000` (30 min) | Session idle timeout in milliseconds. |
-| `SESSION_COOKIE_SECURE` | No | `true` in production | Whether the session cookie requires HTTPS. |
-| `ADMIN_PANEL_METRICS_SECRET` | No | _unset_ | Bearer token required to scrape the `/metrics` Prometheus endpoint. The endpoint returns `401` when unset or mismatched. |
+| Variable                        | Required              | Default                                                                           | Description                                                                                                                                                                               |
+| ------------------------------- | --------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SESSION_SECRET`                | **Yes** in production | Hardcoded dev fallback when running `bun dev`; **no default** in the Docker image | Session encryption key. Must be at least 32 characters.                                                                                                                                   |
+| `VITE_API_BASE_URL`             | **Yes** in Docker     | `http://localhost:3080` (local dev only)                                          | Browser-facing URL of the LibreChat API server, used for OAuth redirects.                                                                                                                 |
+| `API_SERVER_URL`                | No                    | Falls back to `VITE_API_BASE_URL`                                                 | Server-side URL for LibreChat API calls. Useful when the admin-panel server reaches LibreChat on a different URL than the browser (e.g. internal Kubernetes service vs. public hostname). |
+| `PORT`                          | No                    | `3000`                                                                            | Port the admin panel listens on.                                                                                                                                                          |
+| `ADMIN_SSO_ONLY`                | No                    | `false`                                                                           | Hide the email/password form, forcing SSO-only login.                                                                                                                                     |
+| `ADMIN_SESSION_IDLE_TIMEOUT_MS` | No                    | `1800000` (30 min)                                                                | Session idle timeout in milliseconds.                                                                                                                                                     |
+| `SESSION_COOKIE_SECURE`         | No                    | `true` in production                                                              | Whether the session cookie requires HTTPS.                                                                                                                                                |
+| `ADMIN_PANEL_METRICS_SECRET`    | No                    | _unset_                                                                           | Bearer token required to scrape the `/metrics` Prometheus endpoint. The endpoint returns `401` when unset or mismatched.                                                                  |
+
+### LibreChat Redirect URL
+
+When the admin panel is hosted on a separate URL from LibreChat, set `ADMIN_PANEL_URL` in the LibreChat API environment. Use the external admin panel base URL, including any path prefix, and omit the trailing slash:
+
+```bash filename=".env"
+ADMIN_PANEL_URL=https://admin.example.com/admin
+```
+
+For Helm deployments, set `librechat.adminPanelUrl` in your values file. The chart renders it as `ADMIN_PANEL_URL` for LibreChat's admin OAuth flow:
+
+```yaml filename="values.yaml"
+librechat:
+  adminPanelUrl: https://admin.example.com/admin
+```
+
+For OpenID SSO, register `${DOMAIN_SERVER}/api/admin/oauth/openid/callback` with your identity provider.
 
 ### Cache Controls
 
 These mirror LibreChat's cache env vars. `ADMIN_PANEL_*` variants take precedence, falling back to the shared LibreChat equivalents when unset.
 
-| Variable | Purpose |
-| --- | --- |
-| `STATIC_CACHE_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_MAX_AGE` | Browser `max-age` in seconds for hashed assets in `/assets/` (default 172800 = 2 days). |
-| `STATIC_CACHE_S_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_S_MAX_AGE` | CDN `s-maxage` in seconds (default 86400 = 1 day). |
-| `INDEX_CACHE_CONTROL` / `ADMIN_PANEL_INDEX_CACHE_CONTROL` | `Cache-Control` header for the HTML index response. |
-| `INDEX_PRAGMA` / `ADMIN_PANEL_INDEX_PRAGMA` | `Pragma` header for the HTML index response. |
-| `INDEX_EXPIRES` / `ADMIN_PANEL_INDEX_EXPIRES` | `Expires` header for the HTML index response. |
+| Variable                                                        | Purpose                                                                                 |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `STATIC_CACHE_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_MAX_AGE`     | Browser `max-age` in seconds for hashed assets in `/assets/` (default 172800 = 2 days). |
+| `STATIC_CACHE_S_MAX_AGE` / `ADMIN_PANEL_STATIC_CACHE_S_MAX_AGE` | CDN `s-maxage` in seconds (default 86400 = 1 day).                                      |
+| `INDEX_CACHE_CONTROL` / `ADMIN_PANEL_INDEX_CACHE_CONTROL`       | `Cache-Control` header for the HTML index response.                                     |
+| `INDEX_PRAGMA` / `ADMIN_PANEL_INDEX_PRAGMA`                     | `Pragma` header for the HTML index response.                                            |
+| `INDEX_EXPIRES` / `ADMIN_PANEL_INDEX_EXPIRES`                   | `Expires` header for the HTML index response.                                           |
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

I refreshed the v0.8.6 docs updates against current docs `main` and regenerated the release changelog from the latest generated release notes.

- Added dotenv coverage for admin-panel redirect URLs, file logging control, OpenTelemetry tracing, session cookie secure overrides, and MCP streamable HTTP response limits.
- Documented new `librechat.yaml` fields for retention mode, per-server MCP proxy URLs, and model-spec badge row hiding.
- Updated the retention docs to clarify that `retentionMode: "all"` includes persistent agent resource files.
- Added the `config_v1.3.12` changelog entry and bumped example config versions to `1.3.12`.
- Refreshed the `v0.8.6` release changelog from the formatted `temp-changelog.md`; it now covers 127 changes and 17 new contributors since `v0.8.6-rc1`.
- Updated admin panel, logging, Redis, and MCP reference pages with the related setup notes.
- Left detailed HyperDX RUM docs to #585 and Bedrock profile/API-key auth coverage to #584 to avoid duplicate docs.

## Change Type

- [x] Documentation update

## Testing

### **Test Configuration**:

- Ran `npm exec -- prettier --check temp-changelog.md` in `/Users/danny/Projects/LibreChat`.
- Ran `pnpm exec prettier --check` on the changelog/config docs files that are Prettier-clean on `main`.
- Ran `git diff --check`.
- Checked merge-tree compatibility with overlapping docs PRs #590, #589, #587, #585, #584, #583, #582, #581, #580, #578, #576, #571, #557, and #526.
- Confirmed #554, #548, #544, #543, and #542 still have the same base-branch merge conflicts they already have against current `main`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
