### PR TITLE
🧾 docs: Resolve Documentation Feedback Issues

### DIFF
--- a/content/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/azure.mdx
@@ -8,7 +8,7 @@ description: Learn how to configure LibreChat to use Azure Entra for user authen
 2. In the search box, type "Azure Entra" and click on it.
 3. On the left menu, click on App registrations and then on New registration.
 4. Give your app a name and select Web as the platform type.
-5. In the Redirect URI field, enter `http://localhost:3080/oauth/openid/callback` and click on Register.
+5. In the Redirect URI field, enter your LibreChat OpenID callback URL and click on Register. For local Docker installs, use `http://localhost:3080/oauth/openid/callback`. For deployed instances, replace `http://localhost:3080` with your public `DOMAIN_SERVER` value, for example `https://chat.example.com/oauth/openid/callback`.
 
 ![image](https://github.com/danny-avila/LibreChat/assets/6623884/2b1aabce-850e-4165-bf76-3c1984f10b6c)
 
@@ -58,6 +58,9 @@ OPENID_REQUIRED_ROLE="Your Group Name" # Single role or comma-separated roles (e
 # Optional: redirects the user to the end session endpoint after logging out
 OPENID_USE_END_SESSION_ENDPOINT=true 
 ```
+
+The redirect URI registered in Azure must exactly match the URL LibreChat serves. If `DOMAIN_SERVER=https://chat.example.com`, Azure should use `https://chat.example.com/oauth/openid/callback`.
+
 11. Save the .env file
 
 > Note: If using docker, run `docker compose up -d` to apply the .env configuration changes

--- a/content/docs/configuration/authentication/OAuth2-OIDC/index.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/index.mdx
@@ -43,3 +43,6 @@ If you encounter issues with OpenID Connect authentication:
 5. **Validate Tokens**: Ensure your provider is issuing valid tokens with the expected claims
 6. **Ensure _nonce_ is generated**: Some identity providers generate `nonce` url parameter if it's missing in the request. Set `OPENID_GENERATE_NONCE=true` to force the openid-client to generate it.
 
+### Admin Panel Redirects
+
+If the Admin Panel is hosted on a separate URL from LibreChat, set [`ADMIN_PANEL_URL`](/docs/features/admin_panel#librechat-redirect-url) in the LibreChat API environment. This tells LibreChat where to send admins after the admin OAuth or SSO callback completes.

--- a/content/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -99,7 +99,7 @@ baseURL: "user_provided"
 **Key:**
 <OptionTable
   options={[
-    ['iconURL', 'String', 'The URL to use as the Endpoint Icon.', ''],
+    ['iconURL', 'String', 'Image URL, public asset path, or built-in endpoint icon key to use as the endpoint icon.', ''],
   ]}
 />
 
@@ -109,10 +109,17 @@ baseURL: "user_provided"
 ```yaml filename="endpoints / custom / iconURL"
 iconURL: https://github.com/danny-avila/LibreChat/raw/main/docs/assets/LibreChat.svg
 ```
+or reuse a built-in endpoint icon:
+```yaml filename="endpoints / custom / iconURL"
+iconURL: openAI
+```
 **Notes:**
 
-* If you want to use existing project icons, define the endpoint `name` as one of the main endpoints (case-sensitive):
-  - "openAI" | "azureOpenAI" | "google" | "anthropic" | "assistants" | "gptPlugins"
+* Do not set a custom endpoint `name` to a built-in endpoint name just to reuse an icon. Custom endpoint names must be unique and should not use default endpoint values such as:
+  - "openAI" | "azureOpenAI" | "google" | "anthropic" | "assistants" | "azureAssistants" | "agents" | "bedrock"
+* To use a project-included endpoint icon, keep the custom endpoint `name` unique and set `iconURL` to one of the built-in endpoint keys instead.
+  - "openAI" | "azureOpenAI" | "google" | "anthropic" | "assistants" | "azureAssistants" | "agents" | "bedrock"
+* To use a custom image, set `iconURL` to an image URL or a path served by LibreChat, such as `/assets/my-icon.svg`.
 * There are also "known endpoints" (case-insensitive), which have icons provided. If your endpoint `name` matches the following names, you should omit this field:
   - "Anyscale"
   - "APIpie"

--- a/content/docs/configuration/rag_api.mdx
+++ b/content/docs/configuration/rag_api.mdx
@@ -128,6 +128,8 @@ Docker uses the "lite" image of the RAG API by default, which only supports remo
 
 Local embeddings are supported by changing the image used by the default compose file, from `registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite:latest` to `registry.librechat.ai/danny-avila/librechat-rag-api-dev:latest`.
 
+The default compose files store the PGVector/PostgreSQL data in the Docker-managed `pgdata2` volume. This is intentional: the database files do not need to be edited directly from the host, and a managed volume avoids common ownership and permission problems. User-facing files and editable config, such as uploads, logs, images, MongoDB data, and NGINX config, are bind-mounted to project folders where direct host access is useful.
+
 As always, make these changes in your update URLs [Docker Compose Override File](/docs/configuration/docker_override). You can find an example for exactly how to change the image in `docker-compose.override.yml.example` at the root of the project.
 
 If you wish to see an example of a compose file that only includes the PostgresQL + PGVector database and the Python API, see `rag.yml` file at the root of the project.

--- a/content/docs/configuration/tools/index.mdx
+++ b/content/docs/configuration/tools/index.mdx
@@ -74,6 +74,14 @@ Start a chat with that agent and ask for something that requires the tool, such 
 | Wolfram\|Alpha | Math, computation, units, curated knowledge, and real-time data | `WOLFRAM_APP_ID` | [Wolfram\|Alpha](/docs/configuration/tools/wolfram) |
 | Calculator | Basic and complex calculations | None | [Calculator](/docs/configuration/tools/calculator) |
 
+## Creating Custom Tools
+
+Most custom tools should be added without editing LibreChat source code.
+
+- Use [MCP](/docs/features/mcp) when you want to connect an agent to a local script, internal service, database, browser automation server, or a custom API wrapper. For example, a DuckDuckGo search tool can be exposed through an MCP server and then selected from the Agent Builder.
+- Use [Actions](/docs/features/agents#actions) when the tool is an HTTP API that can be described with an OpenAPI schema.
+- Edit LibreChat's source-level structured tools only when you are developing LibreChat itself. The legacy [Tools and Plugins development guide](/docs/development/tools_and_plugins) remains available for contributors, but MCP and Actions are the recommended extension paths for deployments.
+
 ## Tool Availability
 
 Tools are identified internally by their `pluginKey` from LibreChat's `api/app/clients/tools/manifest.json`.

--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -23,6 +23,18 @@ LibreChat provides two ways to use MCP servers, either in the chat area or with 
 
 You can configure MCP servers manually in your `librechat.yaml` file or by using [smithery.ai](https://smithery.ai) to find and install MCP servers into `librechat.yaml` ([see example below](#basic-configuration)). Any time you add or edit an MCP server, you will need to restart LibreChat to initialize the connections.
 
+### OAuth Callback URL
+
+For OAuth-enabled MCP servers, the LibreChat callback URL is:
+
+```text
+${DOMAIN_SERVER}/api/mcp/<server-name>/oauth/callback
+```
+
+`<server-name>` is the key used under `mcpServers` in `librechat.yaml` or the server name created in the MCP Settings UI. For example, a server named `salesforce` with `DOMAIN_SERVER=https://chat.example.com` uses `https://chat.example.com/api/mcp/salesforce/oauth/callback`.
+
+Register this exact callback URL with the OAuth provider. Local Docker installs usually use `http://localhost:3080` as the base URL.
+
 ### In Chat Area
 
 ![MCP Tools in Chat Area](/images/agents/mcp_chat.png)

--- a/content/docs/local/docker.mdx
+++ b/content/docs/local/docker.mdx
@@ -135,7 +135,8 @@ docker compose down
 docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
 
 # Windows (PowerShell)
-docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }
+docker images -a --filter "reference=registry.librechat.ai/danny-avila/librechat*" --format "{{.ID}}" | ForEach-Object { docker rmi $_ }
+docker images -a --filter "reference=ghcr.io/danny-avila/librechat*" --format "{{.ID}}" | ForEach-Object { docker rmi $_ }
 ```
 
 ```bash filename="Pull latest project changes"

--- a/content/docs/remote/docker_linux.mdx
+++ b/content/docs/remote/docker_linux.mdx
@@ -339,7 +339,8 @@ docker compose -f ./deploy-compose.yml down
 docker images -a | grep "librechat" | awk '{print $3}' | xargs docker rmi
 
 # Windows (PowerShell)
-docker images -a --format "{{.ID}}" --filter "reference=*librechat*" | ForEach-Object { docker rmi $_ }
+docker images -a --filter "reference=registry.librechat.ai/danny-avila/librechat*" --format "{{.ID}}" | ForEach-Object { docker rmi $_ }
+docker images -a --filter "reference=ghcr.io/danny-avila/librechat*" --format "{{.ID}}" | ForEach-Object { docker rmi $_ }
 ```
 
 ```bash filename="Pull latest project changes"


### PR DESCRIPTION
## Summary

I resolved a batch of open documentation issues around Docker updates, OAuth redirects, custom tools, MCP callbacks, endpoint icons, RAG volume storage, and admin panel redirects.

- Corrected the Windows Docker image cleanup commands to use valid prefix-based `reference` filters for the current registry and legacy GHCR images.
- Clarified Azure Entra redirect URI setup for local and deployed LibreChat instances using the public `DOMAIN_SERVER` value.
- Updated custom endpoint `iconURL` guidance so users do not reuse built-in endpoint names to borrow icons.
- Added a custom tool creation section that points deployments to MCP and Actions, with source-level tools framed for LibreChat contributors.
- Documented the general OAuth callback URL pattern for MCP servers and added the missing anchor used by the MCP object-structure docs.
- Added OpenID guidance for `ADMIN_PANEL_URL` when the Admin Panel is hosted separately from LibreChat.
- Explained why the default RAG PGVector/PostgreSQL storage uses the Docker-managed `pgdata2` volume.

Closes #187
Closes #377
Closes #388
Closes #411
Closes #422
Closes #567
Closes #572

## Change Type

- [x] Documentation update

## Testing

- Ran `pnpm build` successfully.
- Ran `git diff --check` successfully.

### **Test Configuration**:

- macOS
- Node/Next.js project using the existing repository toolchain

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings