### PR TITLE
docs: add EmpirioLabs AI endpoint example

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/empiriolabs.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/empiriolabs.mdx
@@ -1,0 +1,25 @@
+---
+title: EmpirioLabs
+description: Example configuration for EmpirioLabs AI
+---
+
+> **EmpirioLabs API key:** [platform.empiriolabs.ai/dashboard/api-keys](https://platform.empiriolabs.ai/dashboard/api-keys)
+
+**Notes:**
+
+- OpenAI-compatible multi-model API hosting open and proprietary models (Qwen, DeepSeek, GLM, Kimi, MiniMax, Gemma, and more) with pay-as-you-go pricing.
+- Fetching the list of models is supported and recommended; the catalog with per-model pricing and context windows is at [empiriolabs.ai/models](https://empiriolabs.ai/models).
+- Reasoning-capable models accept the `reasoning_effort` parameter (`none`, `low`, `medium`, `high`, `max`).
+- A low-cost model like `gemma-4-26b-a4b` works well for title generation.
+
+```yaml filename="librechat.yaml"
+    - name: "EmpirioLabs"
+      apiKey: "${EMPIRIOLABS_API_KEY}"
+      baseURL: "https://api.empiriolabs.ai/v1"
+      models:
+        default: ["qwen3-7-plus", "deepseek-v4-flash", "glm-5-1", "kimi-k2-6", "minimax-m3"]
+        fetch: true
+      titleConvo: true
+      titleModel: "gemma-4-26b-a4b"
+      modelDisplayLabel: "EmpirioLabs"
+```

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -8,6 +8,7 @@
     "cohere",
     "databricks",
     "deepseek",
+    "empiriolabs",
     "fireworks",
     "groq",
     "helicone",


### PR DESCRIPTION
Adds an example `librechat.yaml` configuration for [EmpirioLabs AI](https://empiriolabs.ai), an OpenAI-compatible multi-model API, under AI Endpoints. Follows the existing per-provider page format (API key link, notes, YAML snippet) and registers the page in meta.json in alphabetical position. Model fetching works against the standard `/v1/models` endpoint; the configuration was verified against the live API.