### PR TITLE
docs: clarify `requiresOAuth` applies to all remote MCP transports, not just `sse`

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -92,7 +92,7 @@ mcpServers:
     ['timeout', 'Integer', '(Optional) Timeout in milliseconds for MCP server requests. Must be a non-negative integer.', 'timeout: 30000'],
     ['initTimeout', 'Integer', '(Optional) Timeout in milliseconds for MCP server initialization. Must be a non-negative integer.', 'initTimeout: 10000'],
     ['env', 'Object', '(Optional, `stdio` type only) Environment variables to use when spawning the process.', 'env:\n  NODE_ENV: "production"'],
-    ['requiresOAuth', 'Boolean', '(Optional, `sse` type only) Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it\'s best to set this value explicitly if you know whether the server requires OAuth or not.', 'requiresOAuth: true'],
+    ['requiresOAuth', 'Boolean', '(Optional, remote transports: `sse`, `streamable-http`, `websocket`) Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it\'s best to set this value explicitly if you know whether the server requires OAuth or not. Setting `requiresOAuth: false` is useful for servers protected by a static `Authorization` header, to skip auto-detection that would otherwise misclassify them as OAuth-protected.', 'requiresOAuth: false'],
     ['stderr', 'String or Integer', '(Optional, `stdio` type only) How to handle `stderr` of the child process. Options: `"pipe"`, `"ignore"`, `"inherit"`, or a non-negative integer (file descriptor). Defaults to `"inherit"`.', 'stderr: "inherit"'],
     ['customUserVars', 'Object', '(Optional) Defines custom variables that users can set for this MCP server, allowing for per-user credentials or configurations (e.g., API keys). These variables can then be referenced in `headers` or `env` fields.', 'customUserVars:\n  API_KEY:\n    title: "API Key"\n    description: "Your personal API key."'],
     ['oauth', 'Object', '(Optional) OAuth2 configuration for authenticating with the MCP server. When configured, users will be prompted to authenticate via OAuth flow.', 'oauth:\n  authorization_url: "https://example.com/oauth/authorize"\n  token_url: "https://example.com/oauth/token"'],
@@ -289,13 +289,14 @@ mcpServers:
 
 #### `requiresOAuth`
 
-- **Type:** Boolean (Optional, `sse` type only)
+- **Type:** Boolean (Optional, remote transports only: `sse`, `streamable-http`, `websocket`)
 - **Description:** Whether this server requires OAuth authentication. If not specified, will be auto-detected during server startup. Although optional, it's best to set this value explicitly if you know whether the server requires OAuth or not.
 - **Default Value:** Auto-detected if not specified
 - **Notes:**
-  - Only applicable to `sse` type MCP servers
+  - Applicable to remote (URL-based) transports: `sse`, `streamable-http`, and `websocket`. It has no effect on `stdio` servers, which have no URL to authenticate against.
   - Auto-detection occurs during server startup, which may add initialization time
   - Explicit configuration improves startup performance by skipping detection
+  - Set `requiresOAuth: false` for servers protected only by a static `Authorization` header (e.g. a Bearer API key). Auto-detection probes the server *without* your configured headers, so a server that answers `401` with a `WWW-Authenticate: Bearer` challenge can be misclassified as OAuth-protected; this flag bypasses that probe and lets your static header authenticate the connection normally.
   - Works with MCP OAuth environment variables (`MCP_OAUTH_ON_AUTH_ERROR`, `MCP_OAUTH_DETECTION_TIMEOUT`) for enhanced connection management
 
 #### `stderr`


### PR DESCRIPTION
The `requiresOAuth` option was documented as `sse` type only, but it lives in the shared base MCP options schema and is honored at runtime for every URL-based transport (`sse`, `streamable-http`, `websocket`). This PR corrects the type annotation and notes accordingly, and adds guidance that `requiresOAuth: false` should be set for servers protected only by a static `Authorization` header (e.g. a Bearer API key) — since startup auto-detection probes the server without the configured headers and can misclassify such a server as OAuth-protected when it answers with a `401`/`WWW-Authenticate: Bearer` challenge.
