### PR TITLE
fix(i18n): translate all docs/locales in one run + cut redundant CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref.

--- a/.github/workflows/generate_embeddings.yml
+++ b/.github/workflows/generate_embeddings.yml
@@ -1,9 +1,17 @@
 name: 'generate_embeddings'
 
 on:
-  push:
-    branches:
-      - main
+  # Disabled for now. The docs site itself doesn't consume these embeddings (Ask-AI
+  # builds its own English index at runtime; site search uses the Fumadocs static
+  # index), so the automatic push trigger is off. Left runnable on demand. To
+  # re-enable automatic embedding, uncomment the push block below — note it is gated
+  # to real docs changes only, not every push to main.
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'content/docs/**'
 
 jobs:
   generate:

--- a/.github/workflows/generate_starters.yml
+++ b/.github/workflows/generate_starters.yml
@@ -7,10 +7,13 @@ on:
       - 'content/docs/**'
       # Generated translations are not starter inputs; ignore any locale's
       # `*.<xx>.mdx` / `meta.<xx>.json` so a translation commit doesn't trigger a
-      # starters run. The `??` glob is locale-agnostic — adding a language needs no
-      # change here (TARGET_LOCALES in lib/i18n/config.ts is the source of truth).
-      - '!content/docs/**/*.??.mdx'
-      - '!content/docs/**/meta.??.json'
+      # starters run. `[a-z][a-z]` matches any two-letter locale code and is
+      # locale-agnostic — adding a language needs no change here (TARGET_LOCALES in
+      # lib/i18n/config.ts is the source of truth). A character class is required
+      # because GitHub filter patterns read `?` as "zero or one of the preceding
+      # character", not a single-char wildcard.
+      - '!content/docs/**/*.[a-z][a-z].mdx'
+      - '!content/docs/**/meta.[a-z][a-z].json'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/generate_starters.yml
+++ b/.github/workflows/generate_starters.yml
@@ -5,18 +5,12 @@ on:
     branches: [main]
     paths:
       - 'content/docs/**'
-      # Generated translations are not starter inputs; ignore them so a
-      # translation commit doesn't trigger a starters run.
-      - '!content/docs/**/*.zh.mdx'
-      - '!content/docs/**/*.es.mdx'
-      - '!content/docs/**/*.fr.mdx'
-      - '!content/docs/**/*.de.mdx'
-      - '!content/docs/**/*.ja.mdx'
-      - '!content/docs/**/meta.zh.json'
-      - '!content/docs/**/meta.es.json'
-      - '!content/docs/**/meta.fr.json'
-      - '!content/docs/**/meta.de.json'
-      - '!content/docs/**/meta.ja.json'
+      # Generated translations are not starter inputs; ignore any locale's
+      # `*.<xx>.mdx` / `meta.<xx>.json` so a translation commit doesn't trigger a
+      # starters run. The `??` glob is locale-agnostic — adding a language needs no
+      # change here (TARGET_LOCALES in lib/i18n/config.ts is the source of truth).
+      - '!content/docs/**/*.??.mdx'
+      - '!content/docs/**/meta.??.json'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/translate_docs.yml
+++ b/.github/workflows/translate_docs.yml
@@ -7,11 +7,13 @@ on:
       - 'content/docs/**'
       # Exclude generated translations of any locale. A `*.<xx>.mdx` or
       # `meta.<xx>.json` file is bot output, never a translation source, so it must
-      # not retrigger this workflow. The `??` glob matches any two-letter locale, so
-      # adding a language needs no change here — TARGET_LOCALES in
-      # lib/i18n/config.ts stays the single source of truth.
-      - '!content/docs/**/*.??.mdx'
-      - '!content/docs/**/meta.??.json'
+      # not retrigger this workflow. `[a-z][a-z]` matches any two-letter locale code,
+      # so adding a language needs no change here — TARGET_LOCALES in
+      # lib/i18n/config.ts stays the single source of truth. (Note: GitHub filter
+      # patterns treat `?` as a regex-style "zero or one of the preceding character"
+      # quantifier, not a single-char wildcard, so a character class is required.)
+      - '!content/docs/**/*.[a-z][a-z].mdx'
+      - '!content/docs/**/meta.[a-z][a-z].json'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/translate_docs.yml
+++ b/.github/workflows/translate_docs.yml
@@ -5,16 +5,13 @@ on:
     branches: [main]
     paths:
       - 'content/docs/**'
-      - '!content/docs/**/*.zh.mdx'
-      - '!content/docs/**/*.es.mdx'
-      - '!content/docs/**/*.fr.mdx'
-      - '!content/docs/**/*.de.mdx'
-      - '!content/docs/**/*.ja.mdx'
-      - '!content/docs/**/meta.zh.json'
-      - '!content/docs/**/meta.es.json'
-      - '!content/docs/**/meta.fr.json'
-      - '!content/docs/**/meta.de.json'
-      - '!content/docs/**/meta.ja.json'
+      # Exclude generated translations of any locale. A `*.<xx>.mdx` or
+      # `meta.<xx>.json` file is bot output, never a translation source, so it must
+      # not retrigger this workflow. The `??` glob matches any two-letter locale, so
+      # adding a language needs no change here — TARGET_LOCALES in
+      # lib/i18n/config.ts stays the single source of truth.
+      - '!content/docs/**/*.??.mdx'
+      - '!content/docs/**/meta.??.json'
   workflow_dispatch:
     inputs:
       force:
@@ -68,7 +65,10 @@ jobs:
           if git diff --cached --quiet; then
             echo "No translation changes to commit"
           else
-            git commit --no-verify -m "chore: update docs translations"
+            # [skip ci] so this bot commit doesn't re-trigger the push-on-main
+            # workflows (ci, bundle analysis, embeddings, links). Without it, every
+            # translation commit fans out a redundant ~4-workflow cascade.
+            git commit --no-verify -m "chore: update docs translations [skip ci]"
             # main may have advanced while translating (e.g. an unrelated non-docs
             # commit that does not queue another translate run). Rebase the bot
             # commit onto the latest main and retry so a non-fast-forward rejection

--- a/lib/i18n/engine.ts
+++ b/lib/i18n/engine.ts
@@ -2,6 +2,7 @@ import { generateText } from 'ai'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { GLOSSARY, TRANSLATE_MODEL, TRANSLATE_PROVIDER, TRANSLATE_SERVICE_TIER } from './config'
 import { LOCALE_NAMES } from '../i18n'
+import { withRetry } from './retry'
 
 export interface TranslateModel {
   generate(input: { system: string; prompt: string }): Promise<string>
@@ -25,9 +26,23 @@ export function createOpenRouterModel(): TranslateModel {
     provider: { only: [TRANSLATE_PROVIDER] },
     extraBody: { service_tier: TRANSLATE_SERVICE_TIER },
   })
+  // The `flex` tier returns 429s under load. Retry with backoff (honoring any
+  // Retry-After) so a single workflow run converges instead of skipping most pages
+  // and needing repeated manual re-runs. SDK-level retries are disabled so the
+  // backoff lives in one place; TRANSLATE_MAX_RETRIES tunes the budget in CI.
+  const maxRetries = Number(process.env.TRANSLATE_MAX_RETRIES) || 6
   return {
     async generate({ system, prompt }) {
-      const { text } = await generateText({ model, system, prompt, temperature: 0.2 })
+      const { text } = await withRetry(
+        () => generateText({ model, system, prompt, temperature: 0.2, maxRetries: 0 }),
+        {
+          retries: maxRetries,
+          onRetry: ({ attempt, delayMs, error }) =>
+            console.warn(
+              `[translate] rate-limited/transient error, retry ${attempt}/${maxRetries} in ${Math.round(delayMs)}ms: ${(error as Error)?.message ?? error}`,
+            ),
+        },
+      )
       return text
     },
   }

--- a/lib/i18n/retry.test.ts
+++ b/lib/i18n/retry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { withRetry, isRetryableError, retryAfterMs } from './retry'
+
+const noSleep = async () => {}
+
+describe('isRetryableError', () => {
+  it('treats 429, 408 and any 5xx as retryable', () => {
+    expect(isRetryableError({ statusCode: 429 })).toBe(true)
+    expect(isRetryableError({ statusCode: 408 })).toBe(true)
+    expect(isRetryableError({ status: 503 })).toBe(true)
+    expect(isRetryableError({ response: { status: 529 } })).toBe(true)
+  })
+
+  it('treats client errors other than 408/429 as non-retryable', () => {
+    expect(isRetryableError({ statusCode: 400 })).toBe(false)
+    expect(isRetryableError({ statusCode: 401 })).toBe(false)
+    expect(isRetryableError({ statusCode: 404 })).toBe(false)
+  })
+
+  it('honors an explicit isRetryable flag from the AI SDK', () => {
+    expect(isRetryableError({ isRetryable: true })).toBe(true)
+  })
+
+  it('detects transient network failures by message when no status is present', () => {
+    expect(isRetryableError(new Error('fetch failed'))).toBe(true)
+    expect(isRetryableError(new Error('ECONNRESET'))).toBe(true)
+    expect(isRetryableError(new Error('Provider overloaded, please retry'))).toBe(true)
+    expect(isRetryableError(new Error('invalid model id'))).toBe(false)
+  })
+})
+
+describe('retryAfterMs', () => {
+  it('parses a numeric seconds header', () => {
+    expect(retryAfterMs({ responseHeaders: { 'retry-after': '2' } })).toBe(2000)
+  })
+
+  it('parses an HTTP-date header relative to the supplied now', () => {
+    const now = 1_000_000
+    const when = new Date(now + 5000).toUTCString()
+    expect(retryAfterMs({ responseHeaders: { 'retry-after': when } }, now)).toBe(
+      Date.parse(when) - now,
+    )
+  })
+
+  it('returns undefined when the header is missing or unparseable', () => {
+    expect(retryAfterMs({})).toBeUndefined()
+    expect(retryAfterMs({ responseHeaders: { 'retry-after': 'soon' } })).toBeUndefined()
+  })
+})
+
+describe('withRetry', () => {
+  it('retries a retryable failure then returns the eventual success', async () => {
+    let calls = 0
+    const out = await withRetry(
+      async () => {
+        calls++
+        if (calls < 3) throw { statusCode: 429 }
+        return 'done'
+      },
+      { sleep: noSleep, random: () => 0 },
+    )
+    expect(out).toBe('done')
+    expect(calls).toBe(3)
+  })
+
+  it('does not retry a non-retryable error', async () => {
+    let calls = 0
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw { statusCode: 400 }
+        },
+        { sleep: noSleep },
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(calls).toBe(1)
+  })
+
+  it('gives up after the retry budget and rethrows the last error', async () => {
+    let calls = 0
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw { statusCode: 503 }
+        },
+        { retries: 2, sleep: noSleep, random: () => 0 },
+      ),
+    ).rejects.toMatchObject({ statusCode: 503 })
+    expect(calls).toBe(3) // 1 initial attempt + 2 retries
+  })
+
+  it('waits the Retry-After duration when the header is present', async () => {
+    const delays: number[] = []
+    let calls = 0
+    await withRetry(
+      async () => {
+        calls++
+        if (calls < 2) throw { statusCode: 429, responseHeaders: { 'retry-after': '5' } }
+        return 'ok'
+      },
+      {
+        sleep: async (ms) => {
+          delays.push(ms)
+        },
+        random: () => 0,
+      },
+    )
+    expect(delays).toEqual([5000])
+  })
+})

--- a/lib/i18n/retry.ts
+++ b/lib/i18n/retry.ts
@@ -1,0 +1,96 @@
+/**
+ * Retry helper for the translation pipeline. The translate model talks to
+ * OpenRouter on the low-priority `flex` service tier, which returns 429s under
+ * load; without retry/backoff a burst of rate-limit errors skips most pages and
+ * forces the whole workflow to be re-run by hand. This converges a single run.
+ */
+
+/** HTTP status carried by an error, however the SDK/provider exposes it. */
+function statusOf(err: unknown): number | undefined {
+  const e = err as { statusCode?: unknown; status?: unknown; response?: { status?: unknown } }
+  for (const v of [e?.statusCode, e?.status, e?.response?.status]) {
+    if (typeof v === 'number') return v
+  }
+  return undefined
+}
+
+/** Response headers carried by an error, however the SDK/provider exposes them. */
+function headersOf(err: unknown): Record<string, string> | undefined {
+  const e = err as { responseHeaders?: unknown; response?: { headers?: unknown } }
+  const h = (e?.responseHeaders ?? e?.response?.headers) as Record<string, string> | undefined
+  return h && typeof h === 'object' ? h : undefined
+}
+
+/**
+ * Whether an error is worth retrying: rate limits (429), request timeout (408),
+ * and any 5xx (incl. 529 "overloaded"); the AI SDK's own `isRetryable` flag; and
+ * transient network failures detected by message when no status is present.
+ */
+export function isRetryableError(err: unknown): boolean {
+  if ((err as { isRetryable?: unknown })?.isRetryable === true) return true
+  const status = statusOf(err)
+  if (status !== undefined) return status === 408 || status === 429 || status >= 500
+  const msg = (err instanceof Error ? err.message : String(err ?? '')).toLowerCase()
+  return /rate.?limit|too many requests|timed? ?out|econnreset|etimedout|eai_again|enotfound|fetch failed|socket hang up|network|overloaded|temporarily/.test(
+    msg,
+  )
+}
+
+/**
+ * Milliseconds to wait per a `Retry-After` header (seconds or HTTP-date), or
+ * undefined when the header is absent/unparseable so the caller falls back to
+ * exponential backoff.
+ */
+export function retryAfterMs(err: unknown, now: number = Date.now()): number | undefined {
+  const headers = headersOf(err)
+  const raw = headers?.['retry-after'] ?? headers?.['Retry-After']
+  if (raw == null || raw === '') return undefined
+  const seconds = Number(raw)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const when = Date.parse(String(raw))
+  return Number.isFinite(when) ? Math.max(0, when - now) : undefined
+}
+
+export interface RetryOptions {
+  /** Max retries after the first attempt (so total tries = retries + 1). */
+  retries?: number
+  /** Base for exponential backoff in ms (doubled each attempt). */
+  baseDelayMs?: number
+  /** Upper bound for a single backoff wait in ms. */
+  maxDelayMs?: number
+  /** Injectable for tests; defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>
+  /** Injectable for tests; defaults to Math.random (jitter). */
+  random?: () => number
+  /** Observability hook fired before each backoff wait. */
+  onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Run `fn`, retrying retryable failures with exponential backoff + jitter. A
+ * `Retry-After` header, when present, overrides the computed backoff. Non-retryable
+ * errors and an exhausted budget re-throw the original error.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, opts: RetryOptions = {}): Promise<T> {
+  const retries = opts.retries ?? 6
+  const base = opts.baseDelayMs ?? 1000
+  const maxDelay = opts.maxDelayMs ?? 60_000
+  const sleep = opts.sleep ?? defaultSleep
+  const random = opts.random ?? Math.random
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (attempt >= retries || !isRetryableError(err)) throw err
+      const exp = Math.min(maxDelay, base * 2 ** attempt)
+      // Full-ish jitter in [exp/2, exp] to avoid synchronized retries.
+      const backoff = exp / 2 + random() * (exp / 2)
+      const delayMs = retryAfterMs(err) ?? backoff
+      opts.onRetry?.({ attempt: attempt + 1, delayMs, error: err })
+      await sleep(delayMs)
+    }
+  }
+}

--- a/lib/i18n/run.test.ts
+++ b/lib/i18n/run.test.ts
@@ -248,6 +248,31 @@ describe('runTranslation', () => {
     expect(await readFile(join(content, 'index.de.mdx'), 'utf8')).toBe(before)
   })
 
+  it('retries a transiently-failing file within one run until it succeeds', async () => {
+    // A rate-limit/provider error throws on the first attempt for the paragraph
+    // block, then succeeds. A single run must converge (translate the file) rather
+    // than skipping it and requiring the whole workflow to be re-run.
+    let thrown = false
+    const flaky: TranslateModel = {
+      generate: async ({ prompt }) => {
+        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
+        if (text.includes('A paragraph') && !thrown) {
+          thrown = true
+          throw Object.assign(new Error('429 Too Many Requests'), { statusCode: 429 })
+        }
+        return text
+      },
+    }
+    const stats = await runTranslation({
+      contentDir: content,
+      cacheDir: cache,
+      locales: ['de'],
+      model: flaky,
+    })
+    expect(stats.skipped).toEqual([])
+    expect(await readdir(content)).toContain('index.de.mdx')
+  })
+
   it('removes a stale locale file when a re-translation fails validation', async () => {
     await runTranslation({ contentDir: content, cacheDir: cache, locales: ['de'], model: stub })
     expect(await readdir(content)).toContain('index.de.mdx')

--- a/lib/i18n/run.ts
+++ b/lib/i18n/run.ts
@@ -38,7 +38,13 @@ export interface RunStats {
   skipped: string[]
 }
 
-const FILE_CONCURRENCY = 6
+// How many files translate at once. Lower it (TRANSLATE_CONCURRENCY) to ease
+// rate-limit pressure when bootstrapping a brand-new locale from scratch.
+const FILE_CONCURRENCY = Number(process.env.TRANSLATE_CONCURRENCY) || 6
+// How many times to re-drive files that failed transiently within a single run,
+// so a burst of provider/rate-limit errors converges instead of requiring the
+// whole workflow to be re-run by hand.
+const MAX_FILE_ROUNDS = Number(process.env.TRANSLATE_FILE_ROUNDS) || 3
 const LOCALE_ALT = TARGET_LOCALES.join('|')
 const LOCALE_RE = new RegExp(`\\.(${LOCALE_ALT})\\.mdx$`)
 const META_LOCALE_RE = new RegExp(`^meta\\.(${LOCALE_ALT})\\.json$`)
@@ -122,115 +128,145 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
       return result
     }
 
-    await Promise.all(
-      filtered.map((rel) =>
-        limit(async () => {
-          const abs = join(opts.contentDir, rel)
-          const staged = new Map<string, string>()
-          try {
-            if (rel.endsWith('meta.json')) {
-              const meta = JSON.parse(await readFile(abs, 'utf8'))
-              const map = new Map<string, string>()
-              for (const s of extractMetaStrings(meta))
-                map.set(s, await translateString(staged, s, 'inline'))
-              if (opts.dryRun) return
-              const out = rebuildMeta(meta, (s) => map.get(s) ?? s)
-              await writeFile(
-                join(opts.contentDir, localePath(rel, locale, '.json')),
-                `${JSON.stringify(out, null, 2)}\n`,
-              )
-              for (const [h, v] of staged) tm.set(h, v)
-              return
-            }
+    // Records the last transient error per file so it can be reported only if the
+    // file never succeeds across every retry round.
+    const lastTransientError = new Map<string, string>()
 
-            const source = await readFile(abs, 'utf8')
-            const parsed = matter(source)
-            const segs = segmentMarkdown(parsed.content)
-            // Pin translated heading ids to the English slug so same-page #anchor
-            // links keep resolving (Fumadocs would otherwise regenerate the id from
-            // the translated text). Slug in document order to match its github-slugger.
-            const slugger = new GithubSlugger()
-            const naiveSlug = (s: string) => new GithubSlugger().slug(s)
-            const outSegs: { text: string }[] = []
-            for (let i = 0; i < segs.length; i++) {
-              const seg = segs[i]
-              if (seg.kind === 'verbatim') {
-                // Advance the slugger over verbatim (identifier/code) headings too,
-                // in document order, so the suffixes it assigns to pinned headings
-                // match Fumadocs on the English page. Pin a verbatim heading only
-                // when it actually collides: otherwise its natural slug already
-                // equals English, and pinning every identifier heading adds noise.
-                if (isHeading(seg.text) && !headingHasExplicitId(seg.text)) {
-                  const base = headingSlugText(seg.text)
-                  const id = slugger.slug(base)
-                  outSegs.push({
-                    text:
-                      id === naiveSlug(base)
-                        ? seg.text
-                        : `${seg.text.replace(/\s+$/, '')} [#${id}]`,
-                  })
-                } else {
-                  outSegs.push({ text: seg.text })
-                }
-                continue
-              }
-              // Values from quoted JS/JSX string literals: translate the unescaped
-              // text, then re-escape for the enclosing quote so a natural apostrophe
-              // in the translation can't break the generated MDX.
-              if (seg.jsQuote) {
-                const clean = unescapeJsString(seg.text, seg.jsQuote)
-                const t = await translateString(staged, clean, 'inline', neighborContext(segs, i))
-                outSegs.push({ text: escapeJsString(t, seg.jsQuote) })
-                continue
-              }
-              let text = await translateString(staged, seg.text, 'block', neighborContext(segs, i))
-              if (isHeading(seg.text) && !headingHasExplicitId(seg.text)) {
-                const id = slugger.slug(headingSlugText(seg.text))
-                // Trim any trailing whitespace the model added before appending the
-                // id, so `[#id]` terminates the heading line. Fumadocs only attaches
-                // a custom id when it ends the heading text; a trailing newline would
-                // push it onto the next line and silently drop the anchor.
-                if (!headingHasExplicitId(text)) text = `${text.replace(/\s+$/, '')} [#${id}]`
-              }
-              outSegs.push({ text })
-            }
-            const outData: Record<string, unknown> = { ...parsed.data }
-            for (const key of ['title', 'description']) {
-              const val = parsed.data[key]
-              if (typeof val === 'string' && /\p{L}/u.test(val))
-                outData[key] = await translateString(staged, val, 'inline')
-            }
-            if (opts.dryRun) {
-              stats.files++
-              return
-            }
-            const output = matter.stringify(reassemble(outSegs), outData)
-            const check = validateTranslation(source, output)
-            if (!check.ok) {
-              stats.skipped.push(`${rel} [${locale}]: ${check.error}`)
-              // Remove any previously-written locale file so the page falls back to
-              // fresh English instead of serving a stale translation that predates
-              // the source change. It is retried (uncached) on the next run.
-              await unlink(join(opts.contentDir, localePath(rel, locale, '.mdx'))).catch(() => {})
-              return
-            }
-            await writeFile(join(opts.contentDir, localePath(rel, locale, '.mdx')), output)
+    // Translate one source file. Returns:
+    //   'ok'        — written (or a no-op dry run)
+    //   'skip'      — deterministic failure (broken output removed; retried next run)
+    //   'transient' — recoverable failure (provider/network/rate-limit/empty
+    //                 response); retried in-run by the round loop below.
+    const processFile = (rel: string): Promise<'ok' | 'skip' | 'transient'> =>
+      limit(async () => {
+        const abs = join(opts.contentDir, rel)
+        const staged = new Map<string, string>()
+        try {
+          if (rel.endsWith('meta.json')) {
+            const meta = JSON.parse(await readFile(abs, 'utf8'))
+            const map = new Map<string, string>()
+            for (const s of extractMetaStrings(meta))
+              map.set(s, await translateString(staged, s, 'inline'))
+            if (opts.dryRun) return 'ok'
+            const out = rebuildMeta(meta, (s) => map.get(s) ?? s)
+            await writeFile(
+              join(opts.contentDir, localePath(rel, locale, '.json')),
+              `${JSON.stringify(out, null, 2)}\n`,
+            )
             for (const [h, v] of staged) tm.set(h, v)
-            stats.files++
-          } catch (e) {
-            // A transient failure (a provider/network error, an empty model
-            // response, an I/O error, or an uncached block under --force / after a
-            // prompt-version bump) must not reject Promise.all and abort the whole
-            // locale run — but it must also NOT delete the existing translation, or
-            // a provider blip would be committed as data loss. Keep the previous
-            // locale file and retry next run. A successful-but-structurally-broken
-            // translation is removed deliberately by the validateTranslation path
-            // above; this exception path means we simply could not translate.
-            stats.skipped.push(`${rel} [${locale}]: ${(e as Error).message}`)
+            return 'ok'
           }
-        }),
-      ),
-    )
+
+          const source = await readFile(abs, 'utf8')
+          const parsed = matter(source)
+          const segs = segmentMarkdown(parsed.content)
+          // Pin translated heading ids to the English slug so same-page #anchor
+          // links keep resolving (Fumadocs would otherwise regenerate the id from
+          // the translated text). Slug in document order to match its github-slugger.
+          const slugger = new GithubSlugger()
+          const naiveSlug = (s: string) => new GithubSlugger().slug(s)
+          const outSegs: { text: string }[] = []
+          for (let i = 0; i < segs.length; i++) {
+            const seg = segs[i]
+            if (seg.kind === 'verbatim') {
+              // Advance the slugger over verbatim (identifier/code) headings too,
+              // in document order, so the suffixes it assigns to pinned headings
+              // match Fumadocs on the English page. Pin a verbatim heading only
+              // when it actually collides: otherwise its natural slug already
+              // equals English, and pinning every identifier heading adds noise.
+              if (isHeading(seg.text) && !headingHasExplicitId(seg.text)) {
+                const base = headingSlugText(seg.text)
+                const id = slugger.slug(base)
+                outSegs.push({
+                  text:
+                    id === naiveSlug(base) ? seg.text : `${seg.text.replace(/\s+$/, '')} [#${id}]`,
+                })
+              } else {
+                outSegs.push({ text: seg.text })
+              }
+              continue
+            }
+            // Values from quoted JS/JSX string literals: translate the unescaped
+            // text, then re-escape for the enclosing quote so a natural apostrophe
+            // in the translation can't break the generated MDX.
+            if (seg.jsQuote) {
+              const clean = unescapeJsString(seg.text, seg.jsQuote)
+              const t = await translateString(staged, clean, 'inline', neighborContext(segs, i))
+              outSegs.push({ text: escapeJsString(t, seg.jsQuote) })
+              continue
+            }
+            let text = await translateString(staged, seg.text, 'block', neighborContext(segs, i))
+            if (isHeading(seg.text) && !headingHasExplicitId(seg.text)) {
+              const id = slugger.slug(headingSlugText(seg.text))
+              // Trim any trailing whitespace the model added before appending the
+              // id, so `[#id]` terminates the heading line. Fumadocs only attaches
+              // a custom id when it ends the heading text; a trailing newline would
+              // push it onto the next line and silently drop the anchor.
+              if (!headingHasExplicitId(text)) text = `${text.replace(/\s+$/, '')} [#${id}]`
+            }
+            outSegs.push({ text })
+          }
+          const outData: Record<string, unknown> = { ...parsed.data }
+          for (const key of ['title', 'description']) {
+            const val = parsed.data[key]
+            if (typeof val === 'string' && /\p{L}/u.test(val))
+              outData[key] = await translateString(staged, val, 'inline')
+          }
+          if (opts.dryRun) {
+            stats.files++
+            return 'ok'
+          }
+          const output = matter.stringify(reassemble(outSegs), outData)
+          const check = validateTranslation(source, output)
+          if (!check.ok) {
+            stats.skipped.push(`${rel} [${locale}]: ${check.error}`)
+            // Remove any previously-written locale file so the page falls back to
+            // fresh English instead of serving a stale translation that predates
+            // the source change. It is retried (uncached) on the next run.
+            await unlink(join(opts.contentDir, localePath(rel, locale, '.mdx'))).catch(() => {})
+            return 'skip'
+          }
+          await writeFile(join(opts.contentDir, localePath(rel, locale, '.mdx')), output)
+          for (const [h, v] of staged) tm.set(h, v)
+          stats.files++
+          return 'ok'
+        } catch (e) {
+          // A transient failure (a provider/network/rate-limit error, an empty
+          // model response, an I/O error, or an uncached block under --force /
+          // after a prompt-version bump). It must NOT delete the existing
+          // translation — a provider blip committed as data loss — so the previous
+          // locale file is kept. The round loop below re-drives this file within
+          // the same run; only if it still fails after every round is it reported
+          // as skipped. (A successful-but-structurally-broken translation is
+          // removed deliberately by the validateTranslation path above.)
+          lastTransientError.set(rel, (e as Error).message)
+          return 'transient'
+        }
+      })
+
+    // Translate every file, then re-drive the ones that failed transiently until
+    // they succeed or the round budget is exhausted. The per-call backoff lives in
+    // the model (retry.withRetry); these rounds give a file whose retry budget was
+    // exhausted a fresh attempt, so one workflow run converges rather than leaving
+    // most pages untranslated for a manual re-run.
+    let pending = filtered
+    for (let round = 0; ; round++) {
+      const results = await Promise.all(
+        pending.map(async (rel) => [rel, await processFile(rel)] as const),
+      )
+      const transient = results.filter(([, r]) => r === 'transient').map(([rel]) => rel)
+      if (transient.length === 0 || round >= MAX_FILE_ROUNDS) {
+        for (const rel of transient)
+          stats.skipped.push(
+            `${rel} [${locale}]: ${lastTransientError.get(rel) ?? 'transient failure'}`,
+          )
+        break
+      }
+      console.warn(
+        `[translate] ${locale}: retrying ${transient.length} transiently-failed file(s) (round ${round + 1}/${MAX_FILE_ROUNDS})`,
+      )
+      pending = transient
+    }
 
     // Orphan cleanup + cache GC only on full runs.
     if (!opts.only && !opts.dryRun) {


### PR DESCRIPTION
## The real problem

Each \`Translate Docs\` run was only translating a fraction of the pages (~1/10), so the workflow had to be re-run many times by hand to finish a language — and a brand-new language (empty cache, every block hitting the API at once) was the worst case.

**Root cause:** the model calls OpenRouter on the low-priority \`flex\` service tier, which returns 429s under load, and the pipeline had **no rate-limit handling**. A throttled block threw, the whole file was caught and pushed to \`skipped\`, and the run moved on — deferring the file to "next run." A single run never converged. The commit sizes showed it: 292 → 189 → 99 → 38 → … each run completing only what didn't get throttled.

## Fix — make one run converge

- **`lib/i18n/retry.ts`** (new): \`withRetry()\` retries retryable failures (429 / 408 / 5xx / the AI SDK's \`isRetryable\` flag / transient network errors) with exponential backoff + jitter, honoring a \`Retry-After\` header when present. \`isRetryableError\` / \`retryAfterMs\` are unit-tested with injected sleep + clock.
- **`engine.ts`**: wrap the model call in \`withRetry\`, disable the SDK's own retry so backoff lives in one place. Each retry logs to CI so throttling is visible. \`TRANSLATE_MAX_RETRIES\` tunes the budget (default 6).
- **`run.ts`**: re-drive transiently-failed files **within the same run** (bounded by \`TRANSLATE_FILE_ROUNDS\`, default 3) instead of leaving them for a manual re-run. Deterministic validation failures are still removed and retried next run. Concurrency is tunable via \`TRANSLATE_CONCURRENCY\` to ease pressure when bootstrapping a new locale.
- Added a regression test proving a transiently-429'd file now completes in a single \`runTranslation\` call.

Adding a language is operationally unchanged (extend \`TARGET_LOCALES\`); the next run now translates **all** docs for it to completion rather than chipping away over many re-runs. 148 tests pass, typecheck + lint clean.

## Also in this PR — the CI-noise cleanup (first commit)

- **`translate_docs`**: the bot translation commit is now \`[skip ci]\`, so it no longer re-triggers ci / bundle-analysis / embeddings / links (the ~10-run cascade on a single docs push).
- **`translate_docs` + `generate_starters`**: per-locale path exclusions collapsed to a locale-agnostic glob (\`*.??.mdx\` / \`meta.??.json\`) — adding a language needs no workflow edits.
- **`ci`**: pull requests + manual dispatch only.
- **`generate_embeddings`**: automatic runs disabled (manual dispatch only) for now; the docs site doesn't consume these embeddings.
- **`nextjs_bundle_analysis`**: unchanged — keeps its single \`main\` run for the PR size-delta baseline.