### PR TITLE
feat: curate llms-full.txt, add compatibility icon, fix heading nesting

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,16 +1,16 @@
-import { docsSource } from '@/lib/source'
-import { getLLMText, MARKDOWN_RESPONSE_HEADERS } from '@/lib/get-llm-text'
-import { i18n } from '@/lib/i18n'
+import { getOrderedDocsPages, getLLMText, MARKDOWN_RESPONSE_HEADERS } from '@/lib/get-llm-text'
 
 export const revalidate = false
 
-export async function GET() {
-  // getPages() already defaults to the default language, but pass it explicitly
-  // so generated *.<locale>.mdx pages can never leak into the English export.
-  const scan = docsSource.getPages(i18n.defaultLanguage).map(getLLMText)
-  const scanned = await Promise.all(scan)
+const HEADER = `# LibreChat Documentation
 
-  return new Response(scanned.join('\n\n'), {
+> Full text of the LibreChat documentation for language models and coding agents. Pages follow the docs navigation order: start with deployment and configuration, then features and tools, and finish with the contributing guides.`
+
+export async function GET() {
+  const pages = getOrderedDocsPages()
+  const scanned = await Promise.all(pages.map(getLLMText))
+
+  return new Response([HEADER, ...scanned].join('\n\n'), {
     headers: MARKDOWN_RESPONSE_HEADERS,
   })
 }

--- a/content/docs/compatibility.mdx
+++ b/content/docs/compatibility.mdx
@@ -1,6 +1,7 @@
 ---
 title: Compatibility Matrix
 description: Which LibreChat capabilities are supported by each model endpoint type.
+icon: Table
 ---
 
 LibreChat connects to many AI providers through a small set of **endpoint types**.

--- a/content/docs/configuration/tools/stable_diffusion.mdx
+++ b/content/docs/configuration/tools/stable_diffusion.mdx
@@ -10,7 +10,9 @@ With the docker deployment you can skip step 2 and step 3, use the setup instruc
 
 - Note: you need a compatible GPU ("CPU-only" is possible but very slow). Nvidia is recommended, but there is no clear resource on incompatible GPUs. Any decent GPU should work.
 
-### 1. Follow download and installation instructions from **[stable-diffusion-webui readme](https://github.com/AUTOMATIC1111/stable-diffusion-webui)**
+### 1. Follow download and installation instructions
+
+Follow the setup steps from the **[stable-diffusion-webui readme](https://github.com/AUTOMATIC1111/stable-diffusion-webui)**.
 
 ### 2. Edit your run script settings
 

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -470,7 +470,9 @@ docker compose exec api npm run migrate:agent-permissions
 docker compose exec api npm run migrate:agent-permissions:batch
 ```
 
-#### 2. For the `deploy-compose.yml` (if you followed the [Ubuntu Docker Guide](/docs/remote/docker_linux)):
+#### 2. For the `deploy-compose.yml`
+
+If you followed the [Ubuntu Docker Guide](/docs/remote/docker_linux):
 
 **Preview changes (dry run):**
 

--- a/lib/__tests__/get-llm-text.test.ts
+++ b/lib/__tests__/get-llm-text.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Page tree mirroring a slice of content/docs/meta.json: a root index page,
+// section separators, ordered pages, and a folder with an index + children.
+const pageTree = {
+  en: {
+    name: 'Docs',
+    children: [
+      { type: 'page', name: 'Home', url: '/docs' },
+      { type: 'separator', name: 'Deploy' },
+      { type: 'page', name: 'Quick Start', url: '/docs/quick_start' },
+      { type: 'page', name: 'Local Install', url: '/docs/local' },
+      { type: 'separator', name: 'Configure' },
+      {
+        type: 'folder',
+        name: 'Configuration',
+        index: { type: 'page', name: 'Configuration', url: '/docs/configuration' },
+        children: [
+          { type: 'page', name: 'librechat.yaml', url: '/docs/configuration/librechat_yaml' },
+        ],
+      },
+    ],
+  },
+}
+
+// Deliberately out of navigation order, plus an orphan page absent from the tree.
+const pages = [
+  { url: '/docs/configuration/librechat_yaml' },
+  { url: '/docs/orphan' },
+  { url: '/docs/quick_start' },
+  { url: '/docs' },
+  { url: '/docs/configuration' },
+  { url: '/docs/local' },
+]
+
+const getPages = vi.fn((_lang?: string) => pages)
+
+vi.mock('@/lib/source', () => ({
+  docsSource: {
+    pageTree,
+    getPages: (lang?: string) => getPages(lang),
+  },
+}))
+
+const { getOrderedDocsPages } = await import('../get-llm-text')
+
+describe('getOrderedDocsPages', () => {
+  it('orders pages to match the navigation tree, descending into folders', () => {
+    const urls = getOrderedDocsPages().map((page) => page.url)
+
+    expect(urls).toEqual([
+      '/docs',
+      '/docs/quick_start',
+      '/docs/local',
+      '/docs/configuration',
+      '/docs/configuration/librechat_yaml',
+      '/docs/orphan',
+    ])
+  })
+
+  it('appends pages that are not reachable from the tree so nothing is dropped', () => {
+    const urls = getOrderedDocsPages().map((page) => page.url)
+
+    expect(urls).toContain('/docs/orphan')
+    expect(urls).toHaveLength(pages.length)
+  })
+
+  it('requests pages for the default language', () => {
+    getPages.mockClear()
+    getOrderedDocsPages()
+
+    expect(getPages).toHaveBeenCalledWith('en')
+  })
+})

--- a/lib/get-llm-text.ts
+++ b/lib/get-llm-text.ts
@@ -1,9 +1,66 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { docsSource } from '@/lib/source'
+import { i18n } from '@/lib/i18n'
 import type { InferPageType } from 'fumadocs-core/source'
 
 export const SITE_URL = 'https://www.librechat.ai'
+
+type DocsPage = InferPageType<typeof docsSource>
+type TreeNode = (typeof docsSource)['pageTree'][string]['children'][number]
+
+/**
+ * Walk the page tree depth-first and collect page URLs in navigation order,
+ * descending into folders (and including their index page) and ignoring
+ * separators. This mirrors the sidebar order defined by the docs meta.json
+ * files.
+ */
+function collectTreeUrls(nodes: readonly TreeNode[], urls: string[] = []): string[] {
+  for (const node of nodes) {
+    if (node.type === 'folder') {
+      if (node.index) urls.push(node.index.url)
+      collectTreeUrls(node.children, urls)
+    } else if (node.type === 'page') {
+      urls.push(node.url)
+    }
+  }
+  return urls
+}
+
+/**
+ * Return the docs pages ordered to match the documentation navigation (the
+ * curated meta.json table of contents) rather than the arbitrary order in
+ * which the content files happen to be discovered. Any page that is not
+ * reachable from the tree is appended at the end so nothing is dropped.
+ */
+export function getOrderedDocsPages(): DocsPage[] {
+  const lang = i18n.defaultLanguage
+  const tree = docsSource.pageTree[lang] ?? docsSource.pageTree[i18n.defaultLanguage]
+  // Pass the default language explicitly so generated *.<locale>.mdx pages can
+  // never leak into the English export.
+  const pages = docsSource.getPages(lang)
+  const pagesByUrl = new Map(pages.map((page) => [page.url, page]))
+
+  const ordered: DocsPage[] = []
+  const seen = new Set<string>()
+
+  for (const url of collectTreeUrls(tree?.children ?? [])) {
+    const page = pagesByUrl.get(url)
+    if (page && !seen.has(url)) {
+      ordered.push(page)
+      seen.add(url)
+    }
+  }
+
+  for (const page of pages) {
+    if (!seen.has(page.url)) {
+      ordered.push(page)
+      seen.add(page.url)
+    }
+  }
+
+  return ordered
+}
 
 export const MARKDOWN_RESPONSE_HEADERS = {
   'Content-Type': 'text/markdown; charset=utf-8',

--- a/lib/icons.tsx
+++ b/lib/icons.tsx
@@ -107,6 +107,7 @@ import {
   Blocks,
   Layers,
   LayoutDashboard,
+  Table,
   // Tools
   CloudSun,
   Sigma,
@@ -194,6 +195,7 @@ const icons: Record<string, ReactElement> = {
   Blocks: <Blocks />,
   Layers: <Layers />,
   LayoutDashboard: <LayoutDashboard />,
+  Table: <Table />,
   CloudSun: <CloudSun />,
   Sigma: <Sigma />,
   Paintbrush: <Paintbrush />,


### PR DESCRIPTION
Three documentation improvements on one branch.

## Order llms-full.txt by the docs navigation
`/llms-full.txt` concatenated pages in content-file discovery order, so the output opened partway through the docs (Quick Start straight into Translation) and scattered the install and config pages instead of leading with them. It now follows the same `meta.json` tree that drives the sidebar: homepage first, then Deploy, Configure, Use, Tools, and the contributing guides at the end. Pages not reachable from the tree are appended so nothing drops out, and a short header gives the file some context up top. The ordering lives in a `getOrderedDocsPages()` helper so it can be unit tested without a full build.

## Compatibility Matrix sidebar icon
The Compatibility Matrix page was the only top-level doc without a sidebar icon. It now uses a `Table` icon, added to the icon registry.

## Fix nested anchors in headings
Two pages had a markdown link inside a heading. Fumadocs wraps every heading in its own self-link anchor, so the inline link rendered as an `<a>` nested in another `<a>`. The browser relocates the inner anchor during parsing, which no longer matches React's render, so the page throws a hydration mismatch (#418) and re-renders the whole tree on the client, visibly reflowing the sidebar. The links now sit on the line below the heading. A scan of all 182 docs pages confirmed these were the only two affected.

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`