### PR TITLE
fix: stop the CDN caching RSC payloads as documents

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -74,6 +74,42 @@ const nonPermanentRedirects = [
  */
 const OG_VERSION = computeOgVersion()
 
+/**
+ * Edge-cache headers for the App Router routes whose HTML we want a shared CDN
+ * (Cloudflare, in front of the origin) to cache.
+ *
+ * The App Router serves two responses at every page URL: the HTML document and
+ * the RSC flight payload (`text/x-component`), told apart only by the `RSC`
+ * request header that Next advertises via `Vary: RSC`. Cloudflare ignores
+ * `Vary: RSC`, so a single `public, s-maxage` rule on the URL lets it cache
+ * whichever variant it happens to see first and serve that to everyone. When a
+ * Next prefetch populates the entry with the flight payload, real browser
+ * navigations then receive raw `text/x-component` data and render it as garbage
+ * (`:HL[...] 0:{"buildId"...}`) instead of the page.
+ *
+ * Split the rule on the `RSC` header: the document response (no header) stays
+ * shared-cacheable, the flight payload (header present) is marked
+ * `private, no-store` so the CDN never caches it and therefore can never serve
+ * one as a document. A cached document occasionally returned to an RSC request
+ * just makes Next fall back to a full navigation, which is harmless.
+ */
+const SHARED_CDN_CACHE = 'public, s-maxage=86400, stale-while-revalidate=604800'
+const cdnCacheHeaders = [
+  '/docs/:path*',
+  '/(blog|changelog|authors|privacy|tos|cookie)(.*)',
+].flatMap((source) => [
+  {
+    source,
+    missing: [{ type: 'header', key: 'RSC' }],
+    headers: [{ key: 'Cache-Control', value: SHARED_CDN_CACHE }],
+  },
+  {
+    source,
+    has: [{ type: 'header', key: 'RSC' }],
+    headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+  },
+])
+
 /** @type {import('next').NextConfig} */
 const config = {
   poweredByHeader: false,
@@ -209,24 +245,7 @@ const config = {
           },
         ],
       },
-      {
-        source: '/docs/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, s-maxage=86400, stale-while-revalidate=604800',
-          },
-        ],
-      },
-      {
-        source: '/(blog|changelog|authors|privacy|tos|cookie)(.*)',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, s-maxage=86400, stale-while-revalidate=604800',
-          },
-        ],
-      },
+      ...cdnCacheHeaders,
     ]
   },
   async rewrites() {


### PR DESCRIPTION
## Problem

A lot of `/docs/*` pages (and `/blog`, `/changelog`, …) intermittently render as raw garbage in the browser:

```
:HL["/_next/static/media/...woff2","font",...]
0:{"buildId":"...","tree":{...}}
```

That is the **RSC flight payload** (`Content-Type: text/x-component`) being served where the HTML document should be.

## Root cause

Cloudflare sits in front of the origin and **ignores `Vary: rsc`**. The App Router serves two responses at the same URL — the HTML document and the RSC flight payload — distinguished only by the `RSC` request header (advertised via `Vary: rsc`). Because `next.config.mjs` marked these routes `public, s-maxage=86400`, Cloudflare caches them, and once a Next.js 16 prefetch populated a URL's cache entry with the flight payload, CF served that `text/x-component` blob to every subsequent request, including real browser navigations.

Confirmed against production:

```
$ curl -sI https://www.librechat.ai/docs/remote/digitalocean
content-type: text/x-component        <- flight payload served as the document
cache-control: public, s-maxage=86400, stale-while-revalidate=604800
vary: rsc, next-router-state-tree, ...
cf-cache-status: HIT
```

The latent header dates back to #551; it surfaced now because the translation deploy reset the CDN cache and Next 16 segment-prefetch re-populated many entries with the flight variant.

## Fix

Split the cache-control on the `RSC` request header (the documented Next.js `has`/`missing` mechanism):

- document response (no `RSC` header) → stays `public, s-maxage` (CDN-cacheable, unchanged)
- flight payload (`RSC` header present) → `private, no-store`

Cloudflare therefore never caches a flight payload and can never serve one as a document. A cached document occasionally returned to an RSC request just makes Next fall back to a full navigation, which is harmless.

Verified the rules compile correctly into `.next/routes-manifest.json` (the contract Vercel's edge applies) and the production build passes.