### PR TITLE
chore: remove catch-all CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# Code owners for librechat-ai/librechat.ai
-# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-#
-# These owners are requested for review on every pull request. The last
-# matching pattern takes precedence, so add narrower rules below as needed.
-
-* @danny-avila @berry-13 @dustinhealy


### PR DESCRIPTION
## Summary

Removes `.github/CODEOWNERS`, which currently assigns every path in the repository to `@danny-avila`, `@berry-13`, and `@dustinhealy`.

## Why

The catch-all `*` rule causes all listed code owners to be automatically requested for review on every pull request, regardless of the files changed.

## Impact

Future pull requests will no longer auto-request those users solely because of repository-wide code ownership. Reviewers can still be requested manually, or narrower CODEOWNERS rules can be added later for specific paths if needed.

## Validation

Not run; this is a GitHub metadata/config-only change.