### PR TITLE
docs: add Bedrock model access propagation note

### DIFF
--- a/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock_inference_profiles.mdx
@@ -379,13 +379,37 @@ aws cloudwatch list-metrics --namespace AWS/Bedrock --region us-east-1
 
 ### Common Issues
 
-| Issue                     | Cause                           | Solution                                                                      |
-| ------------------------- | ------------------------------- | ----------------------------------------------------------------------------- |
-| Model not recognized      | Missing model in `models` array | Add the model ID to `models` in librechat.yaml                                |
-| ARN not being used        | Model ID doesn't match          | Ensure the model ID in `inferenceProfiles` exactly matches what's in `models` |
-| Env variable not resolved | Typo or not set                 | Check `.env` file and ensure variable name matches `${VAR_NAME}`              |
-| Access Denied             | Missing IAM permissions         | Add `bedrock:InvokeModel*` permissions for the inference profile ARN          |
-| Profile not found         | Wrong region                    | Ensure you're creating/using profiles in the same region                      |
+| Issue                     | Cause                                  | Solution                                                                      |
+| ------------------------- | -------------------------------------- | ----------------------------------------------------------------------------- |
+| Model not recognized      | Missing model in `models` array        | Add the model ID to `models` in librechat.yaml                                |
+| ARN not being used        | Model ID doesn't match                 | Ensure the model ID in `inferenceProfiles` exactly matches what's in `models` |
+| Env variable not resolved | Typo or not set                        | Check `.env` file and ensure variable name matches `${VAR_NAME}`              |
+| Access Denied             | Missing IAM permissions                | Add `bedrock:InvokeModel*` permissions for the inference profile ARN          |
+| Model access denied       | Model agreement missing or propagating | Accept the Bedrock model agreement and wait for availability to propagate     |
+| Profile not found         | Wrong region                           | Ensure you're creating/using profiles in the same region                      |
+
+### Model Access Agreement Propagation
+
+Creating an application inference profile does not automatically enable the underlying foundation model in your AWS account. If model access was just enabled, AWS may also need a short propagation window before requests through the inference profile succeed.
+
+This can appear as an `AccessDeniedException` even when the inference profile exists and your IAM role has `bedrock:InvokeModel` permissions. The error may mention `aws-marketplace:ViewSubscriptions`, `aws-marketplace:Subscribe`, or ask you to try again after a few minutes.
+
+Check the underlying model availability before debugging the LibreChat mapping:
+
+```bash
+aws bedrock get-foundation-model-availability \
+  --region us-east-1 \
+  --model-id us.anthropic.claude-sonnet-4-5-20250929-v1:0
+```
+
+Look for:
+
+- `agreementAvailability.status` set to `AVAILABLE`
+- `authorizationStatus` set to `AUTHORIZED`
+- `entitlementAvailability` set to `AVAILABLE`
+- `regionAvailability` set to `AVAILABLE`
+
+If the agreement is missing, accept the model agreement in the Bedrock console or with an AWS principal that can manage Bedrock model agreements and Marketplace subscriptions. After it changes to `AVAILABLE`, wait a couple of minutes and retry invoking the application inference profile.
 
 ### Debug Checklist
 
@@ -393,7 +417,8 @@ aws cloudwatch list-metrics --namespace AWS/Bedrock --region us-east-1
 2. Model ID in `inferenceProfiles` exactly matches (case-sensitive)
 3. Environment variable is set (if using `${VAR}` syntax)
 4. AWS credentials have permission to invoke the inference profile
-5. LibreChat has been restarted after config changes
+5. The underlying foundation model agreement is `AVAILABLE` in Bedrock
+6. LibreChat has been restarted after config changes
 
 ### Verify Config Loading
 
@@ -471,6 +496,7 @@ aws bedrock list-inference-profiles --type-equals APPLICATION --region $REGION \
 ## Related Resources
 
 - [AWS Bedrock Inference Profiles Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html)
+- [AWS Bedrock Model Access Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
 - [AWS Bedrock Object Structure](/docs/configuration/librechat_yaml/object_structure/aws_bedrock) - YAML config field reference
 - [AWS Bedrock Setup](/docs/configuration/pre_configured_ai/bedrock) - Basic Bedrock configuration
 - [AWS Bedrock Model Invocation Logging](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html)


### PR DESCRIPTION
## Summary

- adds a troubleshooting note for Bedrock model agreement propagation when using application inference profiles
- documents the `get-foundation-model-availability` check before debugging LibreChat inference profile mappings
- adds AWS Bedrock model access docs to the related resources

## Context

An application inference profile can exist and have valid invoke permissions while the underlying foundation model agreement is still missing or propagating. In that state, Bedrock may return `AccessDeniedException` mentioning Marketplace subscription permissions even though the LibreChat inference profile mapping is correct.

## Validation

- `git diff --check`
