### PR TITLE
fix(i18n): persist locale across logo/search and auto-detect language

### DIFF
--- a/app/[lang]/docs/layout.tsx
+++ b/app/[lang]/docs/layout.tsx
@@ -3,7 +3,7 @@ import { DocsI18nProvider } from '@/components/DocsI18nProvider'
 import { docsSource } from '@/lib/source'
 import { getAvailableLocalesBySlug } from '@/lib/doc-locales'
 import { baseOptions } from '@/app/layout.config'
-import { i18n, localizedDocsHref } from '@/lib/i18n'
+import { i18n, localizedDocsHref, localizedHomeHref } from '@/lib/i18n'
 import { getUI } from '@/lib/ui-i18n'
 import { VersionSwitcher } from '@/components/VersionSwitcher'
 import type { ReactNode } from 'react'
@@ -26,6 +26,7 @@ export default async function Layout({
         tree={tree}
         i18n
         {...baseOptions}
+        nav={{ ...baseOptions.nav, url: localizedHomeHref(lang) }}
         links={[
           { text: t.nav.docs, url: docsHref, active: 'nested-url' },
           { text: t.nav.blog, url: '/blog' },

--- a/components/DocsI18nProvider.tsx
+++ b/components/DocsI18nProvider.tsx
@@ -3,7 +3,7 @@
 import { I18nProvider } from 'fumadocs-ui/i18n'
 import { usePathname, useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { i18n, LOCALE_NAMES } from '@/lib/i18n'
+import { i18n, LOCALE_NAMES, rememberLocale } from '@/lib/i18n'
 import { getFumadocsText } from '@/lib/ui-i18n'
 
 const allLocales = i18n.languages.map((locale) => ({
@@ -53,6 +53,8 @@ export function DocsI18nProvider({
   )
 
   const onChange = (next: string) => {
+    // Record the explicit choice so the `/` auto-detect honors it next time.
+    rememberLocale(next)
     const segs = pathname.split('/').filter(Boolean)
     if (i18n.languages.includes(segs[0])) segs.shift()
     const rest = segs.join('/')

--- a/components/HomeI18nProvider.tsx
+++ b/components/HomeI18nProvider.tsx
@@ -3,7 +3,7 @@
 import { I18nProvider } from 'fumadocs-ui/i18n'
 import { useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { i18n, LOCALE_NAMES } from '@/lib/i18n'
+import { i18n, LOCALE_NAMES, rememberLocale } from '@/lib/i18n'
 import { getFumadocsText } from '@/lib/ui-i18n'
 
 const locales = i18n.languages.map((locale) => ({
@@ -21,6 +21,8 @@ const locales = i18n.languages.map((locale) => ({
 export function HomeI18nProvider({ locale, children }: { locale: string; children: ReactNode }) {
   const router = useRouter()
   const onChange = (next: string) => {
+    // Record the explicit choice so the `/` auto-detect honors it next time.
+    rememberLocale(next)
     router.push(next === i18n.defaultLanguage ? '/' : `/${next}`)
   }
 

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -27,7 +27,7 @@ import FooterMenu from '@/components/FooterMenu'
 import { JsonLd } from '@/components/JsonLd'
 import { HomeI18nProvider } from '@/components/HomeI18nProvider'
 import { organizationSchema, websiteSchema, softwareApplicationSchema } from '@/lib/structured-data'
-import { localizedDocsHref } from '@/lib/i18n'
+import { localizedDocsHref, localizedHomeHref } from '@/lib/i18n'
 import { getUI, fmt, type UIStrings } from '@/lib/ui-i18n'
 
 type HomeStrings = UIStrings['home']
@@ -513,7 +513,7 @@ export async function HomePageContent({ lang }: { lang: string }) {
         {...baseOptions}
         i18n
         links={navLinks}
-        nav={{ ...baseOptions.nav, transparentMode: 'top' }}
+        nav={{ ...baseOptions.nav, url: localizedHomeHref(lang), transparentMode: 'top' }}
       >
         <JsonLd data={[organizationSchema, websiteSchema, softwareApplicationSchema]} />
         <main id="main-content" tabIndex={-1} className="min-h-screen">

--- a/components/provider.tsx
+++ b/components/provider.tsx
@@ -1,15 +1,41 @@
 'use client'
 import { RootProvider } from 'fumadocs-ui/provider'
+import { I18nProvider } from 'fumadocs-ui/i18n'
+import { usePathname } from 'next/navigation'
 import type { ReactNode } from 'react'
+import { i18n, LOCALE_NAMES } from '@/lib/i18n'
+import { getFumadocsText } from '@/lib/ui-i18n'
 
+const locales = i18n.languages.map((locale) => ({
+  locale,
+  name: LOCALE_NAMES[locale] ?? locale,
+}))
+
+/**
+ * Site-wide Fumadocs provider. The search dialog is mounted by RootProvider's
+ * SearchProvider at the root, above every route's own I18nProvider, so without
+ * a locale here its chrome — most visibly the search input placeholder — always
+ * renders in English even on localized pages. Wrap RootProvider in an
+ * I18nProvider keyed to the URL locale so the dialog follows the page language.
+ * The wrapper sits *outside* RootProvider because the dialog is a descendant of
+ * SearchProvider, not of `children`. Per-page concerns (the language switcher's
+ * onChange and the available-locales list) are still owned by the nested
+ * Docs/Home I18nProviders, which override this one inside their subtrees.
+ */
 export function Provider({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const first = pathname.split('/').filter(Boolean)[0] ?? ''
+  const locale = i18n.languages.includes(first) ? first : i18n.defaultLanguage
+
   return (
-    <RootProvider
-      search={{
-        enabled: true,
-      }}
-    >
-      {children}
-    </RootProvider>
+    <I18nProvider locale={locale} locales={locales} translations={getFumadocsText(locale)}>
+      <RootProvider
+        search={{
+          enabled: true,
+        }}
+      >
+        {children}
+      </RootProvider>
+    </I18nProvider>
   )
 }

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -33,6 +33,32 @@ export function localizedDocsHref(href: string, lang?: string): string {
   return `/${lang}${href}`
 }
 
+/**
+ * The landing-page URL for a locale. The default language lives at `/` (no
+ * prefix, matching `hideLocale: 'default-locale'`); every other locale at
+ * `/<locale>`. Used for the navbar/logo link so clicking it from a localized
+ * surface keeps the reader in their language instead of dropping them onto the
+ * prefix-less English home.
+ */
+export function localizedHomeHref(lang?: string): string {
+  if (!lang || lang === i18n.defaultLanguage) return '/'
+  return `/${lang}`
+}
+
+/** Cookie that records an explicit language choice (read by the proxy's auto-detect). */
+export const LOCALE_COOKIE = 'NEXT_LOCALE'
+
+/**
+ * Remember an explicit language choice in a cookie so the browser-language
+ * auto-detection on `/` doesn't override the reader the next time they land on
+ * the home page. Client-only; a no-op when called during SSR.
+ */
+export function rememberLocale(locale: string): void {
+  if (typeof document === 'undefined') return
+  // 1 year, lax: a first-party preference that should survive top-level navigations.
+  document.cookie = `${LOCALE_COOKIE}=${locale}; path=/; max-age=31536000; samesite=lax`
+}
+
 /** Human-readable names shown in the language switcher. */
 export const LOCALE_NAMES: Record<string, string> = {
   en: 'English',

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,12 +1,38 @@
 import { NextRequest, NextResponse, type NextFetchEvent } from 'next/server'
 import { createI18nMiddleware } from 'fumadocs-core/i18n'
-import { i18n } from '@/lib/i18n'
+import { i18n, LOCALE_COOKIE } from '@/lib/i18n'
 
 const i18nMiddleware = createI18nMiddleware(i18n)
 
 function isMarkdownPreferred(request: NextRequest): boolean {
   const accept = request.headers.get('accept') ?? ''
   return accept.includes('text/markdown')
+}
+
+/**
+ * The reader's preferred site language: an explicit choice (the LOCALE_COOKIE
+ * set by the language switcher) wins; otherwise the best `Accept-Language`
+ * match among the locales we build; falling back to the default language.
+ */
+function preferredLocale(request: NextRequest): string {
+  const cookie = request.cookies.get(LOCALE_COOKIE)?.value
+  if (cookie && i18n.languages.includes(cookie)) return cookie
+
+  const header = request.headers.get('accept-language')
+  if (!header) return i18n.defaultLanguage
+
+  const ranked = header
+    .split(',')
+    .map((part) => {
+      const [tag, q] = part.trim().split(';q=')
+      return { base: tag.split('-')[0].toLowerCase(), q: q ? Number(q) : 1 }
+    })
+    .sort((a, b) => b.q - a.q)
+
+  for (const { base } of ranked) {
+    if (i18n.languages.includes(base)) return base
+  }
+  return i18n.defaultLanguage
 }
 
 export default function proxy(request: NextRequest, event: NextFetchEvent) {
@@ -24,10 +50,28 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(new URL(`/llms.mdx/docs${rest}`, request.nextUrl))
   }
 
+  // Browser-language auto-detection, scoped to the prefix-less home page. A
+  // reader whose browser prefers a translated locale is forwarded to its
+  // landing page (`/<locale>`); English readers and explicit English choosers
+  // stay on `/`. Deliberately limited to `/`: the content routes (/docs, /blog,
+  // …) are shared-CDN-cached, and an Accept-Language redirect there would be
+  // cached and served to every reader regardless of their language. `no-store`
+  // + `Vary` keep this redirect itself out of any shared cache.
+  if (pathname === '/') {
+    const locale = preferredLocale(request)
+    if (locale === i18n.defaultLanguage) return NextResponse.next()
+    const url = request.nextUrl.clone()
+    url.pathname = `/${locale}`
+    const response = NextResponse.redirect(url, 307)
+    response.headers.set('Cache-Control', 'private, no-store')
+    response.headers.set('Vary', 'Cookie, Accept-Language')
+    return response
+  }
+
   // Locale detection + default-locale rewriting for the docs.
   return i18nMiddleware(request, event)
 }
 
 export const config = {
-  matcher: ['/docs/:path*', '/(zh|es|fr|de|ja)/docs/:path*'],
+  matcher: ['/', '/docs/:path*', '/(zh|es|fr|de|ja)/docs/:path*'],
 }


### PR DESCRIPTION
## Summary

Fixes three ways the docs site dropped readers out of their language, and adds browser-language auto-detection.

- **Logo dropped localized readers onto English.** The navbar/sidebar logo links to `nav.url ?? '/'`, and `baseOptions.nav` had no `url`, so clicking it from `/de/docs/...` went to the English home. Added a `localizedHomeHref(lang)` helper and set `nav.url` in the docs and home layouts so the logo links to `/<locale>`.
- **Search dialog placeholder/chrome was always English.** The dialog is mounted by `RootProvider`'s `SearchProvider` at the root, above every route's own `I18nProvider`, so it read English defaults (note: `fumadocs-ui@14.7.7`'s `RootProvider` has no `i18n` prop — newer-version docs are misleading here). Wrapped `RootProvider` from the outside in an `I18nProvider` keyed to the URL locale; the dialog now follows the page language.
- **Browser-language auto-detection.** Added detection in `proxy.ts`, scoped to `/` only. Readers whose `Accept-Language` prefers a translated locale are forwarded to `/<locale>`. An explicit choice — the `NEXT_LOCALE` cookie set by the language switchers — overrides detection.

### Cache safety
Auto-detect is intentionally **not** applied to `/docs`, `/blog`, etc. Those are shared-CDN-cached, and an `Accept-Language` redirect there would be cached and served to every reader (Cloudflare ignores `Vary`). The redirect on `/` carries `Cache-Control: private, no-store` and `Vary: Cookie, Accept-Language`.

### Out of scope
Legal pages (ToS / Privacy / Cookie) are intentionally left English-only.

## Test plan
- `pnpm typecheck` — passes
- `pnpm test` — 155/155 pass
- `eslint` (0 warnings) + `prettier --check` — clean
- curl on `/`: `de`→`/de`, `fr-FR`→`/fr`, cookie `es`→`/es`; English / unsupported (`pt`) / cookie-`en`-over-German-header all stay on `/`, with `no-store` + `Vary` on each redirect
- Rendered DOM: logo `href="/de"` on `/de/docs/*` and `/de`; `href="/"` on English
- Browser: search dialog placeholder is "Suche" on `/de/*`, "Search" on English

## Follow-up (not in this PR)
The search toggle's `aria-label="Search"` is hardcoded English in the fumadocs patch even on localized pages — worth localizing for screen-reader parity.