### PR TITLE
📝 docs: Document Bundled Admin Panel and Surface It in Features

### DIFF
--- a/components/FeaturesHub.tsx
+++ b/components/FeaturesHub.tsx
@@ -20,6 +20,7 @@ import {
   RefreshCw,
   Shield,
   KeyRound,
+  LayoutDashboard,
   ShieldCheck,
   ArrowRight,
   ChevronRight,
@@ -93,6 +94,7 @@ const categories: {
     layout: 'list',
     items: [
       { icon: Shield, key: 'authentication', href: '/docs/features/authentication' },
+      { icon: LayoutDashboard, key: 'adminPanel', href: '/docs/features/admin_panel' },
       { icon: KeyRound, key: 'passwordReset', href: '/docs/features/password_reset' },
       { icon: ShieldCheck, key: 'moderation', href: '/docs/features/mod_system' },
     ],

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -271,6 +271,18 @@ To configure LibreChat for local use or custom domain deployment, set the follow
       'External admin panel base URL used for admin OAuth/SSO redirects when the admin panel is hosted separately. Do not include a trailing slash.',
       'ADMIN_PANEL_URL=https://admin.example.com/admin',
     ],
+    [
+      'ADMIN_PANEL_SESSION_SECRET',
+      'string',
+      'Session encryption key for the bundled admin panel (min 32 characters). The docker-compose and deploy-compose admin-panel services read it as their SESSION_SECRET. Generate with `openssl rand -hex 32`.',
+      'ADMIN_PANEL_SESSION_SECRET=your-32-char-random-string',
+    ],
+    [
+      'ADMIN_PANEL_PORT',
+      'number',
+      'Host port for the bundled admin panel in the default docker-compose. In deploy-compose the panel is served at http://admin.localhost via nginx instead.',
+      'ADMIN_PANEL_PORT=3000',
+    ],
   ]}
 />
 

--- a/content/docs/configuration/librechat_yaml/index.mdx
+++ b/content/docs/configuration/librechat_yaml/index.mdx
@@ -16,6 +16,12 @@ For Docker installs, editing `librechat.yaml` is not enough. The file must exist
 
 </Callout>
 
+<Callout type="info" title="Prefer a UI? Use the Admin Panel">
+
+The [**LibreChat Admin Panel**](/docs/features/admin_panel) manages this same configuration from a browser -- including per-role and per-group overrides that take effect at login without restarting LibreChat. It ships with the official Docker Compose stacks. Use `librechat.yaml` for file-driven or bootstrap setup, and the admin panel for ongoing management.
+
+</Callout>
+
 ## Setup
 
 <Steps>

--- a/content/docs/features/admin_panel.mdx
+++ b/content/docs/features/admin_panel.mdx
@@ -63,9 +63,40 @@ The admin API surface exposed by LibreChat is:
 - Network access from the admin-panel container/host to the LibreChat API
 - An admin account on LibreChat: either the first-registered user (auto-admin), a user with `role: 'ADMIN'` set in Mongo, or a principal that has been granted the `access:admin` capability
 
-### Run with Docker (recommended)
+### Bundled with LibreChat (recommended)
 
-Using the published image from GHCR:
+If you run LibreChat with its official [`docker-compose.yml`](https://github.com/danny-avila/LibreChat/blob/main/docker-compose.yml) or [`deploy-compose.yml`](https://github.com/danny-avila/LibreChat/blob/main/deploy-compose.yml), the admin panel ships as a service and starts automatically alongside LibreChat -- no separate deployment needed.
+
+| Compose file                   | Admin panel URL          | How it is served                                                  |
+| ------------------------------ | ------------------------ | ----------------------------------------------------------------- |
+| `docker-compose.yml` (default) | `http://localhost:3000`  | Published on a host port (`ADMIN_PANEL_PORT`, default `3000`)     |
+| `deploy-compose.yml`           | `http://admin.localhost` | Routed through the bundled nginx reverse proxy on a subdomain     |
+
+Set the panel's session secret in LibreChat's `.env`; the compose files pass it through as the panel's `SESSION_SECRET`:
+
+```bash filename=".env"
+# Min 32 characters. Generate with: openssl rand -hex 32
+ADMIN_PANEL_SESSION_SECRET=replace-with-a-32-char-random-string
+
+# Optional: host port for the default docker-compose
+# ADMIN_PANEL_PORT=3000
+
+# Optional: set true when the panel is served over HTTPS
+# ADMIN_PANEL_SESSION_COOKIE_SECURE=false
+```
+
+The compose files wire the rest automatically: `API_SERVER_URL` points at the `api` service, `VITE_API_BASE_URL` follows `DOMAIN_CLIENT` for browser-facing OAuth redirects, and `ADMIN_PANEL_URL` is set so LibreChat returns admins to the panel after SSO. To opt out, remove the `admin-panel` service or gate it behind a Compose [`profiles`](https://docs.docker.com/compose/how-tos/profiles/) entry.
+
+<Callout type="info" title="admin.localhost on a real domain">
+  Modern browsers resolve `*.localhost` (including `admin.localhost`) to `127.0.0.1`, so the
+  deploy-compose URL works with no hosts-file change. For a real domain, point a DNS record at the
+  host, update the `admin.localhost` `server_name` in `client/nginx.conf`, and set `ADMIN_PANEL_URL`
+  to match.
+</Callout>
+
+### Standalone (separate deployment)
+
+To host the admin panel on its own -- pointed at a LibreChat instance running elsewhere -- use the published image from GHCR:
 
 ```bash
 # 1. Create an env file

--- a/lib/ui-i18n.ts
+++ b/lib/ui-i18n.ts
@@ -258,6 +258,10 @@ const en = {
             title: 'Authentication',
             description: 'Multi-user auth with OAuth2, SAML, LDAP, and more',
           },
+          adminPanel: {
+            title: 'Admin Panel',
+            description: 'Browser UI for users, roles, and config overrides',
+          },
           passwordReset: {
             title: 'Password Reset',
             description: 'Email-based password recovery',

--- a/lib/ui-translations/de.ts
+++ b/lib/ui-translations/de.ts
@@ -254,6 +254,11 @@ export const de: UIStrings = {
             title: 'Authentifizierung',
             description: 'Mehrbenutzer-Authentifizierung mit OAuth2, SAML, LDAP und mehr',
           },
+          adminPanel: {
+            title: 'Admin-Panel',
+            description:
+              'Browser-Oberfläche für Benutzer, Rollen und Konfigurationsüberschreibungen',
+          },
           passwordReset: {
             title: 'Passwort zurücksetzen',
             description: 'E-Mail-basierte Passwortwiederherstellung',

--- a/lib/ui-translations/es.ts
+++ b/lib/ui-translations/es.ts
@@ -255,6 +255,10 @@ export const es: UIStrings = {
             title: 'Autenticación',
             description: 'Autenticación multiusuario con OAuth2, SAML, LDAP y más',
           },
+          adminPanel: {
+            title: 'Panel de administración',
+            description: 'Interfaz web para usuarios, roles y anulaciones de configuración',
+          },
           passwordReset: {
             title: 'Restablecimiento de contraseña',
             description: 'Recuperación de contraseña por correo electrónico',

--- a/lib/ui-translations/fr.ts
+++ b/lib/ui-translations/fr.ts
@@ -253,6 +253,11 @@ export const fr: UIStrings = {
             description:
               'Authentification multi-utilisateurs avec OAuth2, SAML, LDAP et plus encore',
           },
+          adminPanel: {
+            title: 'Panneau d’administration',
+            description:
+              'Interface web pour les utilisateurs, les rôles et les remplacements de configuration',
+          },
           passwordReset: {
             title: 'Réinitialisation du mot de passe',
             description: 'Récupération du mot de passe par e-mail',

--- a/lib/ui-translations/ja.ts
+++ b/lib/ui-translations/ja.ts
@@ -245,6 +245,10 @@ export const ja: UIStrings = {
             title: '認証',
             description: 'OAuth2、SAML、LDAP などによるマルチユーザー認証',
           },
+          adminPanel: {
+            title: '管理パネル',
+            description: 'ユーザー、ロール、設定オーバーライドを管理するブラウザ UI',
+          },
           passwordReset: {
             title: 'パスワードのリセット',
             description: 'メールによるパスワード復旧',

--- a/lib/ui-translations/zh.ts
+++ b/lib/ui-translations/zh.ts
@@ -225,6 +225,10 @@ export const zh: UIStrings = {
             title: '身份认证',
             description: '支持 OAuth2、SAML、LDAP 等的多用户认证',
           },
+          adminPanel: {
+            title: '管理面板',
+            description: '用于管理用户、角色和配置覆盖的网页界面',
+          },
           passwordReset: {
             title: '密码重置',
             description: '基于邮件的密码找回',


### PR DESCRIPTION
## Summary

I documented the admin panel now that it ships bundled in LibreChat's official Docker Compose stacks (see [danny-avila/LibreChat#13876](https://github.com/danny-avila/LibreChat/pull/13876)), and surfaced it on the Features overview so it is discoverable rather than only reachable through the sidebar.

- Added the **Admin Panel** to the Features hub under the Security category (`components/FeaturesHub.tsx`), with a `LayoutDashboard` icon linking to `/docs/features/admin_panel`.
- Added the `adminPanel` `featuresHub.categories.security.items` entry to the English dictionary (`lib/ui-i18n.ts`) and to all five locale dictionaries (`de`, `es`, `fr`, `ja`, `zh`) so the typed `UIStrings` contract stays satisfied across locales.
- Reworked the admin panel page (`content/docs/features/admin_panel.mdx`): added a **Bundled with LibreChat (recommended)** section documenting the `docker-compose.yml` (`http://localhost:3000`) and `deploy-compose.yml` (`http://admin.localhost`) deployments, the pass-through env vars, and the opt-out path; relabeled the previous Docker section to **Standalone (separate deployment)**.
- Pointed the `librechat.yaml` landing page (`content/docs/configuration/librechat_yaml/index.mdx`) at the admin panel as the UI for managing the same configuration plus per-role/group overrides.
- Documented the new `ADMIN_PANEL_SESSION_SECRET` and `ADMIN_PANEL_PORT` variables in the `.env` reference (`content/docs/configuration/dotenv.mdx`), alongside the existing `ADMIN_PANEL_URL`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Ran `prettier` across the changed files; reformatted the longer German and French descriptions to match repo style, all others unchanged.
- Verified `featuresHub.categories.security.items` key parity across all six dictionaries (`authentication`, `adminPanel`, `passwordReset`, `moderation`) so the `UIStrings = typeof en` constraint holds for every locale.
- `tsc --noEmit` reports only pre-existing environment errors (missing `vitest`/`gray-matter`/fumadocs internals, ungenerated `.source`); none reference the edited files, and there is no "property 'adminPanel' is missing" mismatch.
- Recommended follow-up before merge: `pnpm install && pnpm run build` in a fully provisioned checkout to render the MDX and the Features hub.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
