### PR TITLE
🪣 docs: Clarify S3 Endpoint URL Scheme

### DIFF
--- a/content/docs/configuration/cdn/s3.mdx
+++ b/content/docs/configuration/cdn/s3.mdx
@@ -94,7 +94,7 @@ AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_REGION=your_selected_region
 AWS_BUCKET_NAME=your_bucket_name
-AWS_ENDPOINT_URL=your_endpoint_url
+AWS_ENDPOINT_URL=https://your_endpoint_url
 # AWS_FORCE_PATH_STYLE=false
 ```
 
@@ -102,7 +102,7 @@ AWS_ENDPOINT_URL=your_endpoint_url
 - **AWS_SECRET_ACCESS_KEY:** Your IAM user's secret key.
 - **AWS_REGION:** The AWS region where your S3 bucket is located.
 - **AWS_BUCKET_NAME:** The name of the S3 bucket you created.
-- **AWS_ENDPOINT_URL:** (Optional) The custom AWS endpoint URL. Required for S3-compatible services such as MinIO, Cloudflare R2, Hetzner Object Storage, and Backblaze B2.
+- **AWS_ENDPOINT_URL:** (Optional) The custom AWS endpoint URL. Required for S3-compatible services such as MinIO, Cloudflare R2, Hetzner Object Storage, Backblaze B2, and IDrive e2. Include the URL scheme, such as `https://a7g8.da.idrivee2-32.com`; values without `http://` or `https://` can cause an `Invalid URL` error when files are streamed.
 - **AWS_FORCE_PATH_STYLE:** (Optional) Set to `true` for providers that require path-style URLs (`endpoint/bucket/key`) rather than virtual-hosted-style (`bucket.endpoint/key`). Required for Hetzner Object Storage, MinIO, and similar providers whose SSL certificates don't cover bucket subdomains. Not needed for AWS S3 or Cloudflare R2. Default: `false`.
 
 If you are using **IRSA** on Kubernetes, you do **not** need to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your environment. The AWS SDK will automatically obtain temporary credentials via the service account assigned to your pod. Ensure that `AWS_REGION` and `AWS_BUCKET_NAME` are still provided.

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -2507,8 +2507,8 @@ See: **[Amazon S3 Configuration](/docs/configuration/cdn/s3)** and **[CloudFront
     [
       'AWS_ENDPOINT_URL',
       'string',
-      'Custom AWS endpoint URL (optional). For S3-compatible services.',
-      '# AWS_ENDPOINT_URL=',
+      'Custom AWS endpoint URL (optional). For S3-compatible services. Include the URL scheme, such as https://a7g8.da.idrivee2-32.com.',
+      '# AWS_ENDPOINT_URL=https://your_endpoint_url',
     ],
     [
       'AWS_FORCE_PATH_STYLE',


### PR DESCRIPTION
## Summary

I clarified the S3-compatible storage docs so custom `AWS_ENDPOINT_URL` values show a full URL with a scheme, matching the IDrive e2 workaround from danny-avila/LibreChat#13312.

- Updated the S3 configuration example to use `https://your_endpoint_url` instead of a bare hostname.
- Added IDrive e2 to the S3-compatible provider guidance and warned that missing `http://` or `https://` can cause `Invalid URL` during file streaming.
- Updated the `.env` option table to show the same fully qualified endpoint pattern.

Refs danny-avila/LibreChat#13312.
Refs danny-avila/librechat-agent-triage-reports#20.

## Change Type

- [x] Documentation update

## Testing

- Ran `pnpm exec prettier --check content/docs/configuration/cdn/s3.mdx content/docs/configuration/dotenv.mdx`.
- Ran `pnpm build`.

### **Test Configuration**:

- macOS
- Existing local checkout dependencies
- Next.js 16.1.6 production build

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
