### PR TITLE
docs: document MCP_TOOLS_LIST_MAX_PAGES env var

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -3000,6 +3000,12 @@ Configure Model Context Protocol settings for enhanced server management and OAu
       'MCP_CONNECTION_CHECK_TTL=30000',
     ],
     [
+      'MCP_TOOLS_LIST_MAX_PAGES',
+      'number',
+      'Maximum number of tools/list pages to request when an MCP server paginates its tool list (cursor pagination). Bounds the pagination loop so a misbehaving server cannot stall tool discovery. Clamped to a minimum of 1. Default: 50.',
+      'MCP_TOOLS_LIST_MAX_PAGES=50',
+    ],
+    [
       'MCP_SKIP_CODE_CHALLENGE_CHECK',
       'boolean',
       'Skip code challenge method validation. When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration',


### PR DESCRIPTION
## Summary

Documents the new `MCP_TOOLS_LIST_MAX_PAGES` environment variable in the MCP Server Configuration section of the `.env` reference.

It was introduced in danny-avila/LibreChat#13840, which makes LibreChat follow MCP `tools/list` cursor pagination (previously only the first page of tools was loaded). `MCP_TOOLS_LIST_MAX_PAGES` bounds the pagination loop (default `50`, clamped to a minimum of `1`) so a misbehaving server cannot stall tool discovery.

## Change

- `content/docs/configuration/dotenv.mdx` — add `MCP_TOOLS_LIST_MAX_PAGES` to the MCP Server Configuration option table, next to `MCP_CONNECTION_CHECK_TTL`.
