### PR TITLE
📚 docs: Document messagePiiFilter object

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -1250,16 +1250,16 @@ see: [Speech Object Structure](/docs/configuration/librechat_yaml/object_structu
 
 see: [Turnstile Object Structure](/docs/configuration/librechat_yaml/object_structure/turnstile)
 
-## messagePiiFilter
+## messageFilter
 
 **Key:**
 
 <OptionTable
   options={[
     [
-      'messagePiiFilter',
+      'messageFilter',
       'Object',
-      'Rejects chat messages whose text matches configured credential-shaped patterns before they reach moderation, the model, or the database. Omit to disable.',
+      'Groups configurable user-message safety filters. Filter types live under per-type sub-keys (`pii` today). Omit to disable.',
       '',
     ],
   ]}
@@ -1270,21 +1270,15 @@ see: [Turnstile Object Structure](/docs/configuration/librechat_yaml/object_stru
 <OptionTable
   options={[
     [
-      'starterPatterns',
-      'Array of Strings',
-      'Optional subset of starter pattern ids (`sk_prefix`, `bearer_header`, `api_key_header`). Omit to enable all starters; pass `[]` to disable starters entirely.',
-      '',
-    ],
-    [
-      'customPatterns',
-      'Array of Objects',
-      'Optional operator-defined regex patterns. Each entry needs `id`, `label`, and `regex`.',
+      'pii',
+      'Object',
+      'Configures the credential-pattern (PII) filter. Rejects user prompts that contain credential-shaped tokens (e.g. `sk-`, `Bearer`, `api-key:`) before they reach moderation, the model, or the database.',
       '',
     ],
   ]}
 />
 
-see: [Message PII Filter Object Structure](/docs/configuration/librechat_yaml/object_structure/message_pii_filter)
+see: [Message Filter Object Structure](/docs/configuration/librechat_yaml/object_structure/message_filter)
 
 ## transactions
 

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -1250,6 +1250,42 @@ see: [Speech Object Structure](/docs/configuration/librechat_yaml/object_structu
 
 see: [Turnstile Object Structure](/docs/configuration/librechat_yaml/object_structure/turnstile)
 
+## messagePiiFilter
+
+**Key:**
+
+<OptionTable
+  options={[
+    [
+      'messagePiiFilter',
+      'Object',
+      'Rejects chat messages whose text matches configured credential-shaped patterns before they reach moderation, the model, or the database. Omit to disable.',
+      '',
+    ],
+  ]}
+/>
+
+**Subkeys:**
+
+<OptionTable
+  options={[
+    [
+      'starterPatterns',
+      'Array of Strings',
+      'Optional subset of starter pattern ids (`sk_prefix`, `bearer_header`, `api_key_header`). Omit to enable all starters; pass `[]` to disable starters entirely.',
+      '',
+    ],
+    [
+      'customPatterns',
+      'Array of Objects',
+      'Optional operator-defined regex patterns. Each entry needs `id`, `label`, and `regex`.',
+      '',
+    ],
+  ]}
+/>
+
+see: [Message PII Filter Object Structure](/docs/configuration/librechat_yaml/object_structure/message_pii_filter)
+
 ## transactions
 
 **Key:**

--- a/content/docs/configuration/librechat_yaml/object_structure/message_filter.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/message_filter.mdx
@@ -1,19 +1,21 @@
 ---
-title: "Message PII Filter Object Structure"
+title: "Message Filter Object Structure"
 icon: ShieldAlert
 ---
 
 ## Overview
 
-The `messagePiiFilter` object lets operators reject user prompts whose text matches credential-shaped patterns before the request reaches OpenAI moderation, the model, or the database. The filter is opt-in: omit the section entirely to leave it inert.
+The `messageFilter` object groups configurable safety filters that scan user prompts before the request reaches OpenAI moderation, the model, or the database. Filters live under per-type sub-keys (`messageFilter.<type>`); today only `pii` ships, but the namespace is structured so future filter types can plug in.
 
-The same set of patterns guards three entry points:
+The PII filter rejects user prompts whose text matches credential-shaped patterns. It is opt-in: omit the section entirely to leave it inert.
+
+The same pattern set guards three entry points:
 
   - The agent chat route (`/api/agents/chat`), where the filter is mounted as middleware ahead of `moderateText`.
   - The OpenAI-compatible remote agents endpoint (`/api/agents/v1/chat/completions`), where the controller walks the incoming `messages` array.
   - The Responses remote agents endpoint (`/api/agents/v1/responses`), where the controller walks the converted internal messages.
 
-When a configured pattern matches any user-role content, the request is refused with HTTP 400 and the error code `message_pii_filter_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted.
+When a configured pattern matches any user-role content, the request is refused with HTTP 400 and the error code `message_filter_pii_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted.
 
 Three starter patterns ship by default:
 
@@ -26,18 +28,19 @@ Operators can pick a subset of the starters with `starterPatterns: [...]`, suppl
 ## Example
 
 ```yaml
-messagePiiFilter:
-  # Omit `starterPatterns` to enable all starters. Pass an explicit
-  # list to subset them. Pass `[]` to disable starters entirely.
-  starterPatterns: [sk_prefix, bearer_header, api_key_header]
+messageFilter:
+  pii:
+    # Omit `starterPatterns` to enable all starters. Pass an explicit
+    # list to subset them. Pass `[]` to disable starters entirely.
+    starterPatterns: [sk_prefix, bearer_header, api_key_header]
 
-  # Operator-defined patterns. Each entry needs `id`, `label`, and a
-  # JavaScript-flavor `regex`. The regex is validated at config load
-  # time; an invalid pattern fails startup.
-  customPatterns:
-    - id: anthropic_api_key
-      label: Anthropic API key
-      regex: "sk-ant-[A-Za-z0-9_-]{20,}"
+    # Operator-defined patterns. Each entry needs `id`, `label`, and a
+    # JavaScript-flavor `regex`. The regex is validated at config load
+    # time; an invalid pattern fails startup.
+    customPatterns:
+      - id: anthropic_api_key
+        label: Anthropic API key
+        regex: "sk-ant-[A-Za-z0-9_-]{20,}"
 ```
 
 ## Fields
@@ -45,11 +48,18 @@ messagePiiFilter:
 **Key:**
 <OptionTable
   options={[
-    ['messagePiiFilter', 'Object', 'Configures credential-pattern matching for the chat endpoint. Omit to disable.', ''],
+    ['messageFilter', 'Object', 'Groups configurable user-message safety filters. Filter types live under per-type sub-keys (`pii` today). Omit to disable.', ''],
   ]}
 />
 
 **Subkeys:**
+<OptionTable
+  options={[
+    ['pii', 'Object', 'Configures the credential-pattern (PII) filter. Omit to disable.', ''],
+  ]}
+/>
+
+**`pii` subkeys:**
 <OptionTable
   options={[
     ['starterPatterns', 'Array of Strings', 'Optional subset of starter pattern ids to enable. Omit to enable all starters. Pass `[]` to disable starters entirely.', ''],
@@ -68,13 +78,13 @@ messagePiiFilter:
 
 ## Rejection response
 
-Each entry point returns a 400 in the shape it normally uses for invalid requests, with the `message_pii_filter_block` code.
+Each entry point returns a 400 in the shape it normally uses for invalid requests, with the `message_filter_pii_block` code.
 
 The chat route returns:
 
 ```json
 {
-  "error": "message_pii_filter_block",
+  "error": "message_filter_pii_block",
   "message": "Message contains a <pattern label>. Remove it and try again."
 }
 ```
@@ -85,7 +95,7 @@ The OpenAI-compatible endpoint returns its standard error envelope:
 {
   "error": {
     "type": "invalid_request_error",
-    "code": "message_pii_filter_block",
+    "code": "message_filter_pii_block",
     "message": "Message contains a <pattern label>. Remove it and try again.",
     "param": null
   }

--- a/content/docs/configuration/librechat_yaml/object_structure/message_filter.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/message_filter.mdx
@@ -15,7 +15,7 @@ The same pattern set guards three entry points:
   - The OpenAI-compatible remote agents endpoint (`/api/agents/v1/chat/completions`), where the controller walks the incoming `messages` array.
   - The Responses remote agents endpoint (`/api/agents/v1/responses`), where the controller walks the converted internal messages.
 
-When a configured pattern matches any user-role content, the request is refused with HTTP 400 and the error code `message_filter_pii_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted.
+When a configured pattern matches any user-supplied message content, the request is refused with HTTP 400 and the error code `message_filter_pii_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted.
 
 Three starter patterns ship by default:
 
@@ -109,5 +109,5 @@ The `<pattern label>` matches the `label` of the first matching pattern (starter
 ## Notes
 
 - Pattern matching uses JavaScript regex semantics. `customPatterns` entries from `librechat.yaml` are validated at config load time; entries that arrive through the admin DB override path skip Zod validation, so an invalid pattern is logged and skipped at request time rather than crashing the chat.
-- Only user-role message content is scanned. Authorization headers, system prompts, and assistant turns are not inspected.
+- All caller-supplied message content is scanned regardless of role. The remote agent APIs accept `system`, `assistant`, `tool`, and `developer` roles in addition to `user`, and the caller controls the full message history; the chat route only carries the single user prompt. HTTP transport headers (e.g. `Authorization`) are not inspected.
 - The filter is independent of the moderation feature controlled by `OPENAI_MODERATION`. Both can run together; the PII filter executes first so credential-shaped text is never sent to the moderation service.

--- a/content/docs/configuration/librechat_yaml/object_structure/message_pii_filter.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/message_pii_filter.mdx
@@ -1,0 +1,80 @@
+---
+title: "Message PII Filter Object Structure"
+icon: ShieldAlert
+---
+
+## Overview
+
+The `messagePiiFilter` object lets operators reject chat messages whose text matches credential-shaped patterns before the request reaches OpenAI moderation, the model, or the database. The filter is opt-in: omit the section entirely to leave it inert.
+
+The middleware is mounted on the agent chat route ahead of `moderateText`. When a configured pattern matches the user's message, the request is refused with HTTP 400 and the error code `message_pii_filter_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted to MongoDB.
+
+Three starter patterns ship by default:
+
+  - `sk_prefix` — tokens beginning with `sk-` (OpenAI, Anthropic, Langfuse, etc.)
+  - `bearer_header` — `Bearer <token>` strings (case-insensitive)
+  - `api_key_header` — `api-key: <token>` headers (case-insensitive)
+
+Operators can pick a subset of the starters with `starterPatterns: [...]`, supply their own regex with `customPatterns`, or do both.
+
+## Example
+
+```yaml
+messagePiiFilter:
+  # Omit `starterPatterns` to enable all starters. Pass an explicit
+  # list to subset them. Pass `[]` to disable starters entirely.
+  starterPatterns: [sk_prefix, bearer_header, api_key_header]
+
+  # Operator-defined patterns. Each entry needs `id`, `label`, and a
+  # JavaScript-flavor `regex`. The regex is validated at config load
+  # time; an invalid pattern fails startup.
+  customPatterns:
+    - id: anthropic_api_key
+      label: Anthropic API key
+      regex: "sk-ant-[A-Za-z0-9_-]{20,}"
+```
+
+## Fields
+
+**Key:**
+<OptionTable
+  options={[
+    ['messagePiiFilter', 'Object', 'Configures credential-pattern matching for the chat endpoint. Omit to disable.', ''],
+  ]}
+/>
+
+**Subkeys:**
+<OptionTable
+  options={[
+    ['starterPatterns', 'Array of Strings', 'Optional subset of starter pattern ids to enable. Omit to enable all starters. Pass `[]` to disable starters entirely.', ''],
+    ['customPatterns', 'Array of Objects', 'Optional operator-defined patterns. Each entry needs `id`, `label`, and `regex`.', ''],
+  ]}
+/>
+
+**`customPatterns` entry:**
+<OptionTable
+  options={[
+    ['id', 'String', 'Stable identifier used in logs and error responses.', ''],
+    ['label', 'String', 'Human-readable label included in the rejection error message.', ''],
+    ['regex', 'String', 'JavaScript-flavor regex. The pattern is compiled with the `g` flag and validated at config load time.', ''],
+  ]}
+/>
+
+## Rejection response
+
+When the middleware rejects a request the chat endpoint returns:
+
+```json
+{
+  "error": "message_pii_filter_block",
+  "message": "Message contains a <pattern label>. Remove it and try again."
+}
+```
+
+The `<pattern label>` matches the `label` of the first matching pattern (starter labels are `sk- prefix token`, `Bearer token`, `api-key header`; custom labels are whatever the operator supplies).
+
+## Notes
+
+- The filter runs only on the agent chat route. Other endpoints (OpenAI-compatible, Responses, programmatic agent sessions) are not covered.
+- Pattern matching uses JavaScript regex semantics. Custom regex is rejected at config load time if `new RegExp(value, 'g')` throws.
+- The filter is independent of the moderation feature controlled by `OPENAI_MODERATION`. Both can run together; the PII filter executes first so credential-shaped text is never sent to the moderation service.

--- a/content/docs/configuration/librechat_yaml/object_structure/message_pii_filter.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/message_pii_filter.mdx
@@ -5,9 +5,15 @@ icon: ShieldAlert
 
 ## Overview
 
-The `messagePiiFilter` object lets operators reject chat messages whose text matches credential-shaped patterns before the request reaches OpenAI moderation, the model, or the database. The filter is opt-in: omit the section entirely to leave it inert.
+The `messagePiiFilter` object lets operators reject user prompts whose text matches credential-shaped patterns before the request reaches OpenAI moderation, the model, or the database. The filter is opt-in: omit the section entirely to leave it inert.
 
-The middleware is mounted on the agent chat route ahead of `moderateText`. When a configured pattern matches the user's message, the request is refused with HTTP 400 and the error code `message_pii_filter_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted to MongoDB.
+The same set of patterns guards three entry points:
+
+  - The agent chat route (`/api/agents/chat`), where the filter is mounted as middleware ahead of `moderateText`.
+  - The OpenAI-compatible remote agents endpoint (`/api/agents/v1/chat/completions`), where the controller walks the incoming `messages` array.
+  - The Responses remote agents endpoint (`/api/agents/v1/responses`), where the controller walks the converted internal messages.
+
+When a configured pattern matches any user-role content, the request is refused with HTTP 400 and the error code `message_pii_filter_block`. Nothing is sent to the moderation endpoint, nothing is dispatched to the model, and nothing is persisted.
 
 Three starter patterns ship by default:
 
@@ -62,7 +68,9 @@ messagePiiFilter:
 
 ## Rejection response
 
-When the middleware rejects a request the chat endpoint returns:
+Each entry point returns a 400 in the shape it normally uses for invalid requests, with the `message_pii_filter_block` code.
+
+The chat route returns:
 
 ```json
 {
@@ -71,10 +79,25 @@ When the middleware rejects a request the chat endpoint returns:
 }
 ```
 
+The OpenAI-compatible endpoint returns its standard error envelope:
+
+```json
+{
+  "error": {
+    "type": "invalid_request_error",
+    "code": "message_pii_filter_block",
+    "message": "Message contains a <pattern label>. Remove it and try again.",
+    "param": null
+  }
+}
+```
+
+The Responses endpoint uses the same envelope with `"type": "invalid_request"`.
+
 The `<pattern label>` matches the `label` of the first matching pattern (starter labels are `sk- prefix token`, `Bearer token`, `api-key header`; custom labels are whatever the operator supplies).
 
 ## Notes
 
-- The filter runs only on the agent chat route. Other endpoints (OpenAI-compatible, Responses, programmatic agent sessions) are not covered.
-- Pattern matching uses JavaScript regex semantics. Custom regex is rejected at config load time if `new RegExp(value, 'g')` throws.
+- Pattern matching uses JavaScript regex semantics. `customPatterns` entries from `librechat.yaml` are validated at config load time; entries that arrive through the admin DB override path skip Zod validation, so an invalid pattern is logged and skipped at request time rather than crashing the chat.
+- Only user-role message content is scanned. Authorization headers, system prompts, and assistant turns are not inspected.
 - The filter is independent of the moderation feature controlled by `OPENAI_MODERATION`. Both can run together; the PII filter executes first so credential-shaped text is never sent to the moderation service.

--- a/content/docs/configuration/librechat_yaml/object_structure/meta.json
+++ b/content/docs/configuration/librechat_yaml/object_structure/meta.json
@@ -7,6 +7,7 @@
     "interface",
     "registration",
     "turnstile",
+    "message_pii_filter",
     "---Models & Specs---",
     "model_specs",
     "model_config",

--- a/content/docs/configuration/librechat_yaml/object_structure/meta.json
+++ b/content/docs/configuration/librechat_yaml/object_structure/meta.json
@@ -7,7 +7,7 @@
     "interface",
     "registration",
     "turnstile",
-    "message_pii_filter",
+    "message_filter",
     "---Models & Specs---",
     "model_specs",
     "model_config",


### PR DESCRIPTION
## Summary

Adds documentation for the new `messageFilter` configuration object introduced in danny-avila/LibreChat#13602. The page lives at `content/docs/configuration/librechat_yaml/object_structure/message_filter.mdx` and is linked from the top-level `config.mdx` and the General section of the object-structure navigation.

Covers what the namespace is for (today only `pii` ships; future safety filters plug in alongside), the three entry points the PII filter guards (`/api/agents/chat`, `/api/agents/v1/chat/completions`, `/api/agents/v1/responses`), the three starter patterns shipped by default, the `customPatterns` shape, the per-endpoint rejection error envelopes (all carrying the `message_filter_pii_block` code), and the override-path Zod-skip note operators need when authoring patterns through the admin UI.

## Companion PR

Depends on danny-avila/LibreChat#13602. Should land after the code PR is merged so the configuration this page documents is actually shipped.