### PR TITLE
fix: slow docs language switching + attribute chat usage to LibreChat

### DIFF
--- a/app/[lang]/docs/layout.tsx
+++ b/app/[lang]/docs/layout.tsx
@@ -1,8 +1,9 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs'
-import { I18nProvider } from 'fumadocs-ui/i18n'
+import { DocsI18nProvider } from '@/components/DocsI18nProvider'
 import { docsSource } from '@/lib/source'
+import { getAvailableLocalesBySlug } from '@/lib/doc-locales'
 import { baseOptions } from '@/app/layout.config'
-import { i18n, LOCALE_NAMES } from '@/lib/i18n'
+import { i18n } from '@/lib/i18n'
 import { VersionSwitcher } from '@/components/VersionSwitcher'
 import type { ReactNode } from 'react'
 
@@ -17,10 +18,7 @@ export default async function Layout({
   const tree = docsSource.pageTree[lang] ?? docsSource.pageTree[i18n.defaultLanguage]
 
   return (
-    <I18nProvider
-      locale={lang}
-      locales={i18n.languages.map((locale) => ({ locale, name: LOCALE_NAMES[locale] ?? locale }))}
-    >
+    <DocsI18nProvider locale={lang} availableLocales={getAvailableLocalesBySlug()}>
       <DocsLayout
         tree={tree}
         i18n
@@ -55,6 +53,6 @@ export default async function Layout({
         <div id="main-content" tabIndex={-1} />
         {children}
       </DocsLayout>
-    </I18nProvider>
+    </DocsI18nProvider>
   )
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -135,6 +135,13 @@ function searchDocs(docs: SearchDoc[], query: string, limit: number): SearchDoc[
 
 const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY,
+  // OpenRouter app-attribution headers: HTTP-Referer (site URL) and X-Title
+  // (app name) attribute this traffic to LibreChat on openrouter.ai's app
+  // rankings. https://openrouter.ai/docs/api-reference/overview#headers
+  headers: {
+    'HTTP-Referer': 'https://www.librechat.ai',
+    'X-Title': 'LibreChat',
+  },
 })
 
 const systemPrompt = `You are the LibreChat docs assistant. You help users find answers in the LibreChat documentation.

--- a/components/DocsI18nProvider.tsx
+++ b/components/DocsI18nProvider.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { I18nProvider } from 'fumadocs-ui/i18n'
+import { usePathname, useRouter } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { i18n, LOCALE_NAMES } from '@/lib/i18n'
+
+const allLocales = i18n.languages.map((locale) => ({
+  locale,
+  name: LOCALE_NAMES[locale] ?? locale,
+}))
+
+/**
+ * Wraps Fumadocs' I18nProvider with two changes to the language switcher:
+ *
+ * 1. Custom `onChange`: Fumadocs' default does `router.push()` AND
+ *    `router.refresh()`. The refresh wipes the client Router Cache and forces a
+ *    second, full server round-trip on every switch. It also always prefixes the
+ *    locale, producing `/en/docs/...` for the default language — a non-canonical
+ *    duplicate of the prefix-less English URL that isn't edge-cached. This
+ *    handler does a single `push` and routes the default language back to its
+ *    canonical, prefix-less URL.
+ *
+ * 2. Per-page locale list: only offer locales that actually have a translation
+ *    for the page being viewed (`availableLocales`, keyed by slug-path), plus the
+ *    current locale as a safety net. Without this the switcher lists every
+ *    language and most pages are untranslated, so the choice just bounces the
+ *    reader straight back to English.
+ */
+export function DocsI18nProvider({
+  locale,
+  availableLocales,
+  children,
+}: {
+  locale: string
+  availableLocales: Record<string, string[]>
+  children: ReactNode
+}) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  // Slug-path of the current page: drop the locale prefix (when present) and the
+  // leading `docs` segment. A docs slug never starts with a locale code, so the
+  // first segment is a prefix only when it matches a configured language.
+  const segments = pathname.split('/').filter(Boolean)
+  if (i18n.languages.includes(segments[0])) segments.shift()
+  const slug = segments.slice(1).join('/')
+
+  const available = availableLocales[slug] ?? [i18n.defaultLanguage]
+  const locales = allLocales.filter(
+    (item) => available.includes(item.locale) || item.locale === locale,
+  )
+
+  const onChange = (next: string) => {
+    const segs = pathname.split('/').filter(Boolean)
+    if (i18n.languages.includes(segs[0])) segs.shift()
+    const rest = segs.join('/')
+    router.push(next === i18n.defaultLanguage ? `/${rest}` : `/${next}/${rest}`)
+  }
+
+  return (
+    <I18nProvider locale={locale} locales={locales} onChange={onChange}>
+      {children}
+    </I18nProvider>
+  )
+}

--- a/lib/doc-locales.ts
+++ b/lib/doc-locales.ts
@@ -1,0 +1,36 @@
+import { docsSource } from '@/lib/source'
+import { i18n } from '@/lib/i18n'
+
+/**
+ * Map of docs slug-path -> locales that have a REAL translated file
+ * (`foo.<locale>.mdx`), always including the default language. Pages whose only
+ * available locale is the default are omitted, so a lookup miss means
+ * "English only".
+ *
+ * Same discriminator as generateStaticParams and the hreflang gate: getPage
+ * falls back to the English file for a missing locale (path ends `.mdx`), while
+ * a real translation's path ends `.<locale>.mdx`.
+ *
+ * Used to filter the language switcher per page so it never offers a locale that
+ * would just bounce the reader back to English.
+ */
+let cached: Record<string, string[]> | null = null
+
+export function getAvailableLocalesBySlug(): Record<string, string[]> {
+  if (cached) return cached
+
+  const map: Record<string, string[]> = {}
+  const nonDefault = i18n.languages.filter((l) => l !== i18n.defaultLanguage)
+
+  for (const page of docsSource.getPages(i18n.defaultLanguage)) {
+    const locales = [i18n.defaultLanguage]
+    for (const locale of nonDefault) {
+      const translated = docsSource.getPage(page.slugs, locale)
+      if (translated?.file.path.endsWith(`.${locale}.mdx`)) locales.push(locale)
+    }
+    if (locales.length > 1) map[page.slugs.join('/')] = locales
+  }
+
+  cached = map
+  return map
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -96,6 +96,10 @@ const OG_VERSION = computeOgVersion()
 const SHARED_CDN_CACHE = 'public, s-maxage=86400, stale-while-revalidate=604800'
 const cdnCacheHeaders = [
   '/docs/:path*',
+  // Localized docs (/<locale>/docs/...). Without this they match no cache rule,
+  // so Cloudflare never edge-caches them and every language switch is a full
+  // origin round-trip — including the 307 that untranslated pages redirect with.
+  '/(zh|es|fr|de|ja)/docs/:path*',
   '/(blog|changelog|authors|privacy|tos|cookie)(.*)',
 ].flatMap((source) => [
   {


### PR DESCRIPTION
## Why

Changing language in the docs felt laggy and frequently appeared to do nothing. Investigation (reproduced against a production build) found several interacting causes, plus a quick win to attribute the docs chat's OpenRouter usage to LibreChat.

## Language switching

| Cause | Fix |
|---|---|
| Fumadocs' default locale handler runs `router.push()` **and** `router.refresh()` — a second full server round-trip + Router Cache wipe on every switch | Custom `onChange` does a single `push` (no refresh) |
| Same handler prefixes the default language → non-canonical `/en/docs/...` (not edge-cached) | Handler routes English back to its prefix-less, edge-cached URL |
| Localized `/<locale>/docs/...` routes matched no CDN cache rule, so Cloudflare never edge-cached them — every switch hit the origin | Added them to `cdnCacheHeaders` (with the RSC document/flight split) |
| ~60% of pages have no translation, so the switcher offered locales that just 307-redirect back to English | Switcher is filtered per page to locales that actually have a translated file |

New: `components/DocsI18nProvider.tsx` (client wrapper with the custom handler + per-page locale filter) and `lib/doc-locales.ts` (cached slug → available-locales map, using the same `.<locale>.mdx` discriminator as `generateStaticParams`).

## Chat attribution

The docs assistant now sends OpenRouter's app-attribution headers (`HTTP-Referer` + `X-Title`) so its traffic is credited to LibreChat on OpenRouter's app rankings. Implemented via the existing provider's `headers` option — no new dependency.

> Note: migrating the chat engine onto `@librechat/agents` was considered and deliberately deferred. It pulls in a heavy LangChain/LangGraph + multi-provider dependency tree and would require a stream adapter (the chat UI is coupled to the AI SDK UI message stream protocol), with no attribution benefit over the headers above.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm build` (production) ✓
- `pnpm test` — 133 passed ✓
