### PR TITLE
fix(docs): highlight all in-view headings in clerk TOC

### DIFF
--- a/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/app/[lang]/docs/[[...slug]]/page.tsx
@@ -78,7 +78,10 @@ export default async function Page(props: PageProps) {
   return (
     <DocsPage
       toc={page.data.toc}
-      tableOfContent={{ style: 'clerk' }}
+      // single: false makes the clerk TOC track every heading currently in the
+      // viewport (the thumb spans the visible range and all in-view items
+      // highlight), instead of the default single-active-heading behavior.
+      tableOfContent={{ style: 'clerk', single: false }}
       breadcrumb={{
         enabled: true,
         includeRoot: { url: localizedDocsHref('/docs', params.lang) },


### PR DESCRIPTION
## What

The docs right-side table of contents now highlights **every heading currently in the viewport** (and the clerk thumb spans that range), instead of only ever marking a single heading active.

## Why

We already use the clerk TOC style (`tableOfContent={{ style: 'clerk' }}`), but only one heading ever highlighted. Tracing the Fumadocs 14.7.7 source:

- The clerk thumb and the item highlight both read `useActiveAnchors()` (the full list of in-view headings).
- `DocsPage` passes `single: tocOptions.single` to `AnchorProvider`, which **defaults to `single = true`**.
- With `single = true`, `useAnchorObserver` returns `activeAnchor.slice(0, 1)` — capped at one anchor, and the observer uses a narrow `-80px 0% -70%` band.

Setting `single: false` switches the observer to the wider `-20px 0% -40%` band and returns all intersecting headings, so the thumb spans the visible range and all in-view items highlight. This matches the behavior of [bun-docs](https://bun-docs.vercel.app/docs) (Fumadocs 16, where clerk runs with `single = false` effectively).

`single` is a documented public option on `tableOfContent` (`TableOfContentOptions` includes `Pick<AnchorProviderProps, 'single'>`), so this is type-safe.

## Change

One line in `app/[lang]/docs/[[...slug]]/page.tsx`:

```diff
-      tableOfContent={{ style: 'clerk' }}
+      tableOfContent={{ style: 'clerk', single: false }}
```

## Verification

Ran locally and drove the browser through a full-page scroll:

- Max simultaneously-active TOC items went from **1 → 2+** (e.g. at scroll position ~600px, both "Setup" and "Locate or Create the File" are active and the thumb spans both).
- Confirmed in **both light and dark mode** — no styling/layout regression.
- Behavioral change only; the left nav, breadcrumb, and all other layout are untouched.
