### PR TITLE
feat: serve per-page Markdown and a curated llms.txt index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ codedb.snapshot
 /.openai/
 /.tabnine/
 /.codeium
+codedb.snapshot
 *.local.md
 
 # Background shell state

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ The official documentation site for [LibreChat](https://github.com/danny-avila/L
 - **Docs Engine:** Fumadocs (fumadocs-mdx + fumadocs-ui)
 - **Styling:** Tailwind CSS
 - **Icons:** Lucide React
-- **Package Manager:** Bun
+- **Package Manager:** pnpm
 
 ## Local Development
 
-**Prerequisites:** [Bun](https://bun.sh/) 1.0+
+**Prerequisites:** Node.js 20.19+ and [pnpm](https://pnpm.io/) 9.5.0+
 
 1. Clone the repository
 2. Copy `.env.template` to `.env.local` and fill in any optional values
 3. Install dependencies:
    ```bash
-   bun i
+   pnpm install
    ```
-4. Start the dev server (uses Turbopack):
+4. Start the dev server:
    ```bash
-   bun dev
+   pnpm dev
    ```
 5. Open [http://localhost:3333](http://localhost:3333)
 
-**Note:** Always run `bun run build` before opening a PR to catch build errors early.
+**Note:** Always run `pnpm build` before opening a PR to catch build errors early.
 
 ## Project Structure
 
@@ -39,9 +39,8 @@ content/
   blog/           # Blog posts (MDX)
   changelog/      # Changelog entries (MDX)
 components/       # React components (home, UI, icons, etc.)
-lib/              # Utilities, icons, MDX components, Nextra shims
+lib/              # Utilities, icons, MDX components, content sources
 public/           # Static assets
-pages/            # Legacy pages (migrating to app/)
 source.config.ts  # Fumadocs content collections config
 ```
 
@@ -61,14 +60,14 @@ Only pages listed in the `pages` array appear in the sidebar.
 
 ## Scripts
 
-| Command            | Description                               |
-| ------------------ | ----------------------------------------- |
-| `bun dev`          | Start dev server on port 3333 (Turbopack) |
-| `bun run build`    | Production build                          |
-| `bun start`        | Start production server on port 3333      |
-| `bun run lint`     | Run ESLint                                |
-| `bun run prettier` | Format code with Prettier                 |
-| `bun run analyze`  | Analyze production bundle size            |
+| Command         | Description                          |
+| --------------- | ------------------------------------ |
+| `pnpm dev`      | Start dev server on port 3333        |
+| `pnpm build`    | Production build                     |
+| `pnpm start`    | Start production server on port 3333 |
+| `pnpm lint`     | Run ESLint                           |
+| `pnpm prettier` | Format code with Prettier            |
+| `pnpm analyze`  | Analyze production bundle size       |
 
 ## License
 

--- a/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/app/[lang]/docs/[[...slug]]/page.tsx
@@ -57,9 +57,9 @@ export default async function Page(props: PageProps) {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <div className="flex flex-row gap-2 items-center border-b pt-2 pb-6">
-        <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
+        <LLMCopyButton markdownUrl={`${page.url}.md`} />
         <ViewOptions
-          markdownUrl={`${page.url}.mdx`}
+          markdownUrl={`${page.url}.md`}
           githubUrl={`https://github.com/LibreChat-AI/librechat.ai/blob/main/content/docs/${page.file.path}`}
         />
       </div>

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,5 +1,5 @@
 import { docsSource } from '@/lib/source'
-import { getLLMText } from '@/lib/get-llm-text'
+import { getLLMText, MARKDOWN_RESPONSE_HEADERS } from '@/lib/get-llm-text'
 
 export const revalidate = false
 
@@ -7,5 +7,7 @@ export async function GET() {
   const scan = docsSource.getPages().map(getLLMText)
   const scanned = await Promise.all(scan)
 
-  return new Response(scanned.join('\n\n'))
+  return new Response(scanned.join('\n\n'), {
+    headers: MARKDOWN_RESPONSE_HEADERS,
+  })
 }

--- a/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -1,4 +1,4 @@
-import { getLLMText } from '@/lib/get-llm-text'
+import { getLLMText, MARKDOWN_RESPONSE_HEADERS } from '@/lib/get-llm-text'
 import { docsSource } from '@/lib/source'
 import { i18n } from '@/lib/i18n'
 import { notFound } from 'next/navigation'
@@ -11,9 +11,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug?: 
   if (!page) notFound()
 
   return new Response(await getLLMText(page), {
-    headers: {
-      'Content-Type': 'text/markdown',
-    },
+    headers: MARKDOWN_RESPONSE_HEADERS,
   })
 }
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,99 @@
+import { absoluteUrl, MARKDOWN_RESPONSE_HEADERS } from '@/lib/get-llm-text'
+
+export const revalidate = false
+
+const entries = [
+  {
+    title: 'Homepage',
+    url: '/',
+    description: 'LibreChat overview, feature highlights, project links, and top-level navigation.',
+  },
+  {
+    title: 'Quick Start',
+    url: '/docs/quick_start',
+    description: 'Choose a setup path and get LibreChat running quickly.',
+  },
+  {
+    title: 'Local Install',
+    url: '/docs/local',
+    description: 'Local Docker, npm, and Helm installation guides.',
+  },
+  {
+    title: 'Remote Install',
+    url: '/docs/remote',
+    description: 'Remote hosting options, deployment tradeoffs, tunnels, and reverse proxies.',
+  },
+  {
+    title: 'Configuration',
+    url: '/docs/configuration',
+    description: 'How .env, librechat.yaml, Docker overrides, and service settings fit together.',
+  },
+  {
+    title: 'librechat.yaml',
+    url: '/docs/configuration/librechat_yaml',
+    description: 'Custom AI endpoints, model settings, interface options, and advanced features.',
+  },
+  {
+    title: 'Agents',
+    url: '/docs/features/agents',
+    description:
+      'Build and configure LibreChat agents with tools, files, actions, and capabilities.',
+  },
+  {
+    title: 'MCP',
+    url: '/docs/features/mcp',
+    description: 'Model Context Protocol setup, server connections, OAuth, tools, and variables.',
+  },
+  {
+    title: 'RAG',
+    url: '/docs/features/rag_api',
+    description: 'Chat with files, document indexing, retrieval, and RAG API behavior.',
+  },
+  {
+    title: 'Auth',
+    url: '/docs/configuration/authentication',
+    description: 'Email, LDAP, SAML, and OAuth/OIDC authentication configuration.',
+  },
+  {
+    title: 'Environment Variables',
+    url: '/docs/configuration/dotenv',
+    description: 'Complete .env reference for LibreChat server settings and integrations.',
+  },
+  {
+    title: 'Changelog',
+    url: '/changelog',
+    description: 'Release notes and configuration changelog entries.',
+  },
+]
+
+function docsMarkdownUrl(path: string): string | undefined {
+  return path.startsWith('/docs') ? absoluteUrl(`${path}.md`) : undefined
+}
+
+function renderEntry(entry: (typeof entries)[number]) {
+  const markdownUrl = docsMarkdownUrl(entry.url)
+  const suffix = markdownUrl ? ` Markdown: ${markdownUrl}` : ''
+
+  return `- [${entry.title}](${absoluteUrl(entry.url)}): ${entry.description}${suffix}`
+}
+
+export async function GET() {
+  const body = `# LibreChat
+
+> Curated map of the LibreChat documentation for language models and coding agents.
+
+## Key Pages
+
+${entries.map(renderEntry).join('\n')}
+
+## Complete Documentation
+
+- [Full documentation text](${absoluteUrl('/llms-full.txt')}): All docs pages concatenated as Markdown.
+- Per-page Markdown: append \`.md\` to any docs page URL, for example ${absoluteUrl('/docs/configuration/librechat_yaml.md')}.
+- Legacy per-page MDX URLs ending in \`.mdx\` remain supported for compatibility.
+`
+
+  return new Response(body, {
+    headers: MARKDOWN_RESPONSE_HEADERS,
+  })
+}

--- a/content/docs/documentation/examples.mdx
+++ b/content/docs/documentation/examples.mdx
@@ -480,7 +480,7 @@ Metus imperdiet fusce id rhoncus urna ridiculus sem.
 </FileTree>
 ```
 
-[<span style={{ fontSize: '0.8rem' }}>Source Code ↗</span>](https://github.com/shuding/nextra/blob/main/packages/nextra/src/components/file-tree.tsx)
+[<span style={{ fontSize: '0.8rem' }}>Component mapping ↗</span>](https://github.com/LibreChat-AI/librechat.ai/blob/main/lib/mdx-components.tsx)
 
 </Tabs.Tab>
 </Tabs>
@@ -596,14 +596,13 @@ import { Code } from '@/components/svg/'
   </Tabs.Tab>
 </Tabs>
 
-{/* TODO: Button examples with onClick handlers need client component wrapping for Fumadocs.
-    These were Nextra interactive examples that are incompatible with Server Components. */}
+{/* TODO: Button examples with onClick handlers need client component wrapping for Fumadocs Server Components. */}
 
 ## Default Button
 
 Button examples with interactive handlers are not yet available in the Fumadocs migration.
-See the original Nextra source for reference:
-[Source Code](https://github.com/shuding/nextra/blob/main/packages/nextra/src/components/button.tsx)
+See the local MDX component mapping for the current non-interactive button wrapper:
+[Component mapping](https://github.com/LibreChat-AI/librechat.ai/blob/main/lib/mdx-components.tsx)
 
 ## Features
 
@@ -682,7 +681,7 @@ import { Feature, Features } from '@/components/features'
   </Tabs.Tab>
 </Tabs>
   ```
-  [<span style={{ fontSize: '0.8rem' }}>Source Code ↗</span>](https://github.com/shuding/nextra/blob/main/packages/nextra/src/components/tabs.tsx)
+  [<span style={{ fontSize: '0.8rem' }}>Component mapping ↗</span>](https://github.com/LibreChat-AI/librechat.ai/blob/main/lib/mdx-components.tsx)
   </Tabs.Tab>
 </Tabs>
 
@@ -751,7 +750,7 @@ The `items` prop on the `<Tabs>` component is an array of strings that represent
     </Tabs.Tab>
   </Tabs>
   ```
-  [<span style={{ fontSize: '0.8rem' }}>Source Code ↗</span>](https://github.com/shuding/nextra/blob/main/packages/nextra/src/components/tabs.tsx)
+  [<span style={{ fontSize: '0.8rem' }}>Component mapping ↗</span>](https://github.com/LibreChat-AI/librechat.ai/blob/main/lib/mdx-components.tsx)
   </Tabs.Tab>
 </Tabs>
 
@@ -794,7 +793,7 @@ The `items` prop on the `<Tabs>` component is an array of strings that represent
 
 <Tabs.Tab>
 
-[<span style={{ fontSize: '0.8rem' }}>Source Code ↗</span>](https://github.com/shuding/nextra/blob/main/packages/nextra/src/components/steps.tsx)
+[<span style={{ fontSize: '0.8rem' }}>Component mapping ↗</span>](https://github.com/LibreChat-AI/librechat.ai/blob/main/lib/mdx-components.tsx)
 
 ```tsx copy filename="steps.tsx"
 <Steps>- Step 1: example - Step 2: example - Step 3: example - Step 4: example</Steps>

--- a/content/docs/documentation/index.mdx
+++ b/content/docs/documentation/index.mdx
@@ -4,7 +4,7 @@ icon: BookOpen
 description: Comprehensive guide on how to contribute to our documentation
 ---
 
-Contributions to the documentation are welcome! This guide explains how to contribute to the LibreChat documentation by writing and formatting new documentation. Our website is built with Nextra 3 and our docs use the `.mdx` format (augmented markdown).
+Contributions to the documentation are welcome! This guide explains how to contribute to the LibreChat documentation by writing and formatting new documentation. The website is built with Fumadocs and the docs use the `.mdx` format.
 
 ### When to Write a Doc vs. a Blog Post
 
@@ -33,8 +33,8 @@ To create a new document:
 
 - Use the `.mdx` file extension (see [MDX documentation](https://mdxjs.com/) for more info).
 - Name files using **lowercase letters** and **underscores** (e.g., `documentation_guidelines.mdx`).
-- Place new documents in the relevant folder/sub-folder under `./docs`.
-- Add the document to the table of contents in the `_meta.ts` file of the folder where your document is located. If you don't add it, it will be alphabetically sorted after the ordered docs.
+- Place new documents in the relevant folder/sub-folder under `content/docs`.
+- Add the document to the `pages` array in the `meta.json` file of the folder where your document is located. If you don't add it, Fumadocs can still discover it, but it will not appear in the intended sidebar order.
 
 ## Markdown Formatting Guidelines
 
@@ -58,8 +58,8 @@ See some integrated components examples:
 
 For more information, refer to:
 
-- [Nextra](https://nextra.site/docs/docs-theme/start)
-- [Nextra 3](https://the-guild.dev/blog/nextra-3#intro)
+- [Fumadocs](https://fumadocs.dev)
+- [Fumadocs MDX](https://fumadocs.dev/docs/mdx)
 - [MDX](https://mdxjs.com/)
 
 </Callout>

--- a/content/docs/documentation/syntax_highlighting.mdx
+++ b/content/docs/documentation/syntax_highlighting.mdx
@@ -4,9 +4,7 @@ icon: Paintbrush
 description: All about syntax highlighting
 ---
 
-{/* TODO: This page contained Nextra-specific interactive examples with React hooks
-    (useRef, useEffect, useState) that are incompatible with Fumadocs Server Components.
-    The page needs to be rewritten with Fumadocs syntax highlighting examples. */}
+{/* TODO: Expand this page with current Fumadocs syntax highlighting examples. */}
 
 This documentation uses [Shiki](https://shiki.matsu.io) for syntax highlighting at build time.
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: Quick Start
-icon: Rocket
-description: Choose your setup method and get LibreChat running in minutes.
+title: Documentation
+icon: BookOpen
+description: Installation, configuration, feature, and contribution guides for LibreChat.
 ---
 
-<QuickStartHub />
+<DocsHub />
 
 <Callout type="info" title="Looking for a desktop installer?">
 

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,13 +1,15 @@
 {
   "pages": [
     "index",
-    "features",
-    "compatibility",
     "---Deploy---",
+    "quick_start",
     "local",
     "remote",
+    "---Configure---",
     "configuration",
-    "---Learn---",
+    "---Use---",
+    "features",
+    "compatibility",
     "mcp_servers",
     "user_guides",
     "---Tools---",

--- a/e2e/llms-routes.spec.ts
+++ b/e2e/llms-routes.spec.ts
@@ -48,4 +48,18 @@ test.describe('LLM markdown routes', () => {
       '# Custom Config (https://www.librechat.ai/docs/configuration/librechat_yaml)',
     )
   })
+
+  test('serves .md URLs even when the client also negotiates for markdown', async ({ request }) => {
+    // The .md suffix bypass must win over Accept-based negotiation, otherwise the
+    // slug keeps its .md suffix and the page lookup 404s.
+    const response = await request.get('/docs/configuration/librechat_yaml.md', {
+      headers: { Accept: 'text/markdown' },
+    })
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain(
+      '# Custom Config (https://www.librechat.ai/docs/configuration/librechat_yaml)',
+    )
+  })
 })

--- a/e2e/llms-routes.spec.ts
+++ b/e2e/llms-routes.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('LLM markdown routes', () => {
+  test('serves the curated LLM index as markdown', async ({ request }) => {
+    const response = await request.get('/llms.txt')
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain('Full documentation text')
+  })
+
+  test('serves the full docs export as markdown', async ({ request }) => {
+    const response = await request.get('/llms-full.txt')
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain(
+      '# Custom Config (https://www.librechat.ai/docs/configuration/librechat_yaml)',
+    )
+  })
+
+  test('rewrites the docs index .md URL to markdown', async ({ request }) => {
+    const response = await request.get('/docs.md')
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain(
+      '# Documentation (https://www.librechat.ai/docs)',
+    )
+  })
+
+  test('rewrites .md docs URLs to per-page markdown', async ({ request }) => {
+    const response = await request.get('/docs/configuration/librechat_yaml.md')
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain(
+      '# Custom Config (https://www.librechat.ai/docs/configuration/librechat_yaml)',
+    )
+  })
+
+  test('keeps legacy .mdx docs URLs working', async ({ request }) => {
+    const response = await request.get('/docs/configuration/librechat_yaml.mdx')
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/markdown')
+    await expect(response.text()).resolves.toContain(
+      '# Custom Config (https://www.librechat.ai/docs/configuration/librechat_yaml)',
+    )
+  })
+})

--- a/lib/get-llm-text.ts
+++ b/lib/get-llm-text.ts
@@ -3,6 +3,16 @@ import { join } from 'node:path'
 import { docsSource } from '@/lib/source'
 import type { InferPageType } from 'fumadocs-core/source'
 
+export const SITE_URL = 'https://www.librechat.ai'
+
+export const MARKDOWN_RESPONSE_HEADERS = {
+  'Content-Type': 'text/markdown; charset=utf-8',
+}
+
+export function absoluteUrl(path: string): string {
+  return new URL(path, SITE_URL).toString()
+}
+
 export async function getLLMText(page: InferPageType<typeof docsSource>): Promise<string> {
   const filePath = join(process.cwd(), 'content/docs', page.file.path)
   const raw = await readFile(filePath, 'utf-8')
@@ -10,7 +20,7 @@ export async function getLLMText(page: InferPageType<typeof docsSource>): Promis
   // Strip frontmatter
   const content = raw.replace(/^---[\s\S]*?---\n*/, '')
 
-  return `# ${page.data.title} (${page.url})
+  return `# ${page.data.title} (${absoluteUrl(page.url)})
 
 ${content}`
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -232,6 +232,10 @@ const config = {
   async rewrites() {
     return [
       {
+        source: '/docs/:path*.md',
+        destination: '/llms.mdx/docs/:path*',
+      },
+      {
         source: '/docs/:path*.mdx',
         destination: '/llms.mdx/docs/:path*',
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --max-warnings 0 .",
     "lint:prettier": "prettier --cache --check --ignore-path .gitignore --ignore-path .prettierignore .",
-    "prettier": "bun run lint:prettier --write",
+    "prettier": "prettier --cache --write --ignore-path .gitignore --ignore-path .prettierignore .",
     "prepare": "husky"
   },
   "homepage": "https://www.librechat.ai",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const isCI = !!process.env.CI
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3333'
 
 export default defineConfig({
   testDir: './e2e',
@@ -13,7 +14,7 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: 'http://localhost:3333',
+    baseURL,
     trace: 'on-first-retry',
     navigationTimeout: 30_000,
     actionTimeout: 15_000,
@@ -26,11 +27,13 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    // Production build in CI for deterministic, pre-compiled pages; dev server locally.
-    command: isCI ? 'pnpm start' : 'pnpm dev',
-    url: 'http://localhost:3333',
-    reuseExistingServer: !isCI,
-    timeout: 180_000,
-  },
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        // Production build in CI for deterministic, pre-compiled pages; dev server locally.
+        command: isCI ? 'pnpm start' : 'pnpm dev',
+        url: baseURL,
+        reuseExistingServer: !isCI,
+        timeout: 180_000,
+      },
 })

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,8 +18,8 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(new URL(`/llms.mdx/docs${rest}`, request.nextUrl))
   }
 
-  // Leave the raw `.mdx` route to next.config rewrites; don't localize it.
-  if (pathname.endsWith('.mdx')) return NextResponse.next()
+  // Leave raw markdown routes to next.config rewrites; don't localize them.
+  if (pathname.endsWith('.md') || pathname.endsWith('.mdx')) return NextResponse.next()
 
   // Locale detection + default-locale rewriting for the docs.
   return i18nMiddleware(request, event)

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,14 +12,17 @@ function isMarkdownPreferred(request: NextRequest): boolean {
 export default function proxy(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl
 
+  // Leave raw markdown routes to next.config rewrites; don't localize them.
+  // Must run before content negotiation: an Accept: text/markdown request to a
+  // .md/.mdx URL needs to keep its suffix so the next.config rewrite can strip
+  // it, otherwise the route handler gets a slug that still ends in .md and 404s.
+  if (pathname.endsWith('.md') || pathname.endsWith('.mdx')) return NextResponse.next()
+
   // Serve raw markdown for content-negotiated requests (LLM/agent tooling).
   if (isMarkdownPreferred(request) && pathname.startsWith('/docs')) {
     const rest = pathname.slice('/docs'.length)
     return NextResponse.rewrite(new URL(`/llms.mdx/docs${rest}`, request.nextUrl))
   }
-
-  // Leave raw markdown routes to next.config rewrites; don't localize them.
-  if (pathname.endsWith('.md') || pathname.endsWith('.mdx')) return NextResponse.next()
 
   // Locale detection + default-locale rewriting for the docs.
   return i18nMiddleware(request, event)


### PR DESCRIPTION
## Summary

Makes the documentation easily consumable by LLMs and coding agents by exposing it as Markdown and adding a curated index.

- **Curated `/llms.txt` index** — a hand-picked map of key docs pages (Quick Start, Install, Configuration, `librechat.yaml`, Agents, MCP, RAG, Auth, env vars, Changelog) with absolute URLs and a per-page Markdown link for each entry.
- **`.md` per-page URLs** — `/docs/<path>.md` now rewrites to the Markdown route, served alongside the existing legacy `.mdx` URLs (kept for compatibility). The in-page copy/view buttons now point at `.md`.
- **Absolute URLs + shared headers** — page exports emit absolute `https://www.librechat.ai/...` URLs, and all llms routes return a shared `text/markdown; charset=utf-8` header via `MARKDOWN_RESPONSE_HEADERS`.

### Supporting changes

- **Docs sidebar restructure** — grouped into Deploy / Configure / Use / Tools / Contributing sections, surfaced `quick_start`, and switched the docs index from `QuickStartHub` to `DocsHub`.
- **Docs/README refresh** — updated the README and the contributor guide for the current Fumadocs + pnpm stack (replacing stale Bun/Nextra references and source links).
- **Playwright** — `PLAYWRIGHT_BASE_URL` lets the suite target an already-running server (skips the managed web server when set).

## Testing

- `pnpm typecheck` — passes
- `pnpm lint` — passes
- Added `e2e/llms-routes.spec.ts` covering `/llms.txt`, `/llms-full.txt`, `/docs.md`, per-page `.md`, and legacy `.mdx` routes (content-type + body assertions).