### PR TITLE
docs: add Google Workspace MCP guide

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -376,6 +376,7 @@ mcpServers:
 - **Optional Subkeys:**
   - `grant_types_supported`: Array of Strings - Supported grant types (defaults to `["authorization_code", "refresh_token"]`)
   - `token_endpoint_auth_methods_supported`: Array of Strings - Supported token endpoint authentication methods (defaults to `["client_secret_basic", "client_secret_post"]`)
+  - `token_exchange_method`: String - Token exchange request method. Use `default_post` for providers that expect the OAuth client credentials in the POST body.
   - `response_types_supported`: Array of Strings - Supported response types (defaults to `["code"]`)
   - `code_challenge_methods_supported`: Array of Strings - Supported PKCE code challenge methods (defaults to `["S256", "plain"]`)
   - `skip_code_challenge_check`: Boolean - Skip checking whether the OAuth provider advertises PKCE support. Useful for providers like AWS Cognito that support S256 but don't advertise it in their metadata. (defaults to `false`)
@@ -390,6 +391,7 @@ mcpServers:
     scope: "read execute"
     grant_types_supported: ["authorization_code", "refresh_token"]
     token_endpoint_auth_methods_supported: ["client_secret_post"]
+    token_exchange_method: default_post
     response_types_supported: ["code"]
     code_challenge_methods_supported: ["S256", "plain"]
   ```

--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -195,6 +195,7 @@ Your MCP server is now installed and configurable in `librechat.yaml`. Restart L
 
 For detailed configuration options and examples, see:
 
+- [MCP Server Guides](/docs/mcp_servers)
 - [MCP Servers Configuration](/docs/configuration/librechat_yaml/object_structure/mcp_servers)
 - [Agent Configuration](/docs/configuration/librechat_yaml/object_structure/agents)
 - [Advanced Agent Features](/docs/features/agents#model-context-protocol-mcp)

--- a/content/docs/mcp_servers/google_workspace.mdx
+++ b/content/docs/mcp_servers/google_workspace.mdx
@@ -1,0 +1,383 @@
+---
+title: Google Workspace MCP
+icon: Chrome
+description: Configure Google's remote Workspace MCP servers for Gmail, Drive, Calendar, People, and Chat in LibreChat.
+---
+
+Google provides remote Model Context Protocol (MCP) servers for Google Workspace products. In LibreChat, each Google Workspace product is configured as its own OAuth-enabled remote MCP server.
+
+<Callout type="warning" title="Developer Preview">
+  Google marks the Workspace MCP servers as part of the Google Workspace Developer Preview Program.
+  Review Google's current documentation before deploying this broadly, because available products,
+  scopes, and verification requirements may change.
+</Callout>
+
+## What You Will Configure
+
+Google Workspace MCP is not one combined server. Configure only the products you want to expose to users:
+
+| Product         | MCP server URL                              |
+| --------------- | ------------------------------------------- |
+| Gmail           | `https://gmailmcp.googleapis.com/mcp/v1`    |
+| Google Drive    | `https://drivemcp.googleapis.com/mcp/v1`    |
+| Google Calendar | `https://calendarmcp.googleapis.com/mcp/v1` |
+| People API      | `https://people.googleapis.com/mcp/v1`      |
+| Google Chat     | `https://chatmcp.googleapis.com/mcp/v1`     |
+
+Each user connects each server from the LibreChat UI. LibreChat stores OAuth tokens per user, so Gmail, Drive, Calendar, People, and Chat access follows the Google account that authorized the connection.
+
+## Prerequisites
+
+- A Google Cloud project.
+- Permission to enable APIs and create OAuth clients in that project.
+- `gcloud` installed and authenticated, or access to the Google Cloud console.
+- A running LibreChat instance with `librechat.yaml` mounted or otherwise loaded.
+- The public base URL users use to open LibreChat, for example `http://localhost:3080` for local development or `https://chat.example.com` for production.
+
+<Callout type="info" title="OAuth callback path">
+  LibreChat's MCP OAuth callback path is `BASE_URL/api/mcp/SERVER_NAME/oauth/callback`.
+  `SERVER_NAME` is the key under `mcpServers` in `librechat.yaml`, such as `gmail` or `drive`.
+</Callout>
+
+## Setup
+
+<Steps>
+  <Step>
+
+### Enable the Google Workspace APIs
+
+Replace `PROJECT_ID` with your Google Cloud project ID:
+
+```bash
+gcloud services enable gmail.googleapis.com \
+  drive.googleapis.com \
+  calendar-json.googleapis.com \
+  chat.googleapis.com \
+  people.googleapis.com \
+  --project=PROJECT_ID
+```
+
+  </Step>
+  <Step>
+
+### Enable the Google Workspace MCP services
+
+Enable the MCP services for the products you plan to configure:
+
+```bash
+gcloud services enable gmailmcp.googleapis.com \
+  drivemcp.googleapis.com \
+  calendarmcp.googleapis.com \
+  chatmcp.googleapis.com \
+  people.googleapis.com \
+  --project=PROJECT_ID
+```
+
+  </Step>
+  <Step>
+
+### Configure Google Chat, if needed
+
+The Google Chat MCP server requires a Chat app in the same Google Cloud project.
+
+In the Google Cloud console, open **Google Chat API** > **Manage** > **Configuration** and create a Chat app:
+
+- **App name**: `Chat MCP`
+- **Avatar URL**: `https://developers.google.com/chat/images/quickstart-app-avatar.png`
+- **Description**: `Chat MCP server`
+- **Functionality**: turn off **Enable interactive features**
+- **Logs**: select **Log errors to Logging**
+
+Click **Save**.
+
+<Callout type="warning" title="Workspace account required for Chat">
+  Google Chat app configuration may be unavailable for consumer Google accounts. If the console says
+  that the Google Chat API is only available to Google Workspace users, omit the `chat` MCP server
+  or use a Workspace-backed project/account.
+</Callout>
+
+  </Step>
+  <Step>
+
+### Configure the Google Auth Platform
+
+In the Google Cloud console, go to **Google Auth Platform**.
+
+If the Google Auth Platform is not configured yet, click **Get Started** and provide:
+
+- **App name**: use a clear name, such as `LibreChat Google Workspace MCP`.
+- **User support email**: your support email or Google group.
+- **Audience**: choose **Internal** for a Google Workspace organization, or **External** if users are outside your organization or you are using a personal Google account.
+- **Developer contact information**: an email where Google can notify you about the project.
+
+If you choose **External** and keep the app in testing mode, add yourself and any other allowed users under **Audience** > **Test users**.
+
+  </Step>
+  <Step>
+
+### Add Data Access scopes
+
+Open **Data Access** > **Add or Remove Scopes**. Under **Manually add scopes**, paste the scopes for the servers you want to use.
+
+```text
+https://www.googleapis.com/auth/gmail.readonly
+https://www.googleapis.com/auth/gmail.compose
+https://www.googleapis.com/auth/drive.readonly
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/calendar.calendarlist.readonly
+https://www.googleapis.com/auth/calendar.events.freebusy
+https://www.googleapis.com/auth/calendar.events.readonly
+https://www.googleapis.com/auth/directory.readonly
+https://www.googleapis.com/auth/userinfo.profile
+https://www.googleapis.com/auth/contacts.readonly
+https://www.googleapis.com/auth/chat.spaces.readonly
+https://www.googleapis.com/auth/chat.memberships.readonly
+https://www.googleapis.com/auth/chat.messages.readonly
+https://www.googleapis.com/auth/chat.messages.create
+https://www.googleapis.com/auth/chat.users.readstate.readonly
+```
+
+Click **Add to Table**, **Update**, then **Save**.
+
+<Callout type="warning" title="Sensitive and restricted scopes">
+  Gmail, Drive, Chat, Contacts, and Directory scopes can trigger Google's sensitive or restricted
+  scope review. For personal or limited development use, users may see an unverified app warning and
+  a 100-user cap. For public or organization-wide use, complete Google's OAuth verification process
+  and any required restricted-scope review.
+</Callout>
+
+  </Step>
+  <Step>
+
+### Create a Web application OAuth client
+
+In **Google Auth Platform** > **Clients**, create an OAuth client:
+
+- **Application type**: `Web application`
+- **Name**: use a descriptive name, such as `LibreChat Google Workspace MCP`
+
+Add an authorized redirect URI for every server you configure. For local development:
+
+```text
+http://localhost:3080/api/mcp/gmail/oauth/callback
+http://localhost:3080/api/mcp/drive/oauth/callback
+http://localhost:3080/api/mcp/calendar/oauth/callback
+http://localhost:3080/api/mcp/people/oauth/callback
+http://localhost:3080/api/mcp/chat/oauth/callback
+```
+
+For production, replace `http://localhost:3080` with your LibreChat URL:
+
+```text
+https://chat.example.com/api/mcp/gmail/oauth/callback
+```
+
+Click **Create**, then copy the **Client ID** and **Client secret**.
+
+  </Step>
+  <Step>
+
+### Add OAuth credentials to `.env`
+
+Add the OAuth client values to your LibreChat `.env` file:
+
+```bash filename=".env"
+GOOGLE_WORKSPACE_MCP_CLIENT_ID=your-oauth-client-id
+GOOGLE_WORKSPACE_MCP_CLIENT_SECRET=your-oauth-client-secret
+```
+
+You can use different environment variable names if you also update the `librechat.yaml` references.
+
+  </Step>
+  <Step>
+
+### Add the MCP servers to `librechat.yaml`
+
+Add the servers you want under `mcpServers`. This example uses all currently documented Google Workspace MCP servers:
+
+```yaml filename="librechat.yaml"
+mcpServers:
+  gmail:
+    type: streamable-http
+    url: 'https://gmailmcp.googleapis.com/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    requiresOAuth: true
+    startup: false
+    oauth:
+      authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent'
+      token_url: 'https://oauth2.googleapis.com/token'
+      client_id: '${GOOGLE_WORKSPACE_MCP_CLIENT_ID}'
+      client_secret: '${GOOGLE_WORKSPACE_MCP_CLIENT_SECRET}'
+      scope: 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose'
+      redirect_uri: 'http://localhost:3080/api/mcp/gmail/oauth/callback'
+      token_exchange_method: default_post
+      token_endpoint_auth_methods_supported: ['client_secret_post']
+
+  drive:
+    type: streamable-http
+    url: 'https://drivemcp.googleapis.com/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    requiresOAuth: true
+    startup: false
+    oauth:
+      authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent'
+      token_url: 'https://oauth2.googleapis.com/token'
+      client_id: '${GOOGLE_WORKSPACE_MCP_CLIENT_ID}'
+      client_secret: '${GOOGLE_WORKSPACE_MCP_CLIENT_SECRET}'
+      scope: 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file'
+      redirect_uri: 'http://localhost:3080/api/mcp/drive/oauth/callback'
+      token_exchange_method: default_post
+      token_endpoint_auth_methods_supported: ['client_secret_post']
+
+  calendar:
+    type: streamable-http
+    url: 'https://calendarmcp.googleapis.com/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    requiresOAuth: true
+    startup: false
+    oauth:
+      authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent'
+      token_url: 'https://oauth2.googleapis.com/token'
+      client_id: '${GOOGLE_WORKSPACE_MCP_CLIENT_ID}'
+      client_secret: '${GOOGLE_WORKSPACE_MCP_CLIENT_SECRET}'
+      scope: 'https://www.googleapis.com/auth/calendar.calendarlist.readonly https://www.googleapis.com/auth/calendar.events.freebusy https://www.googleapis.com/auth/calendar.events.readonly'
+      redirect_uri: 'http://localhost:3080/api/mcp/calendar/oauth/callback'
+      token_exchange_method: default_post
+      token_endpoint_auth_methods_supported: ['client_secret_post']
+
+  people:
+    type: streamable-http
+    url: 'https://people.googleapis.com/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    requiresOAuth: true
+    startup: false
+    oauth:
+      authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent'
+      token_url: 'https://oauth2.googleapis.com/token'
+      client_id: '${GOOGLE_WORKSPACE_MCP_CLIENT_ID}'
+      client_secret: '${GOOGLE_WORKSPACE_MCP_CLIENT_SECRET}'
+      scope: 'https://www.googleapis.com/auth/directory.readonly https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/contacts.readonly'
+      redirect_uri: 'http://localhost:3080/api/mcp/people/oauth/callback'
+      token_exchange_method: default_post
+      token_endpoint_auth_methods_supported: ['client_secret_post']
+
+  chat:
+    type: streamable-http
+    url: 'https://chatmcp.googleapis.com/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    requiresOAuth: true
+    startup: false
+    oauth:
+      authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent'
+      token_url: 'https://oauth2.googleapis.com/token'
+      client_id: '${GOOGLE_WORKSPACE_MCP_CLIENT_ID}'
+      client_secret: '${GOOGLE_WORKSPACE_MCP_CLIENT_SECRET}'
+      scope: 'https://www.googleapis.com/auth/chat.spaces.readonly https://www.googleapis.com/auth/chat.memberships.readonly https://www.googleapis.com/auth/chat.messages.readonly https://www.googleapis.com/auth/chat.messages.create https://www.googleapis.com/auth/chat.users.readstate.readonly'
+      redirect_uri: 'http://localhost:3080/api/mcp/chat/oauth/callback'
+      token_exchange_method: default_post
+      token_endpoint_auth_methods_supported: ['client_secret_post']
+```
+
+If LibreChat is deployed at a public URL, update every `redirect_uri` to match the exact redirect URI registered in Google Cloud.
+
+<Callout type="info" title="Strict MCP domain allowlists">
+  If your `librechat.yaml` also configures `mcpSettings.allowedDomains`, add the Google MCP hosts
+  you use, such as `gmailmcp.googleapis.com`, `drivemcp.googleapis.com`,
+  `calendarmcp.googleapis.com`, `chatmcp.googleapis.com`, and `people.googleapis.com`.
+</Callout>
+
+  </Step>
+  <Step>
+
+### Restart LibreChat
+
+Restart LibreChat so it reloads `.env` and `librechat.yaml`.
+
+| Deployment | Command                              |
+| ---------- | ------------------------------------ |
+| Docker     | `docker compose up -d`               |
+| Local      | Stop the server, then start it again |
+
+To confirm the servers loaded in Docker, check the API logs:
+
+```bash
+docker logs LibreChat --tail 200 | grep MCP
+```
+
+  </Step>
+  <Step>
+
+### Connect each server in LibreChat
+
+Open LibreChat, then open **MCP Settings** or the **MCP Servers** dropdown in the chat input.
+
+For each Google Workspace server:
+
+1. Click **Connect**.
+2. Complete the Google OAuth flow in the browser.
+3. Review the requested scopes.
+4. Click **Allow**.
+
+After OAuth succeeds, the server's tools become available in chat and in the Agent Builder.
+
+  </Step>
+</Steps>
+
+## Testing
+
+Try prompts that target one server at a time:
+
+| Server   | Prompt                                                                     |
+| -------- | -------------------------------------------------------------------------- |
+| People   | "According to my Google profile, what's my name?"                          |
+| Drive    | "Find a file named Marketing Plan and summarize it."                       |
+| Gmail    | "Find my latest email about the marketing plan."                           |
+| Gmail    | "Draft an email to ariel@example.com saying I approve the marketing plan." |
+| Calendar | "When is my next meeting with Ariel?"                                      |
+| Chat     | "Search recent Google Chat messages about the marketing plan."             |
+
+## Troubleshooting
+
+| Symptom                                             | What to check                                                                                                                                                                                                           |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Google says `redirect_uri_mismatch`                 | The Google OAuth client redirect URI must exactly match the `redirect_uri` in `librechat.yaml`, including protocol, hostname, port, server name, and path.                                                              |
+| LibreChat shows the server but no tools             | Connect the server from the LibreChat UI. OAuth-enabled remote servers expose tools after the user has authenticated.                                                                                                   |
+| Google shows an unverified app warning              | This is expected for unverified apps requesting sensitive or restricted scopes. For personal or limited development use, users can continue through the warning until the project reaches Google's unverified user cap. |
+| OAuth works in testing but later expires            | External apps in testing mode can receive refresh tokens that expire after 7 days. Publish the app to production for longer-lived refresh tokens, or re-authenticate during development.                                |
+| Google Chat configuration is disabled               | Use a Google Workspace-backed project/account for Chat, or omit the `chat` server.                                                                                                                                      |
+| MCP requests are blocked by LibreChat domain policy | If `mcpSettings.allowedDomains` is configured, add the Google MCP server hostnames you use.                                                                                                                             |
+
+## Security Notes
+
+- Connect Google Workspace MCP servers only to LibreChat instances you trust.
+- Request only the products and scopes users actually need.
+- Review assistant-suggested actions before sending email, posting Chat messages, uploading files, or changing calendar events.
+- Treat email messages, documents, and chat messages as untrusted input. They can contain indirect prompt injection attempts that try to influence the assistant.
+- For public or organization-wide deployments, complete Google OAuth verification and follow your organization's third-party app access controls.
+
+## Related Pages
+
+<Cards num={3}>
+  <Cards.Card title="MCP" href="/docs/features/mcp" arrow>
+    Learn how MCP servers work in LibreChat.
+  </Cards.Card>
+  <Cards.Card
+    title="MCP Servers Object Structure"
+    href="/docs/configuration/librechat_yaml/object_structure/mcp_servers"
+    arrow
+  >
+    Review every available `mcpServers` configuration field.
+  </Cards.Card>
+  <Cards.Card
+    title="Google Workspace MCP servers"
+    href="https://developers.google.com/workspace/guides/configure-mcp-servers"
+    arrow
+  >
+    Read Google's official Workspace MCP setup guide.
+  </Cards.Card>
+</Cards>

--- a/content/docs/mcp_servers/index.mdx
+++ b/content/docs/mcp_servers/index.mdx
@@ -1,0 +1,16 @@
+---
+title: MCP Server Guides
+icon: Blocks
+description: Step-by-step guides for configuring specific MCP servers in LibreChat.
+---
+
+Use these guides to configure specific MCP servers with the right transport, OAuth callbacks, scopes, environment variables, and LibreChat settings.
+
+<Cards num={2}>
+  <Cards.Card title="Google Workspace MCP" href="/docs/mcp_servers/google_workspace" arrow>
+    Configure Gmail, Drive, Calendar, People, and Chat remote MCP servers with Google OAuth.
+  </Cards.Card>
+  <Cards.Card title="MCP overview" href="/docs/features/mcp" arrow>
+    Learn how MCP works in LibreChat before adding product-specific servers.
+  </Cards.Card>
+</Cards>

--- a/content/docs/mcp_servers/meta.json
+++ b/content/docs/mcp_servers/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "MCP Servers",
+  "icon": "Blocks",
+  "pages": ["index", "google_workspace"]
+}

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,6 +7,7 @@
     "configuration",
     "---Learn---",
     "features",
+    "mcp_servers",
     "user_guides",
     "---Tools---",
     "toolkit",


### PR DESCRIPTION
## Summary
- Add a new top-level MCP Servers docs section for product-specific MCP setup guides
- Add a Google Workspace MCP guide covering Google Cloud APIs, OAuth consent/scopes, Web app callbacks, LibreChat YAML, UI connection, testing, and troubleshooting
- Link the new MCP server guides section from the existing MCP overview and document `token_exchange_method` in the MCP OAuth object structure

## Validation
- `corepack pnpm exec prettier --check content/docs/mcp_servers/index.mdx content/docs/mcp_servers/meta.json content/docs/mcp_servers/google_workspace.mdx content/docs/meta.json`
- `pnpm build`