### PR TITLE
📋 docs: Managing user-provided API keys with Model Specs

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -24,6 +24,12 @@ There are 3 main fields under `modelSpecs`:
   - `presets`
 - If you would like to enable these interface elements along with model specs, you can set them to `true` in the `interface` object.
 
+<Callout type="info" title="Managing user-provided API keys with Model Specs">
+  When Model Specs disable `modelSelect`, the endpoints dropdown — and the gear icon that opens the **Set API Key** dialog — is hidden. Users can still set or rotate keys for any endpoint configured with `apiKey: "user_provided"` from **Settings → Data controls → API keys**.
+
+  That list is scoped to the endpoints a user can actually reach: the endpoints referenced by your model specs, plus any [`addedEndpoints`](#addedendpoints). When the `agents` endpoint is reachable, it also includes the agent [`allowedProviders`](/docs/configuration/librechat_yaml/object_structure/agents#allowedproviders) (or every configured provider when `allowedProviders` is left unset).
+</Callout>
+
 ## Example
 
 ```yaml filename="modelSpecs"
@@ -143,7 +149,7 @@ modelSpecs:
 
 **Note:** Must be one of the following:
 
-- `openAI, azureOpenAI, google, anthropic, assistants, azureAssistants, bedrock`
+- `openAI, azureOpenAI, google, anthropic, assistants, azureAssistants, bedrock, agents`
 
 **Example:**
 


### PR DESCRIPTION
## Summary

Documents how end users manage **user-provided API keys** when Model Specs are configured, matching the new Settings behavior added in LibreChat PR https://github.com/danny-avila/LibreChat/pull/13864.

Edits `content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx`:

- Adds a `Callout` right where the docs explain that Model Specs hide `modelSelect`. It clarifies that users can still set/rotate keys for `apiKey: "user_provided"` endpoints from **Settings → Data controls → API keys**, and that this list is scoped to the endpoints a user can actually reach — the specs' endpoints plus `addedEndpoints`, expanding to the agent `allowedProviders` when the `agents` endpoint is reachable.
- Adds `agents` to the documented set of valid `addedEndpoints` values (it is schema-valid and is referenced by the new behavior).

## Why

Before, when `modelSpecs.list` was set, `interface.modelSelect` defaulted to `false`, hiding the endpoints dropdown and the gear icon that opened the **Set API Key** dialog — leaving no way to enter or rotate a `user_provided` key. The companion code PR surfaces that flow in Settings and scopes it like the model selector / mention popover; these docs explain it.

## Notes

- Draft / companion PR — should land alongside or after LibreChat https://github.com/danny-avila/LibreChat/pull/13864.
- `prettier --check` passes on the edited file; internal anchors (`#addedendpoints`, `agents#allowedproviders`) resolve to existing headings.