### PR TITLE
docs: scope Bedrock guardrailConfig with appliesTo (agents/models)

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/aws_bedrock.mdx
@@ -20,6 +20,11 @@ endpoints:
       guardrailVersion: '1'
       trace: 'enabled'
       streamProcessingMode: 'sync'
+      appliesTo:
+        agentIds:
+          - 'agent_abc123'
+        models:
+          - '*claude-sonnet-4-6*'
 ```
 
 > **Note:** AWS Bedrock endpoint supports all [Shared Endpoint Settings](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings), including `streamRate`, `titleModel`, `titleMethod`, `titlePrompt`, `titlePromptTemplate`, and `titleEndpoint`. The settings shown below are specific to Bedrock or have Bedrock-specific defaults.
@@ -214,6 +219,24 @@ endpoints:
       'Controls guardrail stream processing mode. Options: "sync" or "async".',
       'Optional. Default: "sync"',
     ],
+    [
+      'appliesTo',
+      'Object',
+      'Restricts the guardrail to specific agents and/or models. Omit to apply it to every Bedrock conversation. When both filters are set, a request must match both (logical AND).',
+      'Optional',
+    ],
+    [
+      'appliesTo.agentIds',
+      'String[]',
+      'Apply the guardrail only when the request agent_id matches one of these IDs (exact match).',
+      'Optional',
+    ],
+    [
+      'appliesTo.models',
+      'String[]',
+      'Apply the guardrail only when the model matches one of these. Supports "*" wildcards (anchored full-match), e.g. "*claude-sonnet-4-6*" to cover all region prefixes and version suffixes.',
+      'Optional',
+    ],
   ]}
 />
 
@@ -227,6 +250,11 @@ endpoints:
       guardrailVersion: '1'
       trace: 'enabled'
       streamProcessingMode: 'sync'
+      appliesTo:
+        agentIds:
+          - 'agent_abc123'
+        models:
+          - '*claude-sonnet-4-6*'
 ```
 
 **Notes:**
@@ -236,6 +264,9 @@ endpoints:
 - Set `trace` to `"enabled"` or `"enabled_full"` during development to see which guardrail policies are triggered
 - Set `streamProcessingMode` to `"async"` to stream responses faster (at the cost of guardrail possibly allowing inappropriate content through until its scan completes)
 - For production, set `trace` to `"disabled"` to reduce response payload size
+- Use `appliesTo` to scope the guardrail instead of applying it to all Bedrock traffic — for example, set `agentIds` to guard a specific agent while leaving direct chat on the same model unguarded
+- `appliesTo.models` entries support `*` wildcards; because Bedrock model IDs carry region prefixes (`us.`/`eu.`/`apac.`) and version suffixes (`-v1:0`), use `*claude-sonnet-4-6*` to match every variant
+- When both `appliesTo.agentIds` and `appliesTo.models` are set, a request must match both (logical AND); within each list, entries are matched as "any of"
 
 ## Notes
 

--- a/content/docs/configuration/pre_configured_ai/bedrock.mdx
+++ b/content/docs/configuration/pre_configured_ai/bedrock.mdx
@@ -111,6 +111,11 @@ endpoints:
       guardrailVersion: '1'
       trace: 'enabled'
       streamProcessingMode: 'sync'
+      appliesTo:
+        agentIds:
+          - 'agent_abc123'
+        models:
+          - '*claude-sonnet-4-6*'
 ```
 
 - `streamRate`: (Optional) Set the rate of processing each new token in milliseconds.
@@ -129,6 +134,7 @@ endpoints:
   - `guardrailVersion`: The guardrail version number (e.g., `"1"`) or `"DRAFT"`.
   - `trace`: (Optional) Enable trace logging: `"enabled"`, `"disabled"`, or `"enabled_full"`.
   - `streamProcessingMode`: (Optional) Set stream processing mode: `"sync"` or `"async"` (defaults to `"sync"`).
+  - `appliesTo`: (Optional) Restrict the guardrail to specific `agentIds` (exact match) and/or `models` (supports `*` wildcards, e.g. `"*claude-sonnet-4-6*"`). Omit to apply to all Bedrock conversations; when both are set they combine with AND.
   - See [AWS Bedrock Guardrails documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-how.html) for creating and managing guardrails.
 
 ## Inference Profiles


### PR DESCRIPTION
Document the optional `appliesTo` scope on `endpoints.bedrock.guardrailConfig`, which restricts the global guardrail to specific agentIds and/or models (models support "*" wildcards). Updates the librechat.yaml object structure reference and the pre-configured Bedrock guide.

corresponding PR: https://github.com/danny-avila/LibreChat/pull/13789
