### PR TITLE
fix: attribute docs translation traffic to LibreChat on OpenRouter

### DIFF
--- a/lib/i18n/engine.ts
+++ b/lib/i18n/engine.ts
@@ -8,7 +8,16 @@ export interface TranslateModel {
 }
 
 export function createOpenRouterModel(): TranslateModel {
-  const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY })
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    // OpenRouter app-attribution headers: HTTP-Referer (site URL) and X-Title
+    // (app name) credit this traffic to LibreChat on openrouter.ai's app
+    // rankings. https://openrouter.ai/docs/api-reference/overview#headers
+    headers: {
+      'HTTP-Referer': 'https://www.librechat.ai',
+      'X-Title': 'LibreChat',
+    },
+  })
   // Pin the provider via OpenRouter's routing preferences; `service_tier` is not a
   // typed setting, so pass it through `extraBody` (merged verbatim into the request
   // body and forwarded to the upstream provider).


### PR DESCRIPTION
## Summary

The docs translation pipeline wasn't crediting its OpenRouter traffic to LibreChat in OpenRouter's app rankings.

#644 added OpenRouter's app-attribution headers (`HTTP-Referer` + `X-Title`) to the docs assistant chat route (`app/api/chat/route.ts`). However, the translation path creates its own OpenRouter provider in `lib/i18n/engine.ts` (`createOpenRouterModel()`, used by `scripts/translate.ts`), which still omitted those headers, so automated translation runs went unattributed.

This adds the same headers to the translation provider. Now both the docs assistant chat and the automated docs translation runs are credited to LibreChat on OpenRouter's app stats.

## Notes

- `scripts/generate-starters.ts` is a separate starters generator (not translation) and is left untouched, in keeping with the scope of this fix.
- Engine tests use mock models and never invoke `createOpenRouterModel()`, so they're unaffected.