### PR TITLE
fix: bust social-card caches with content-fingerprinted OG URLs

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -108,6 +108,20 @@ export function GET(request: Request) {
         { name: 'Geist', data: geistRegular, weight: 400, style: 'normal' },
         { name: 'Geist', data: geistSemiBold, weight: 600, style: 'normal' },
       ],
+      // Cards are content-addressed: callers append a `?v=` fingerprint
+      // (lib/og.ts) that changes whenever the art changes, so a given URL's
+      // bytes never change. Cache them hard at every layer.
+      //
+      // NB Cloudflare: for this to hold at the edge, the zone must respect
+      // origin cache headers for these responses (Cache Rule -> "Respect
+      // origin" / Browser Cache TTL -> "Respect Existing Headers"). The legacy
+      // unversioned /images/socialcards/*.png was served stale for ~15 days
+      // because Cloudflare ignored its `max-age=0, must-revalidate` and applied
+      // its own long edge TTL. Versioned URLs sidestep that, but the zone
+      // setting should still respect origin so unversioned assets revalidate.
+      headers: {
+        'Cache-Control': 'public, max-age=31536000, s-maxage=31536000, immutable',
+      },
     },
   )
 }

--- a/lib/og-version.mjs
+++ b/lib/og-version.mjs
@@ -1,0 +1,53 @@
+// @ts-check
+/**
+ * Content fingerprint for the Open Graph social cards.
+ *
+ * Every social-card URL (the homepage card and the per-page cards from
+ * app/api/og/route.tsx) carries this hash as a `?v=` query param. Because the
+ * hash is derived from the bytes that actually determine how a card looks,
+ * editing the card template, swapping the logo/fonts, or dropping in a new
+ * static card produces a brand-new URL that no CDN edge or social scraper
+ * (Discord/WhatsApp/Facebook image proxies) has ever cached. That is the only
+ * thing that reliably forces those caches to refetch.
+ *
+ * Computed once at build time and inlined via `env.OG_VERSION` in
+ * next.config.mjs, so there are no filesystem reads at request time (which
+ * keeps it safe on serverless/edge). Contributors never hand-edit a version
+ * number; the fingerprint updates itself.
+ */
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * Files whose contents determine the rendered card. Keep this in sync with the
+ * inputs of app/api/og/route.tsx. The static socialcards are included so that
+ * any legacy/author-referenced static card also bumps the fingerprint.
+ */
+const OG_SOURCES = [
+  'app/api/og/route.tsx',
+  'lib/fonts/Geist-Regular.ttf',
+  'lib/fonts/Geist-SemiBold.ttf',
+  'public/librechat.png',
+  'public/images/socialcards/default-image.png',
+  'public/images/socialcards/default-docs-image.png',
+  'public/images/socialcards/default-blog-image.png',
+  'public/images/socialcards/default-changelog-image.png',
+]
+
+/** @returns {string} short hex fingerprint of the OG card inputs */
+export function computeOgVersion() {
+  const hash = createHash('sha256')
+  for (const rel of OG_SOURCES) {
+    try {
+      hash.update(readFileSync(join(ROOT, rel)))
+    } catch {
+      // An optional source that's been renamed/removed simply doesn't
+      // contribute to the fingerprint; it must not break the build.
+    }
+  }
+  return hash.digest('hex').slice(0, 12)
+}

--- a/lib/og.ts
+++ b/lib/og.ts
@@ -3,6 +3,12 @@
  * Used in generateMetadata so every page gets a social card rendered with its
  * own title instead of one shared static image. Relative URLs resolve against
  * `metadataBase` in the root layout.
+ *
+ * Every URL carries a `v=` content fingerprint (lib/og-version.mjs, inlined via
+ * next.config `env.OG_VERSION`). When the card art changes the fingerprint
+ * changes, so the URL is brand-new and no CDN edge or social-scraper image
+ * proxy serves a stale card. Without it, a redesigned card keeps the same URL
+ * and every cache layer keeps the old bytes forever.
  */
 export type OgType = 'docs' | 'blog' | 'changelog'
 
@@ -10,6 +16,7 @@ export function ogImageUrl(opts: { title?: string; type?: OgType } = {}): string
   const params = new URLSearchParams()
   if (opts.title) params.set('title', opts.title)
   if (opts.type) params.set('type', opts.type)
+  if (process.env.OG_VERSION) params.set('v', process.env.OG_VERSION)
   const qs = params.toString()
   return `/api/og${qs ? `?${qs}` : ''}`
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 import { start } from 'fumadocs-mdx/next'
 import NextBundleAnalyzer from '@next/bundle-analyzer'
 import { resolve } from 'path'
+import { computeOgVersion } from './lib/og-version.mjs'
 
 const withBundleAnalyzer = NextBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
@@ -64,9 +65,28 @@ const nonPermanentRedirects = [
   ['/toolkit/creds_generator', '/toolkit/creds-generator'],
 ]
 
+/**
+ * Build-time content fingerprint of the Open Graph cards. Inlined into the
+ * bundle so lib/og.ts can append it as `?v=` to every social-card URL without
+ * any runtime filesystem reads. A card change yields a new hash -> a new URL
+ * -> a cache-miss at every layer (Cloudflare edge + scraper image proxies),
+ * which is what makes updated cards show up without a manual purge/re-scrape.
+ */
+const OG_VERSION = computeOgVersion()
+
 /** @type {import('next').NextConfig} */
 const config = {
   poweredByHeader: false,
+  env: {
+    OG_VERSION,
+  },
+  // The OG renderer (app/api/og/route.tsx) reads the logo + fonts from disk at
+  // runtime via process.cwd(). Those paths aren't statically analyzable, so
+  // Next's tracing can miss them and the function 404s/500s on Vercel. Force
+  // them into the serverless bundle for that route.
+  outputFileTracingIncludes: {
+    '/api/og': ['./lib/fonts/Geist-Regular.ttf', './lib/fonts/Geist-SemiBold.ttf', './public/librechat.png'],
+  },
   typescript: {
     ignoreBuildErrors: false,
   },


### PR DESCRIPTION
## Problem

Updated Open Graph cards keep showing **stale** on Discord, WhatsApp, Facebook, and behind Cloudflare even though the correct card is live at origin. Root cause: the card URL never changes when the art changes. Both the static `default-image.png` and `/api/og(?title=…)` are byte-identical across redesigns, so every CDN edge and scraper image proxy keeps its first copy indefinitely. A one-time purge + re-scrape fixes today but the problem recurs on every future card update.

Confirmed against live prod:
- Homepage `og:image` = `/images/socialcards/default-image.png` (prod runs a build older than #618).
- That asset: origin `cache-control: max-age=0, must-revalidate`, but Cloudflare serves `cf-cache-status: HIT`, `age` ~15 days.
- `/api/og` currently returns **404** at the edge — the dynamic route from #617/#618 isn't deployed yet, though HEAD already routes all branded cards through it.

## Fix

Append an auto-derived `?v=<hash>` token to every card URL so a card change is always a brand-new URL that misses every cache layer.

- **`lib/og-version.mjs`** — SHA-256 fingerprint of the card inputs (route template, fonts, logo, static fallback PNGs). Deterministic, content-sensitive; a one-byte card change flips it.
- **`next.config.mjs`** — computes the hash once at build time and inlines it via `env.OG_VERSION` (no runtime `fs` reads, safe on serverless/edge). Nothing to hand-edit: drop in a new card, the URL updates itself.
- **`lib/og.ts`** — appends `v=` to every `/api/og` URL (homepage + all per-page cards).

## Hardening

- **`outputFileTracingIncludes`** for `/api/og` so the fonts + logo it reads from `process.cwd()` are bundled into the serverless function — the most likely reason it would 404/500 once deployed.
- The renderer now serves `Cache-Control: public, max-age=31536000, immutable` (correct, since URLs are content-addressed), with an inline note documenting the Cloudflare zone setting that was overriding `must-revalidate` on the legacy unversioned asset (Cache Rule → respect origin / "Respect Existing Headers").

## Verify before/after merge

- Confirm `/api/og` returns **200** on a preview deploy (it 404s in prod only because the route isn't live yet).
- One-time ops (recurring problem is fixed after this): Cloudflare purge for the current image + Facebook Sharing Debugger "Scrape Again."

Out of scope: per-author avatars (`authors/[id]`) and author-supplied post `ogImage` are untouched (not branded cards).