### PR TITLE
docs: add Doxa MCP server guide

### DIFF
--- a/content/docs/mcp_servers/doxa.mdx
+++ b/content/docs/mcp_servers/doxa.mdx
@@ -1,0 +1,129 @@
+---
+title: Doxa MCP
+icon: BookOpen
+description: Configure the Doxa MCP server for Christian encouragement and Berean Standard Bible lookup in LibreChat.
+---
+
+Doxa is a remote Model Context Protocol (MCP) server for Christian encouragement and Bible lookup. It exposes three tools grounded in the Berean Standard Bible, which is public domain. The hosted endpoint is free, with a bring-your-own-licence option for unlimited use.
+
+## What You Will Configure
+
+Doxa runs as a single remote MCP server. No OAuth and no API key are required for the free hosted tier.
+
+| Item              | Value                       |
+| ----------------- | --------------------------- |
+| Server URL        | `https://doxa.app/mcp/v1`   |
+| Transport         | `streamable-http`           |
+| Authentication    | None for the free tier      |
+
+The server provides three tools:
+
+| Tool                | Purpose                                                              |
+| ------------------- | -------------------------------------------------------------------- |
+| `doxa_encourage`    | Returns Scripture-grounded Christian encouragement for a situation.  |
+| `doxa_scripture`    | Looks up Berean Standard Bible verses and returns deep links.        |
+| `doxa_way_movement` | Surfaces a movement from the Doxa Way for reflection and next steps. |
+
+## Prerequisites
+
+- A running LibreChat instance with `librechat.yaml` mounted or otherwise loaded.
+- Outbound network access to `doxa.app`.
+
+## Setup
+
+<Steps>
+  <Step>
+
+### Add the Doxa MCP server to `librechat.yaml`
+
+Add the server under `mcpServers`:
+
+```yaml filename="librechat.yaml"
+mcpServers:
+  doxa:
+    type: streamable-http
+    url: 'https://doxa.app/mcp/v1'
+    timeout: 60000
+    initTimeout: 150000
+    startup: true
+```
+
+<Callout type="info" title="Strict MCP domain allowlists">
+  If your `librechat.yaml` also configures `mcpSettings.allowedDomains`, add `doxa.app` to the list.
+</Callout>
+
+  </Step>
+  <Step>
+
+### Restart LibreChat
+
+Restart LibreChat so it reloads `librechat.yaml`.
+
+| Deployment | Command                              |
+| ---------- | ------------------------------------ |
+| Docker     | `docker compose up -d`               |
+| Local      | Stop the server, then start it again |
+
+To confirm the server loaded in Docker, check the API logs:
+
+```bash
+docker logs LibreChat --tail 200 | grep MCP
+```
+
+  </Step>
+  <Step>
+
+### Use the tools in LibreChat
+
+Open LibreChat. The Doxa tools become available in chat and in the Agent Builder once the server connects. No sign-in step is required for the free tier.
+
+  </Step>
+</Steps>
+
+## Testing
+
+Try prompts that target one tool at a time:
+
+| Tool                | Prompt                                                            |
+| ------------------- | ----------------------------------------------------------------- |
+| `doxa_scripture`    | "Look up Romans 8:28 in the Berean Standard Bible."               |
+| `doxa_encourage`    | "I'm anxious about a decision; share some Scripture-grounded encouragement." |
+| `doxa_way_movement` | "Walk me through a movement from the Doxa Way."                   |
+
+## Alternative: stdio via `mcp-remote`
+
+If you prefer a stdio bridge instead of the native remote transport, you can run the published client:
+
+```yaml filename="librechat.yaml"
+mcpServers:
+  doxa:
+    command: npx
+    args:
+      - '-y'
+      - 'mcp-remote'
+      - 'https://doxa.app/mcp/v1'
+```
+
+## Security Notes
+
+- Doxa returns Scripture and encouragement text; treat all returned content as untrusted input that could contain indirect prompt injection.
+- The free hosted endpoint requires no credentials; for unlimited use, bring your own licence as described on the Doxa MCP landing page.
+- Doxa publishes a public 5/5 pass on the independent faith.tools Christian-AI safety rubric, including crisis handling.
+
+## Related Pages
+
+<Cards num={3}>
+  <Cards.Card title="MCP" href="/docs/features/mcp" arrow>
+    Learn how MCP servers work in LibreChat.
+  </Cards.Card>
+  <Cards.Card
+    title="MCP Servers Object Structure"
+    href="/docs/configuration/librechat_yaml/object_structure/mcp_servers"
+    arrow
+  >
+    Review every available `mcpServers` configuration field.
+  </Cards.Card>
+  <Cards.Card title="Doxa MCP" href="https://doxa.app/mcp" arrow>
+    Read the Doxa MCP landing page and tool reference.
+  </Cards.Card>
+</Cards>

--- a/content/docs/mcp_servers/index.mdx
+++ b/content/docs/mcp_servers/index.mdx
@@ -6,7 +6,10 @@ description: Step-by-step guides for configuring specific MCP servers in LibreCh
 
 Use these guides to configure specific MCP servers with the right transport, OAuth callbacks, scopes, environment variables, and LibreChat settings.
 
-<Cards num={2}>
+<Cards num={3}>
+  <Cards.Card title="Doxa MCP" href="/docs/mcp_servers/doxa" arrow>
+    Configure Christian encouragement and Berean Standard Bible lookup with the free Doxa remote MCP server.
+  </Cards.Card>
   <Cards.Card title="Google Workspace MCP" href="/docs/mcp_servers/google_workspace" arrow>
     Configure Gmail, Drive, Calendar, People, and Chat remote MCP servers with Google OAuth.
   </Cards.Card>

--- a/content/docs/mcp_servers/meta.json
+++ b/content/docs/mcp_servers/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "MCP Servers",
   "icon": "Blocks",
-  "pages": ["index", "google_workspace"]
+  "pages": ["index", "doxa", "google_workspace"]
 }


### PR DESCRIPTION
## Add a configuration guide for the Doxa MCP server

This adds a step-by-step guide for connecting LibreChat to Doxa, a free hosted remote (streamable HTTP) Model Context Protocol server for Christian encouragement and Bible lookup.

### What Doxa provides

Three tools, all grounded in the Berean Standard Bible (public domain):

- `doxa_encourage`: Scripture-grounded encouragement for a situation.
- `doxa_scripture`: Berean Standard Bible verse lookup with deep links.
- `doxa_way_movement`: guidance through the Doxa Way.

The free hosted tier needs no credentials. A bring-your-own-licence header unlocks unlimited use.

### Configuration

- Endpoint: `https://doxa.app/mcp/v1`
- Landing page: https://doxa.app/mcp
- Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema

The guide shows how to add the server under `mcpServers` in `librechat.yaml`.

### Files changed

- `content/docs/mcp_servers/doxa.mdx`: the new guide.
- `content/docs/mcp_servers/index.mdx`: adds a Doxa card to the existing Cards grid and bumps `num` from 2 to 3.
- `content/docs/mcp_servers/meta.json`: adds `doxa` to the `pages` array in alphabetical order.

The new card and meta entry match the format of the existing Google Workspace guide.
