### PR TITLE
🧾 docs: Refresh v0.8.7-rc1 Changelog

### DIFF
--- a/content/changelog/config_v1.3.13.mdx
+++ b/content/changelog/config_v1.3.13.mdx
@@ -115,7 +115,7 @@ version: '1.3.13'
 
 - Added `interface.contextCost`
   - Controls whether usage cost is shown with context and token usage details
-  - Defaults to `true`
+  - Defaults to `false`; set to `true` to show usage costs in the UI
 
 - Added `interface.currency`
   - Converts displayed usage costs from USD into another currency with `code` and positive `rate`
@@ -125,6 +125,7 @@ version: '1.3.13'
   - Defines per-model context windows and per-million-token rates for custom endpoints
   - Supports `prompt`, `completion`, `context`, and optional `cacheRead` and `cacheWrite` values for each model name
   - Used by real-time context tracking, visible usage/cost breakdowns, and multi-endpoint agent billing
+  - Token-config cache entries are scoped by tenant and user when endpoint models, keys, URLs, or headers can vary by request context
 
 - Updated context usage after summarization
   - Persisted context usage now records a summary baseline marker after compaction
@@ -138,6 +139,7 @@ version: '1.3.13'
   - Sources must provide exactly one credential reference: either `credentialKey` for a stored admin credential or `token` as an environment variable reference like `${GITHUB_SKILLS_TOKEN}`
   - `skillDiscoveryDepth` defaults to `2` and is capped at `10`
   - `intervalMinutes` defaults to `60` and must be at least `5`
+  - Sync status responses are scoped by tenant and credential visibility so tenant-specific sources are only shown to authorized admins
 
 - Added `messageFilter.pii`
   - Rejects submitted text that matches credential-shaped starter patterns or operator-defined regex patterns before it reaches the model or persistence
@@ -152,6 +154,7 @@ version: '1.3.13'
 - Updated MCP runtime placeholders
   - `{{LIBRECHAT_BODY_*}}` placeholders create request-scoped MCP connections that are reused for the current run and cleaned up when the request ends
   - Request-scoped MCP servers are excluded from the persistent tool cache so request-specific headers and URLs are not reused outside the active run
+  - Cleanup is tied to resumable run completion so reconnects and resumed streams keep request-scoped MCP resources alive until the run finishes
   - `{{LIBRECHAT_USER_*}}`, `{{LIBRECHAT_OPENID_*}}`, and `{{LIBRECHAT_GRAPH_*}}` placeholders still require user-scoped connections, but HTTP transports refresh resolved headers before each tool call without forcing a reconnect by themselves
 
 - Updated outbound proxy environment handling

--- a/content/changelog/config_v1.3.13.mdx
+++ b/content/changelog/config_v1.3.13.mdx
@@ -125,7 +125,7 @@ version: '1.3.13'
   - Defines per-model context windows and per-million-token rates for custom endpoints
   - Supports `prompt`, `completion`, `context`, and optional `cacheRead` and `cacheWrite` values for each model name
   - Used by real-time context tracking, visible usage/cost breakdowns, and multi-endpoint agent billing
-  - Token-config cache entries are scoped by tenant and user when endpoint models, keys, URLs, or headers can vary by request context
+  - Token-config cache entries are scoped by user when endpoint models, keys, URLs, or headers can vary by request context
 
 - Updated context usage after summarization
   - Persisted context usage now records a summary baseline marker after compaction
@@ -135,11 +135,11 @@ version: '1.3.13'
 - Added `skillSync.github`
   - Mirrors Skills from GitHub repositories into LibreChat
   - Supports scheduled syncs with `enabled`, `intervalMinutes`, `runOnStartup`, and `sources`
-  - Each source supports `id`, `owner`, `repo`, `ref`, `paths`, `skillDiscoveryDepth`, `credentialKey`, `token`, and `tenantId`
+  - Each source supports `id`, `owner`, `repo`, `ref`, `paths`, `skillDiscoveryDepth`, `credentialKey`, `token`
   - Sources must provide exactly one credential reference: either `credentialKey` for a stored admin credential or `token` as an environment variable reference like `${GITHUB_SKILLS_TOKEN}`
   - `skillDiscoveryDepth` defaults to `2` and is capped at `10`
   - `intervalMinutes` defaults to `60` and must be at least `5`
-  - Sync status responses are scoped by tenant and credential visibility so tenant-specific sources are only shown to authorized admins
+  - Sync status responses are only shown to authorized admins
 
 - Added `messageFilter.pii`
   - Rejects submitted text that matches credential-shaped starter patterns or operator-defined regex patterns before it reaches the model or persistence

--- a/content/changelog/v0.8.7-rc1.mdx
+++ b/content/changelog/v0.8.7-rc1.mdx
@@ -11,10 +11,10 @@ version: '0.8.7-rc1'
 
 - **Access Control, Auth, and MCP**
   - Added granular shared-link permissions, OpenID role sync, configurable OpenID token reuse windows, and MCP On-Behalf-Of token exchange for delegated downstream access.
-  - Hardened MCP OAuth prompts, token flow categorization, OpenID audience handling, shared-link caching, auth continuation limiting, ACL principal filtering, runtime user/request placeholders, request-scoped MCP connections, request-scoped MCP tool caching, outbound proxy handling, and configurable MCP OAuth completion windows.
+  - Hardened MCP OAuth prompts, token flow categorization, OpenID audience handling, shared-link caching, auth continuation limiting, ACL principal filtering, runtime user/request placeholders, request-scoped MCP connections, request-scoped MCP tool caching, resumable-run MCP cleanup, outbound proxy handling, and configurable MCP OAuth completion windows.
 - **Agents, Skills, and Projects**
   - Added private chat projects, agent file authoring tools, deployment-provided Skills, GitHub Skill Sync, model-spec Skill/Subagent scoping, model-spec conversation starters, soft-default model specs, model-spec landing branding, and the agent marketplace in the model selector.
-  - Deployment Skills now take precedence over persisted duplicates, memory-agent input is bounded, and repeated Skill bodies are deduplicated across fresh primes and message history.
+  - Deployment Skills now take precedence over persisted duplicates, Skill Sync status is scoped correctly, memory-agent input is bounded, and repeated Skill bodies are deduplicated across fresh primes and message history.
 - **Safety and Admin Controls**
   - Added configurable message PII filtering for credential-shaped text across caller-supplied API message roles and hardened model-spec Subagent config so clients cannot supply private Subagent allowlists.
 - **Observability and Operations**
@@ -23,9 +23,9 @@ version: '0.8.7-rc1'
   - Conversation titles can now generate immediately, message navigation supports focus and drag-to-scrub, message timestamps appear on hover, shared-link snapshots are sanitized, viewed branches stay stable when sibling branches change, file-authoring previews stream earlier, stale service-worker assets auto-recover after deploys, and reopened chats reload correctly from non-chat routes.
 - **Provider and Reasoning Updates**
   - Added Claude Fable 5, GPT-5.5, `chat-latest`, and refreshed frontier OpenAI defaults while dropping deprecated OpenAI defaults.
-  - Custom endpoints preserve reasoning params, support native Anthropic-compatible providers, Bedrock cache tokens no longer inflate completion counts, Gemini mixed tool config is enabled, Gemini/Vertex MCP tool schemas are sanitized, Imagen uses its configured region, built-in provider endpoints can forward custom gateway headers, and provider document uploads are preserved.
+  - Custom endpoints preserve reasoning params, support native Anthropic-compatible providers, withhold custom Anthropic headers from user-controlled URLs, Bedrock cache tokens no longer inflate completion counts, Gemini mixed tool config is enabled, Gemini/Vertex MCP tool schemas are sanitized, Imagen uses its configured region, built-in provider endpoints can forward custom gateway headers, and provider document uploads are preserved.
 - **Streaming and Performance**
-  - Completed Markdown blocks are memoized during streaming, tool execution can report per-call results through `onResult`, context usage and cost update in real time with persisted branch/total breakdowns and correct post-summarization baselines, subagent child-run usage is billed into parent transactions, model-spec icons survive stream resume/abort, HEIC conversion, locale resources, React Query Devtools, and Brotli asset serving are lazy/toggled, message tree streaming is covered by E2E tests, and shared package builds now use `tsdown` with isolated declarations.
+  - Completed Markdown blocks are memoized during streaming, tool execution can report per-call results through `onResult`, context usage updates in real time with persisted branch/total breakdowns and correct post-summarization baselines, cost display is opt-in by default, token-config caches are scoped correctly, subagent child-run usage is billed into parent transactions, model-spec icons survive stream resume/abort, HEIC conversion, locale resources, React Query Devtools, and Brotli asset serving are lazy/toggled, message tree streaming is covered by E2E tests, and shared package builds now use `tsdown` with isolated declarations.
 
 ---
 
@@ -143,6 +143,10 @@ version: '0.8.7-rc1'
 - 🔢 fix: Prevent "approximately" tildes from rendering as markdown subscript by [@danny-avila](https://github.com/danny-avila) in [#13743](https://github.com/danny-avila/LibreChat/pull/13743)
 - 🪙 fix: Correct Context Usage Gauge After Summarization by [@danny-avila](https://github.com/danny-avila) in [#13744](https://github.com/danny-avila/LibreChat/pull/13744)
 - 📈 fix: Isolate RUM Telemetry Proxy Auth from App Auth by [@danny-avila](https://github.com/danny-avila) in [#13765](https://github.com/danny-avila/LibreChat/pull/13765)
+- 🫷 fix: Withhold Anthropic Custom Headers From User URLs by [@danny-avila](https://github.com/danny-avila) in [#13767](https://github.com/danny-avila/LibreChat/pull/13767)
+- 🏘️ fix: Scope Skill Sync Status by [@danny-avila](https://github.com/danny-avila) in [#13771](https://github.com/danny-avila/LibreChat/pull/13771)
+- 🗂️ fix: Scope Token Config Cache by [@danny-avila](https://github.com/danny-avila) in [#13770](https://github.com/danny-avila/LibreChat/pull/13770)
+- 🪢 fix: Tie MCP Cleanup To Resumable Runs by [@danny-avila](https://github.com/danny-avila) in [#13769](https://github.com/danny-avila/LibreChat/pull/13769)
 
 ### 🔧 Refactoring and Performance
 
@@ -164,6 +168,7 @@ version: '0.8.7-rc1'
 - ⚙️ refactor: Brotli asset serving behind a feature toggle by [@upman](https://github.com/upman) in [#13641](https://github.com/danny-avila/LibreChat/pull/13641)
 - 🤫 refactor: Silent MCP OAuth Refresh on Mid-Session 401 by [@danny-avila](https://github.com/danny-avila) in [#13369](https://github.com/danny-avila/LibreChat/pull/13369)
 - 📡 refactor: Gate Noisy Redis OTEL Instrumentation by [@danny-avila](https://github.com/danny-avila) in [#13764](https://github.com/danny-avila/LibreChat/pull/13764)
+- 🧾 refactor: Disable Context Cost By Default by [@danny-avila](https://github.com/danny-avila) in [#13768](https://github.com/danny-avila/LibreChat/pull/13768)
 
 ### 🧪 Tests
 
@@ -208,12 +213,15 @@ version: '0.8.7-rc1'
 - 🧹 ci: Relieve disk pressure on GitNexus deploy by [@danny-avila](https://github.com/danny-avila) in [#13666](https://github.com/danny-avila/LibreChat/pull/13666)
 - 📦 chore: npm audit fix by [@danny-avila](https://github.com/danny-avila) in [#13701](https://github.com/danny-avila/LibreChat/pull/13701)
 - 🪟 fix: Cross-Platform Absolute-Path Check in tsdown neverBundle Predicates by [@danny-avila](https://github.com/danny-avila) in [#13700](https://github.com/danny-avila/LibreChat/pull/13700)
+- ✨ v0.8.7-rc1 by [@danny-avila](https://github.com/danny-avila) in [#13592](https://github.com/danny-avila/LibreChat/pull/13592)
+- 📊 chore: Bump Helm chart version to 2.0.6 by [@danny-avila](https://github.com/danny-avila) in [`5986a1c6d2`](https://github.com/danny-avila/LibreChat/commit/5986a1c6d2)
 
 ### 🌍 Internationalization
 
 - 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13466](https://github.com/danny-avila/LibreChat/pull/13466)
 - 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13482](https://github.com/danny-avila/LibreChat/pull/13482)
 - 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13505](https://github.com/danny-avila/LibreChat/pull/13505)
+- 🌍 i18n: Update translation.json with latest translations by [@danny-avila](https://github.com/danny-avila) in [#13766](https://github.com/danny-avila/LibreChat/pull/13766)
 
 ## New Contributors
 

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -384,7 +384,12 @@ interface:
   ]}
 />
 
-**Default:** `true`
+**Default:** `false`
+
+**Notes:**
+
+- Set `contextCost: true` to opt in to visible cost values. Token usage can remain visible through `contextUsage` while cost values stay hidden.
+- `currency` only affects displayed costs when cost display is enabled.
 
 **Example:**
 

--- a/content/docs/configuration/token_usage.mdx
+++ b/content/docs/configuration/token_usage.mdx
@@ -8,7 +8,7 @@ description: This covers how to track and control token usage in LibreChat. You 
 
 As of `v0.6.0`, LibreChat accurately tracks token usage for supported endpoints. All token transactions are stored in the "Transactions" collection in your database. Current releases also show real-time context usage and cost in the conversation UI when enabled.
 
-Currently, you can limit user token usage by enabling user balances. Instead of configuring token credit limits via environment variables, you now set these options in your `librechat.yaml` file under the **balance** section.
+Currently, you can limit user token usage by enabling user balances. Instead of configuring token credit limits via environment variables, you now set these options in your `librechat.yaml` file under the **balance** section. Cost values are hidden by default and must be enabled with `interface.contextCost`.
 
 ## Viewing Context Usage and Cost
 
@@ -34,8 +34,8 @@ interface:
 ```
 
 - `contextUsage` controls whether users see the context window and token usage gauge.
-- `contextCost` controls whether users see cost values in the usage details.
-- `currency` converts displayed USD costs using a static multiplier. Transactions are still recorded using LibreChat's token credit accounting.
+- `contextCost` controls whether users see cost values in the usage details. It defaults to `false`; set it to `true` to show costs.
+- `currency` converts displayed USD costs using a static multiplier when cost display is enabled. Transactions are still recorded using LibreChat's token credit accounting.
 
 ## Custom Endpoint Token Config
 
@@ -57,6 +57,8 @@ endpoints:
 ```
 
 `prompt`, `completion`, and `context` are required for each model entry. `cacheRead` and `cacheWrite` can be added for providers that report cached input usage. For Agents that use multiple endpoints, LibreChat uses the matching endpoint/model token config when recording usage and cost.
+
+Fetched token config is cached with tenant and user scope when endpoint models, keys, URLs, or headers can vary by request context, so isolated custom endpoint pricing and context windows stay separated.
 
 ## Transaction Configuration
 

--- a/content/docs/configuration/token_usage.mdx
+++ b/content/docs/configuration/token_usage.mdx
@@ -58,7 +58,7 @@ endpoints:
 
 `prompt`, `completion`, and `context` are required for each model entry. `cacheRead` and `cacheWrite` can be added for providers that report cached input usage. For Agents that use multiple endpoints, LibreChat uses the matching endpoint/model token config when recording usage and cost.
 
-Fetched token config is cached with tenant and user scope when endpoint models, keys, URLs, or headers can vary by request context, so isolated custom endpoint pricing and context windows stay separated.
+Fetched token config is cached with user scope when endpoint models, keys, URLs, or headers can vary by request context, so isolated custom endpoint pricing and context windows stay separated.
 
 ## Transaction Configuration
 


### PR DESCRIPTION
I refreshed the v0.8.7-rc1 release changelog and aligned the token/cost docs with the final LibreChat behavior.

- Added late LibreChat changes for the release PR, Helm chart bump, i18n sync, Anthropic custom header withholding, context-cost default change, Skill Sync status scoping, token-config cache scoping, and resumable MCP cleanup.
- Updated highlights to reflect opt-in cost display, scoped token-config caches, scoped Skill Sync status, protected Anthropic user URLs, and resumable MCP cleanup.
- Corrected `interface.contextCost` docs and the config changelog to document the new default of `false`.
- Clarified token-config cache scoping for tenant/user-specific custom endpoint pricing and context windows.

## Change Type

- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- `bunx prettier --check content/changelog/v0.8.7-rc1.mdx content/changelog/config_v1.3.13.mdx content/docs/configuration/librechat_yaml/object_structure/interface.mdx content/docs/configuration/token_usage.mdx`
- `bun run build`
- Changelog coverage script confirmed 172 PR-numbered changes and all non-PR release commits from `v0.8.6..origin/dev` are represented in both the docs changelog and Desktop release markdown.

### **Test Configuration**:

- macOS
- Bun via repository scripts
- Next.js production build

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
