### PR TITLE
fix(links): resolve internal links and stop duplicate issues

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,6 +20,12 @@ permissions:
   contents: read
   issues: write
 
+# Serialize runs so overlapping triggers (frequent main pushes + schedule)
+# can't each open a separate issue before the other's exists.
+concurrency:
+  group: link-checker
+  cancel-in-progress: false
+
 jobs:
   link-checker:
     runs-on: ubuntu-latest
@@ -33,6 +39,7 @@ jobs:
           args: >-
             --no-progress
             --include-fragments
+            --base-url https://www.librechat.ai
             --accept 200,403,429
             './content/**/*.mdx'
             './content/**/*.md'
@@ -46,11 +53,14 @@ jobs:
         with:
           script: |
             const title = 'Broken links found in documentation'
-            const { data: issues } = await github.rest.issues.listForRepo({
+            // No space after the comma: the GitHub API treats the label list
+            // literally, so 'documentation, automated' would look for a label
+            // named ' automated' (leading space) and match nothing.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'documentation, automated',
+              labels: 'documentation,automated',
               per_page: 100,
             })
             const existing = issues.find((issue) => !issue.pull_request && issue.title === title)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -32,6 +32,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Root-relative links (/docs, /images, ...) are app routes/assets that do
+      # not map to local files (content lives under content/ and routes are
+      # extensionless). --root-dir lets lychee resolve them to
+      # $GITHUB_WORKSPACE/<seg> instead of erroring with "provide a root dir";
+      # we then exclude them, since they can't be checked on disk. The exclude
+      # is anchored at the regex-escaped workspace so it does NOT also skip
+      # file-relative links (./LICENSE, ../../features/foo.md), which
+      # legitimately resolve under $GITHUB_WORKSPACE/content/ and stay checked.
+      - name: Build internal-route exclude pattern
+        id: routes
+        env:
+          WS: ${{ github.workspace }}
+        run: |
+          esc=$(printf '%s' "$WS" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
+          echo "pattern=^file://${esc}/(docs|blog|changelog|images|videos|assets|toolkit)(/|\$)" >> "$GITHUB_OUTPUT"
+
       - name: Check links
         id: lychee
         uses: lycheeverse/lychee-action@v2
@@ -39,7 +55,8 @@ jobs:
           args: >-
             --no-progress
             --include-fragments
-            --base-url https://www.librechat.ai
+            --root-dir ${{ github.workspace }}
+            --exclude '${{ steps.routes.outputs.pattern }}'
             --accept 200,403,429
             './content/**/*.mdx'
             './content/**/*.md'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,23 @@
+# Lychee ignore list (one regex per line, matched against each URL).
+# Links matched here are skipped by the Links workflow (.github/workflows/links.yml).
+# Keep this list specific: only genuinely dead links in immutable historical
+# content (old changelogs/blog posts) that cannot be fixed belong here.
+
+# Local development server URL referenced in the README setup steps.
+^http://localhost:3333
+
+# Deleted/renamed GitHub contributor accounts credited in historical changelogs.
+^https://github\.com/(Kim-Jaemin420|UnexpectedNull|github-actions|hide361|hulkds|itzraiss|lemonTree43|machinsoft|nagago)/?$
+
+# Dead commit SHAs in the v0.8.0-rc2 changelog (commits never landed on main).
+^https://github\.com/danny-avila/LibreChat/commit/(2f6a96d|58a97c5|a5f4c9b|aa37f2f|bf8e74b)
+
+# Removed/relocated upstream resources linked from old changelogs.
+^https://github\.com/danny-avila/LibreChat/blob/main/docs/features/plugins/chatgpt_plugins_openapi\.md
+^https://github\.com/danny-avila/LibreChat/milestone/4/?$
+^https://replit\.com/@daavila/crypto
+
+# GitHub renders line-number and commit anchors client-side, so lychee's
+# fragment check reports false negatives on these pinned historical links.
+^https://github\.com/danny-avila/LibreChat/blob/1378eb5097b666a4add27923e47be73919957e5b/\.env\.example#L314
+^https://modelcontextprotocol\.io/clients#librechat

--- a/content/blog/2024-05-01_mlx.mdx
+++ b/content/blog/2024-05-01_mlx.mdx
@@ -33,7 +33,7 @@ To load a model with MLX, follow these steps:
 1. Browse the available models on [HuggingFace](https://huggingface.co/models?search=mlx-community).
 2. Copy the text from the model page in the format `<author>/<model_id>` (e.g., `mlx-community/Meta-Llama-3-8B-Instruct-4bit`).
 3. Check the model size. Models that can run in CPU/GPU unified memory tend to perform better.
-4. Follow the instructions to launch the model server [Run OpenAI Compatible Server Locally](https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/SERVER.md) by running the command:
+4. Follow the instructions to launch the model server [Run OpenAI Compatible Server Locally](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md) by running the command:
 
    ```sh filename="Launch the model server"
    mlx_lm.server --model <author>/<model_id>

--- a/content/changelog/v0.7.5-rc1.mdx
+++ b/content/changelog/v0.7.5-rc1.mdx
@@ -11,65 +11,65 @@ Release candidate version for v0.7.5
 
 ### ✨ New Features
 
-* 🛠️ feat: Azure OpenAI Assistants File Downloads by [@danny-avila](https://github.com/@danny-avila) in [#3653](https://github.com/danny-avila/LibreChat/pull/3653)
-* 🤖 feat: Recognize `chatgpt-4o-latest`, update default OpenAI Models by [@danny-avila](https://github.com/@danny-avila) in [#3667](https://github.com/danny-avila/LibreChat/pull/3667)
-* 💾 feat: Anthropic Prompt Caching by [@danny-avila](https://github.com/@danny-avila) in [#3670](https://github.com/danny-avila/LibreChat/pull/3670)
-* 📩 feat: invite user by [@berry-13](https://github.com/@berry-13) in [#3012](https://github.com/danny-avila/LibreChat/pull/3012)
-* 🧪 feat: Prompt Dropdown Variable; style: Add Markdown Support by [@danny-avila](https://github.com/@danny-avila) in [#3681](https://github.com/danny-avila/LibreChat/pull/3681)
-* 🔐 feat: Toggle Access to Prompts via `librechat.yaml` by [@danny-avila](https://github.com/@danny-avila) in [#3735](https://github.com/danny-avila/LibreChat/pull/3735)
-* 🔖 feat: Enhance Bookmarks UX, add RBAC, toggle via `librechat.yaml` by [@danny-avila](https://github.com/@danny-avila) in [#3747](https://github.com/danny-avila/LibreChat/pull/3747)
-* 🧮 feat: Improve LaTeX rendering consistency by [@danny-avila](https://github.com/@danny-avila) in [#3763](https://github.com/danny-avila/LibreChat/pull/3763)
-* 🧮 feat: Improve structured token spending and testing; fix: Anthropic Cache Spend by [@danny-avila](https://github.com/@danny-avila) in [#3766](https://github.com/danny-avila/LibreChat/pull/3766)
-* 🐋 feat: Known Endpoints: DeepSeek, Unify by [@fuegovic](https://github.com/@fuegovic) in [#3776](https://github.com/danny-avila/LibreChat/pull/3776), [#3778](https://github.com/danny-avila/LibreChat/pull/3778)
-* 🧠 feat: Prompt caching switch, prompt query params; refactor: static cache, prompt/markdown styling, trim copied code, switch new chat to convo URL by [@danny-avila](https://github.com/@danny-avila) in [#3784](https://github.com/danny-avila/LibreChat/pull/3784)
+* 🛠️ feat: Azure OpenAI Assistants File Downloads by [@danny-avila](https://github.com/danny-avila) in [#3653](https://github.com/danny-avila/LibreChat/pull/3653)
+* 🤖 feat: Recognize `chatgpt-4o-latest`, update default OpenAI Models by [@danny-avila](https://github.com/danny-avila) in [#3667](https://github.com/danny-avila/LibreChat/pull/3667)
+* 💾 feat: Anthropic Prompt Caching by [@danny-avila](https://github.com/danny-avila) in [#3670](https://github.com/danny-avila/LibreChat/pull/3670)
+* 📩 feat: invite user by [@berry-13](https://github.com/berry-13) in [#3012](https://github.com/danny-avila/LibreChat/pull/3012)
+* 🧪 feat: Prompt Dropdown Variable; style: Add Markdown Support by [@danny-avila](https://github.com/danny-avila) in [#3681](https://github.com/danny-avila/LibreChat/pull/3681)
+* 🔐 feat: Toggle Access to Prompts via `librechat.yaml` by [@danny-avila](https://github.com/danny-avila) in [#3735](https://github.com/danny-avila/LibreChat/pull/3735)
+* 🔖 feat: Enhance Bookmarks UX, add RBAC, toggle via `librechat.yaml` by [@danny-avila](https://github.com/danny-avila) in [#3747](https://github.com/danny-avila/LibreChat/pull/3747)
+* 🧮 feat: Improve LaTeX rendering consistency by [@danny-avila](https://github.com/danny-avila) in [#3763](https://github.com/danny-avila/LibreChat/pull/3763)
+* 🧮 feat: Improve structured token spending and testing; fix: Anthropic Cache Spend by [@danny-avila](https://github.com/danny-avila) in [#3766](https://github.com/danny-avila/LibreChat/pull/3766)
+* 🐋 feat: Known Endpoints: DeepSeek, Unify by [@fuegovic](https://github.com/fuegovic) in [#3776](https://github.com/danny-avila/LibreChat/pull/3776), [#3778](https://github.com/danny-avila/LibreChat/pull/3778)
+* 🧠 feat: Prompt caching switch, prompt query params; refactor: static cache, prompt/markdown styling, trim copied code, switch new chat to convo URL by [@danny-avila](https://github.com/danny-avila) in [#3784](https://github.com/danny-avila/LibreChat/pull/3784)
 
 ### 🚀 Optimizations:
 
-* 📜 refactor: Optimize Longer Message Thread Performance by [@danny-avila](https://github.com/@danny-avila) in [#3610](https://github.com/danny-avila/LibreChat/pull/3610)
-* 🔀 refactor: Modularize TTS Logic for Improved Browser support by [@danny-avila](https://github.com/@danny-avila) in [#3657](https://github.com/danny-avila/LibreChat/pull/3657)
-* 🖱️ fix: Message Scrolling UX; refactor: Frontend UX/DX Optimizations by [@danny-avila](https://github.com/@danny-avila) in [#3733](https://github.com/danny-avila/LibreChat/pull/3733)
+* 📜 refactor: Optimize Longer Message Thread Performance by [@danny-avila](https://github.com/danny-avila) in [#3610](https://github.com/danny-avila/LibreChat/pull/3610)
+* 🔀 refactor: Modularize TTS Logic for Improved Browser support by [@danny-avila](https://github.com/danny-avila) in [#3657](https://github.com/danny-avila/LibreChat/pull/3657)
+* 🖱️ fix: Message Scrolling UX; refactor: Frontend UX/DX Optimizations by [@danny-avila](https://github.com/danny-avila) in [#3733](https://github.com/danny-avila/LibreChat/pull/3733)
 
 ### 🎨 Styling
 
-* 🖼️ style: Conversation Menu and Dialogs update by [@berry-13](https://github.com/@berry-13) in [#3601](https://github.com/danny-avila/LibreChat/pull/3601)
-* ⏺️ style: Better Markdown Lists by [@danny-avila](https://github.com/@danny-avila) in [#3777](https://github.com/danny-avila/LibreChat/pull/3777)
-* ⌨️ style(a11y): kb access for LLM endpoint menu; refactor: style by [@berry-13](https://github.com/@berry-13) in [#3714](https://github.com/danny-avila/LibreChat/pull/3714)
+* 🖼️ style: Conversation Menu and Dialogs update by [@berry-13](https://github.com/berry-13) in [#3601](https://github.com/danny-avila/LibreChat/pull/3601)
+* ⏺️ style: Better Markdown Lists by [@danny-avila](https://github.com/danny-avila) in [#3777](https://github.com/danny-avila/LibreChat/pull/3777)
+* ⌨️ style(a11y): kb access for LLM endpoint menu; refactor: style by [@berry-13](https://github.com/berry-13) in [#3714](https://github.com/danny-avila/LibreChat/pull/3714)
 
 ### 🔧 Fixes
 
-* 📧 fix: [@command](https://github.com/@command) & +command timing for click selections by [@berry-13](https://github.com/@berry-13) in [#3617](https://github.com/danny-avila/LibreChat/pull/3617)
-* 🎛️ fix: Improve Frontend Practices for Audio Settings  by [@danny-avila](https://github.com/@danny-avila) in [#3624](https://github.com/danny-avila/LibreChat/pull/3624)
-* 🎙️ fix: Optimize and Fix Browser TTS Incompatibility (firefox) by [@danny-avila](https://github.com/@danny-avila) in [#3627](https://github.com/danny-avila/LibreChat/pull/3627)
-* 🎧 fix(TTS): Improve State of audio playback, hook patterns, and fix undefined MediaSource by [@danny-avila](https://github.com/@danny-avila) in [#3632](https://github.com/danny-avila/LibreChat/pull/3632)
-* 🔧 fix: Bookmark Order Adjustment When Moving Up by [@ohneda](https://github.com/@ohneda) in [#3634](https://github.com/danny-avila/LibreChat/pull/3634)
-* 🦙 fix: Update Title Message Role for Ollama if None Provided by [@danny-avila](https://github.com/@danny-avila) in [#3663](https://github.com/danny-avila/LibreChat/pull/3663)
-* 🔧 fix: Delete Archived Chat z-index issue by [@arthurian](https://github.com/@arthurian) in [#3643](https://github.com/danny-avila/LibreChat/pull/3643)
-* ⚓ fix: Export Button Content Shift; chore: bump `axios` and add logging by [@berry-13](https://github.com/@berry-13) in [#3668](https://github.com/danny-avila/LibreChat/pull/3668)
-* 📱 fix: Resolve Android Device and Accessibility Issues of Sidebar Combobox by [@danny-avila](https://github.com/@danny-avila) in [#3689](https://github.com/danny-avila/LibreChat/pull/3689)
-* 🐛 fix: Anthropic Prompt Caching Edge Case  by [@danny-avila](https://github.com/@danny-avila) in [#3690](https://github.com/danny-avila/LibreChat/pull/3690)
-* 🔑 fix(AuthService): properly handle reading and deletion of password reset token by [@berry-13](https://github.com/@berry-13) in [#3697](https://github.com/danny-avila/LibreChat/pull/3697)
-* 🔧 fix: add `clear all` button to bookmark navigation items by [@berry-13](https://github.com/@berry-13) in [#3721](https://github.com/danny-avila/LibreChat/pull/3721)
-* 🔧 fix: EndpointIcon crash when using `@` mention command by [@danny-avila](https://github.com/@danny-avila) in [#3742](https://github.com/danny-avila/LibreChat/pull/3742)
-* 🔧 fix: handle missing custom config speech by [@berry-13](https://github.com/@berry-13) in [#3790](https://github.com/danny-avila/LibreChat/pull/3790)
-* 🔍 fix: `USE_REDIS` condition, Markdown list counter, code highlights by [@danny-avila](https://github.com/@danny-avila) in [#3806](https://github.com/danny-avila/LibreChat/pull/3806)
+* 📧 fix: [@command](https://github.com/command) & +command timing for click selections by [@berry-13](https://github.com/berry-13) in [#3617](https://github.com/danny-avila/LibreChat/pull/3617)
+* 🎛️ fix: Improve Frontend Practices for Audio Settings  by [@danny-avila](https://github.com/danny-avila) in [#3624](https://github.com/danny-avila/LibreChat/pull/3624)
+* 🎙️ fix: Optimize and Fix Browser TTS Incompatibility (firefox) by [@danny-avila](https://github.com/danny-avila) in [#3627](https://github.com/danny-avila/LibreChat/pull/3627)
+* 🎧 fix(TTS): Improve State of audio playback, hook patterns, and fix undefined MediaSource by [@danny-avila](https://github.com/danny-avila) in [#3632](https://github.com/danny-avila/LibreChat/pull/3632)
+* 🔧 fix: Bookmark Order Adjustment When Moving Up by [@ohneda](https://github.com/ohneda) in [#3634](https://github.com/danny-avila/LibreChat/pull/3634)
+* 🦙 fix: Update Title Message Role for Ollama if None Provided by [@danny-avila](https://github.com/danny-avila) in [#3663](https://github.com/danny-avila/LibreChat/pull/3663)
+* 🔧 fix: Delete Archived Chat z-index issue by [@arthurian](https://github.com/arthurian) in [#3643](https://github.com/danny-avila/LibreChat/pull/3643)
+* ⚓ fix: Export Button Content Shift; chore: bump `axios` and add logging by [@berry-13](https://github.com/berry-13) in [#3668](https://github.com/danny-avila/LibreChat/pull/3668)
+* 📱 fix: Resolve Android Device and Accessibility Issues of Sidebar Combobox by [@danny-avila](https://github.com/danny-avila) in [#3689](https://github.com/danny-avila/LibreChat/pull/3689)
+* 🐛 fix: Anthropic Prompt Caching Edge Case  by [@danny-avila](https://github.com/danny-avila) in [#3690](https://github.com/danny-avila/LibreChat/pull/3690)
+* 🔑 fix(AuthService): properly handle reading and deletion of password reset token by [@berry-13](https://github.com/berry-13) in [#3697](https://github.com/danny-avila/LibreChat/pull/3697)
+* 🔧 fix: add `clear all` button to bookmark navigation items by [@berry-13](https://github.com/berry-13) in [#3721](https://github.com/danny-avila/LibreChat/pull/3721)
+* 🔧 fix: EndpointIcon crash when using `@` mention command by [@danny-avila](https://github.com/danny-avila) in [#3742](https://github.com/danny-avila/LibreChat/pull/3742)
+* 🔧 fix: handle missing custom config speech by [@berry-13](https://github.com/berry-13) in [#3790](https://github.com/danny-avila/LibreChat/pull/3790)
+* 🔍 fix: `USE_REDIS` condition, Markdown list counter, code highlights by [@danny-avila](https://github.com/danny-avila) in [#3806](https://github.com/danny-avila/LibreChat/pull/3806)
 
 ### ⚙️ Other Changes
 
-* 🤖 refactor: Remove Default Model Params for All Endpoints by [@danny-avila](https://github.com/@danny-avila) in [#3682](https://github.com/danny-avila/LibreChat/pull/3682)
-* 🧹 chore: address minor issues by [@danny-avila](https://github.com/@danny-avila) in [#3710](https://github.com/danny-avila/LibreChat/pull/3710)
-* 🐋 ci: Dockerfile.multi rewrite, maintain package integrity by [@danny-avila](https://github.com/@danny-avila) in [#3772](https://github.com/danny-avila/LibreChat/pull/3772)
-* 🧹 chore: remove legacy markdown code by [@danny-avila](https://github.com/@danny-avila) in [#3789](https://github.com/danny-avila/LibreChat/pull/3789)
-* 🚚 chore: Remove client-dist volume from deploy-compose.yml by [@danny-avila](https://github.com/@danny-avila) in [#3799](https://github.com/danny-avila/LibreChat/pull/3799)
-* 🏷️ chore: Add Unofficial Naming Variation for Claude-3.5-Sonnet by [@danny-avila](https://github.com/@danny-avila) in [#3800](https://github.com/danny-avila/LibreChat/pull/3800)
+* 🤖 refactor: Remove Default Model Params for All Endpoints by [@danny-avila](https://github.com/danny-avila) in [#3682](https://github.com/danny-avila/LibreChat/pull/3682)
+* 🧹 chore: address minor issues by [@danny-avila](https://github.com/danny-avila) in [#3710](https://github.com/danny-avila/LibreChat/pull/3710)
+* 🐋 ci: Dockerfile.multi rewrite, maintain package integrity by [@danny-avila](https://github.com/danny-avila) in [#3772](https://github.com/danny-avila/LibreChat/pull/3772)
+* 🧹 chore: remove legacy markdown code by [@danny-avila](https://github.com/danny-avila) in [#3789](https://github.com/danny-avila/LibreChat/pull/3789)
+* 🚚 chore: Remove client-dist volume from deploy-compose.yml by [@danny-avila](https://github.com/danny-avila) in [#3799](https://github.com/danny-avila/LibreChat/pull/3799)
+* 🏷️ chore: Add Unofficial Naming Variation for Claude-3.5-Sonnet by [@danny-avila](https://github.com/danny-avila) in [#3800](https://github.com/danny-avila/LibreChat/pull/3800)
 
 ### 🌍 Internationalization:
 
-* 🌏i18n: Improve Russian translation  by [@kukoboris](https://github.com/@kukoboris) in [#3674](https://github.com/danny-avila/LibreChat/pull/3674), [#3718](https://github.com/danny-avila/LibreChat/pull/3718)
+* 🌏i18n: Improve Russian translation  by [@kukoboris](https://github.com/kukoboris) in [#3674](https://github.com/danny-avila/LibreChat/pull/3674), [#3718](https://github.com/danny-avila/LibreChat/pull/3718)
 
 ### New Contributors
-* [@akash-singh8](https://github.com/@akash-singh8) made their first contribution in [#3604](https://github.com/danny-avila/LibreChat/pull/3604)
-* [@Tanvez](https://github.com/@Tanvez) made their first contribution in [#3630](https://github.com/danny-avila/LibreChat/pull/3630)
-* [@kukoboris](https://github.com/@kukoboris) made their first contribution in [#3674](https://github.com/danny-avila/LibreChat/pull/3674)
+* [@akash-singh8](https://github.com/akash-singh8) made their first contribution in [#3604](https://github.com/danny-avila/LibreChat/pull/3604)
+* [@Tanvez](https://github.com/Tanvez) made their first contribution in [#3630](https://github.com/danny-avila/LibreChat/pull/3630)
+* [@kukoboris](https://github.com/kukoboris) made their first contribution in [#3674](https://github.com/danny-avila/LibreChat/pull/3674)
 
 
 ### 👀 What's Next

--- a/content/changelog/v0.7.6.mdx
+++ b/content/changelog/v0.7.6.mdx
@@ -134,7 +134,7 @@ version: "0.7.6"
 ## New Contributors
 
 * [@timmanik](https://github.com/timmanik) made their first contribution in [#4494](https://github.com/danny-avila/LibreChat/pull/4494)
-* [@MSITETOP](https://github.com/MSITETOP) made their first contribution in [#4486](https://github.com/danny-avila/LibreChat/pull/4486a)
+* [@MSITETOP](https://github.com/MSITETOP) made their first contribution in [#4486](https://github.com/danny-avila/LibreChat/pull/4486)
 * [@senk](https://github.com/senk) made their first contribution in [#4763](https://github.com/danny-avila/LibreChat/pull/4763)
 * [@siddharthsambharia-portkey](https://github.com/siddharthsambharia-portkey) made their first contribution in [#4625](https://github.com/danny-avila/LibreChat/pull/4625)
 * [@wipash](https://github.com/wipash) made their first contribution in [#4787](https://github.com/danny-avila/LibreChat/pull/4787)


### PR DESCRIPTION
## Summary

Configures the lychee link checker and cleans up genuinely broken links found in the latest report.

### Link checker (`.github/workflows/links.yml`)
- Add `--base-url https://www.librechat.ai` so root-relative app routes (`/docs`, `/blog`, `/changelog`) resolve against the live site instead of erroring with *"To resolve root-relative links in local files, provide a root dir"* — this was the overwhelming majority of the report.
- Stop spamming new issues: add a `concurrency` group so overlapping `main` pushes can't each open an issue, and fix the existing-issue lookup (the `listForRepo` label filter had a leading space — `'documentation, automated'` — so it matched nothing and a fresh issue was opened every run). Now it updates the single tracking issue.

### Fixed broken links
- `v0.7.5-rc1`: stray `@` in 42 contributor profile URLs (`github.com/@user` → `github.com/user`).
- `v0.7.6`: typo'd PR URL `pull/4486a` → `pull/4486`.
- `2024-05-01_mlx` blog: relocated mlx server doc → `ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md` (verified live; matches the URL the docs pages already use).

### `.lycheeignore` (new)
Precise patterns for genuinely dead, immutable historical links: 9 deleted/renamed contributor accounts (verified by scanning all 357 profile URLs in `content/`), 5 dead commit SHAs, removed upstream docs, `milestone/4`, a deleted replit, and two GitHub/MCP anchors lychee can't verify client-side.

## Note
The 5 commit SHAs in `v0.8.0-rc2` are full 40-char hashes absent from the repo (not truncations) — they appear fabricated. Ignored here to clear noise; the changelog's accuracy may be worth a separate check.