### PR TITLE
docs: add TokenMix as a custom AI endpoint

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -23,6 +23,7 @@
     "portkey",
     "shuttleai",
     "togetherai",
+    "tokenmix",
     "truefoundry",
     "vllm",
     "vultrcloudinference",

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/tokenmix.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/tokenmix.mdx
@@ -1,0 +1,133 @@
+---
+title: TokenMix
+description: Complete setup guide for using TokenMix as a custom endpoint in LibreChat
+---
+
+[TokenMix](https://tokenmix.ai/) is an OpenAI-compatible API gateway that exposes 300+ models from 17 vendors -- including OpenAI, Anthropic, and Google, plus Chinese models that are otherwise hard to reach from outside China (Qwen, DeepSeek, Doubao, GLM, Kimi, Hunyuan) -- behind a single base URL and a single API key. This guide walks you through adding TokenMix as a custom endpoint in LibreChat.
+
+<Callout type="info" title="Prerequisites">
+
+Before starting, make sure you have:
+- LibreChat installed and running (see [Docker setup](/docs/local/docker))
+- A `librechat.yaml` file created and mounted (see [librechat.yaml guide](/docs/configuration/librechat_yaml))
+
+</Callout>
+
+## Setup
+
+<Steps>
+  <Step>
+
+### Get an API Key
+
+Create an account at [tokenmix.ai](https://tokenmix.ai/) and generate an API key. See the [TokenMix documentation](https://tokenmix.ai/docs) for details.
+
+  </Step>
+  <Step>
+
+### Add the Key to Your .env File
+
+Open your `.env` file in the project root and add your TokenMix API key:
+
+```bash filename=".env"
+TOKENMIX_API_KEY=your-key-here
+```
+
+  </Step>
+  <Step>
+
+### Add the Endpoint to librechat.yaml
+
+Add the following to your `librechat.yaml` file. If the file already has content, merge the `endpoints` section with your existing configuration:
+
+```yaml filename="librechat.yaml"
+version: 1.3.5
+cache: true
+endpoints:
+  custom:
+    - name: "TokenMix"
+      apiKey: "${TOKENMIX_API_KEY}"
+      baseURL: "https://api.tokenmix.ai/v1"
+      models:
+        default: ["deepseek/deepseek-v3.2", "qwen/qwen3.7-max", "moonshot/kimi-k2.6"]
+        fetch: true
+      titleConvo: true
+      titleModel: "deepseek/deepseek-v3.2"
+      modelDisplayLabel: "TokenMix"
+```
+
+Key fields explained:
+
+| Field | Purpose |
+|-------|---------|
+| `apiKey: "${TOKENMIX_API_KEY}"` | References the env var from Step 2. The `${}` syntax tells LibreChat to read the value from `.env`. |
+| `baseURL` | TokenMix's OpenAI-compatible endpoint. |
+| `models.fetch: true` | Fetches the full model list from `/v1/models`, so new models appear automatically. |
+| `modelDisplayLabel: "TokenMix"` | The name shown in LibreChat's endpoint selector. |
+
+  </Step>
+  <Step>
+
+### Restart LibreChat
+
+<Tabs items={['Docker', 'Local']}>
+  <Tabs.Tab>
+
+```bash
+docker compose down && docker compose up -d
+```
+
+  </Tabs.Tab>
+  <Tabs.Tab>
+
+Stop the running process (Ctrl+C) and restart:
+
+```bash
+npm run backend
+```
+
+  </Tabs.Tab>
+</Tabs>
+
+  </Step>
+  <Step>
+
+### Verify It Works
+
+Open LibreChat in your browser. You should see **TokenMix** in the endpoint selector dropdown. Select it to see the available models.
+
+  </Step>
+</Steps>
+
+## Customization
+
+### Using user_provided API Key
+
+Instead of storing the key in `.env`, you can let each user provide their own key through the LibreChat UI:
+
+```yaml
+apiKey: "user_provided"
+```
+
+Users will see a key input field when selecting the TokenMix endpoint.
+
+### Limiting Available Models
+
+Instead of fetching all models, you can specify a fixed list:
+
+```yaml
+models:
+  default: ["deepseek/deepseek-v3.2", "qwen/qwen3.7-max", "anthropic/claude-opus-4.8"]
+  fetch: false
+```
+
+## Reference
+
+<Cards num={2}>
+  <Cards.Card title="Custom Endpoint Fields" href="/docs/configuration/librechat_yaml/object_structure/custom_endpoint" arrow>
+    All available fields for custom endpoint configuration
+  </Cards.Card>
+  <Cards.Card title="Full Example Config" href="/docs/configuration/librechat_yaml/example" arrow>
+    Complete annotated librechat.yaml with multiple endpoints
+  </Cards.Card>
+</Cards>


### PR DESCRIPTION
## Summary

Adds a setup guide for **TokenMix** as a custom (OpenAI-compatible) endpoint, following the existing pattern used by OpenRouter, Requesty, and TogetherAI.

TokenMix is an OpenAI-compatible API gateway that exposes 300+ models from 17 vendors behind a single base URL (`https://api.tokenmix.ai/v1`) and one API key — including OpenAI, Anthropic and Google models, plus Chinese models that are otherwise hard to reach from outside China (Qwen, DeepSeek, Doubao, GLM, Kimi, Hunyuan). Because it's OpenAI-compatible, it works with LibreChat's `endpoints.custom` block and `fetch: true` model discovery with no code changes.

## Changes

- Add `content/docs/configuration/librechat_yaml/ai_endpoints/tokenmix.mdx` — full setup guide (get key → `.env` → `librechat.yaml` → restart → verify), matching the style of the existing endpoint pages.
- Register the page in `meta.json` (inserted alphabetically) so it appears in the sidebar.

All example model IDs (`deepseek/deepseek-v3.2`, `qwen/qwen3.7-max`, `moonshot/kimi-k2.6`) are live entries in the TokenMix catalog.
