### PR TITLE
fix: bind translate workflow to Production environment

### DIFF
--- a/.github/workflows/translate_docs.yml
+++ b/.github/workflows/translate_docs.yml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   translate:
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +52,7 @@ jobs:
       - name: Translate docs
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_TRANSLATE_MODEL: ${{ vars.OPENROUTER_TRANSLATE_MODEL }}
+          OPENROUTER_TRANSLATE_MODEL: ${{ secrets.OPENROUTER_TRANSLATE_MODEL }}
         run: |
           FLAGS=""
           if [ "${{ inputs.force }}" = "true" ]; then


### PR DESCRIPTION
## Problem

The Translate Docs workflow was failing with `OPENROUTER_API_KEY is not set`. The job reads `OPENROUTER_API_KEY` and `OPENROUTER_TRANSLATE_MODEL`, both stored under the `Production` environment, but the job never declared `environment:`. Environment-scoped secrets are only injected when the job opts into that environment, so both values resolved to empty strings and the run exited 1.

## Changes

- Add `environment: Production` to the `translate` job so it can access the environment secrets.
- Read `OPENROUTER_TRANSLATE_MODEL` from `secrets` instead of `vars`, since it is stored as a secret.

## Note

If the `Production` environment has protection rules (required reviewers or a deployment-branch restriction), this auto-push job will pause for approval or fail unless `main` is an allowed branch. If gating is undesirable, the alternative is repository-level secrets.