### PR TITLE
📝 docs: Point Code Interpreter Docs at Open-Source code-interpreter Service

### DIFF
--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -53,7 +53,7 @@ When enabled, the Code Interpreter capability allows your agent to:
 - Run code without local setup, configuration, or sandbox deployment
 - Handle file uploads and downloads seamlessly
 - [More info about the Code Interpreter API](/docs/features/code_interpreter)
-  - **Requires an API Subscription from [code.librechat.ai](https://code.librechat.ai/pricing)**
+  - **Powered by the open-source [code-interpreter](https://github.com/ClickHouse/code-interpreter) service (self-hosted)**
 
 ### File Search
 

--- a/content/docs/features/code_interpreter.mdx
+++ b/content/docs/features/code_interpreter.mdx
@@ -14,14 +14,15 @@ LibreChat's Code Interpreter API provides a secure and hassle-free way to execut
   aspectRatio="16/9"
 />
 
-## Subscription 
-**Access to this feature requires an [API subscription, get started here](https://code.librechat.ai/pricing).**
+<Callout type="info" title="Open source">
+  LibreChat's Code Interpreter is powered by [**ClickHouse/code-interpreter**](https://github.com/ClickHouse/code-interpreter), an open-source (Apache 2.0) sandboxed code-execution service. Self-host it and point LibreChat at your own instance.
+</Callout>
 
 ## Getting Started
 
-1. Visit [code.librechat.ai](https://code.librechat.ai/pricing) to get your API key
-2. Integrate the API into your application or use it through LibreChat
-3. Start executing code and generating files securely
+1. Deploy the [code-interpreter](https://github.com/ClickHouse/code-interpreter) service (Docker Compose or Helm, see the repository's README)
+2. Point LibreChat at it with the `LIBRECHAT_CODE_BASEURL` and `LIBRECHAT_CODE_API_KEY` environment variables
+3. Start executing code and generating files securely through LibreChat's Agents or the "Run Code" button
 
 ## Key Features
 
@@ -40,9 +41,9 @@ Execute code in multiple programming languages:
 ### Security & Convenience
 
 - Secure sandboxed execution environment
-- No local setup required
-- No server deployment needed
-- No configuration management
+- Strong isolation modes (NsJail or microVM via libkrun)
+- No local setup required for end users
+- Session-based, isolated file storage
 
 ## Using the API
 
@@ -65,12 +66,12 @@ The API has first-class support in LibreChat through two main methods:
 
 The Code Interpreter API can be integrated into any application using a simple API key authentication:
 
-1. Get your API key from [code.librechat.ai](https://code.librechat.ai/pricing)
+1. Deploy your own [code-interpreter](https://github.com/ClickHouse/code-interpreter) instance and create an API key
 2. Include the API key in your requests using the `x-api-key` header
 
-### Enterprise
+### Self-hosted base URL
 
-The enterprise plan requires use of the `LIBRECHAT_CODE_BASEURL` environment variable to correspond with the self-hosted instance of the API, along with any generated API keys from the dashboard, used the same way as mentioned above.
+Set the `LIBRECHAT_CODE_BASEURL` environment variable to point LibreChat at your self-hosted [code-interpreter](https://github.com/ClickHouse/code-interpreter) instance, along with an API key generated on that deployment, used the same way as above.
 
 ## Core Functionality
 
@@ -93,20 +94,7 @@ The enterprise plan requires use of the `LIBRECHAT_CODE_BASEURL` environment var
 ### Limitations
 - Code cannot access the network
 - Only 10 files can be generated per run
-- Execution limits vary by plan:
-  - **Hobby**: 
-    - 256 MB RAM per execution
-    - 25 MB per file upload
-    - 750 requests per month
-  - **Enthusiast**: 
-    - 512 MB RAM per execution
-    - 50 MB per file upload
-    - 3,000 requests per month
-  - **Pro**: 
-    - 512 MB RAM per execution
-    - 150 MB per file upload
-    - 7,000 requests per month
-- The [Enterprise Plan](https://code.librechat.ai/pricing) provides custom limits and features
+- Resource limits (RAM per execution, file upload size, and request quotas) depend on how you provision and configure your deployment
 
 ## Use Cases
 
@@ -116,31 +104,18 @@ The enterprise plan requires use of the `LIBRECHAT_CODE_BASEURL` environment var
 - **Development Tools**: Build interactive coding environments
 - **Objective Logic**: Verify code logic and correctness, improving AI models
 
-## Why a Paid API?
+## Open Source & Self-Hosting
 
-While LibreChat remains free and open source under the MIT license, the Code Interpreter API is offered as a paid service for several key reasons:
+The Code Interpreter service is open source under the Apache 2.0 license at [ClickHouse/code-interpreter](https://github.com/ClickHouse/code-interpreter). Keeping code execution as a separate service keeps the core LibreChat application lightweight: you only deploy the sandbox infrastructure when you need it, and you can scale it independently of the chat app.
 
-1. **Project Sustainability**: Subscribing to an API plan provides direct support to the project's development, even more effectively than [GitHub Sponsors](https://github.com/sponsors/danny-avila). Your subscription helps ensure LibreChat's continued growth and improvement.
-
-2. **Technical Considerations**: Including code execution capabilities in the core project would add significant complexity and hardware requirements that not all users need. The API service eliminates these concerns while maintaining a lightweight core application.
-
-3. **Managed Service Benefits**:
-   - No complex configuration
-   - Immediate availability
-   - Regular updates and maintenance
-   - Professional support
-   - Secure, sandboxed environment
-
-4. **Intellectual Property Protection**: The Code Interpreter's architecture represents significant innovation in secure, scalable sandbox technology. While similar solutions exist, they often lack the comprehensive security measures and scalability features that make this implementation unique. Keeping this component as a closed-source API helps protect these innovations and ensures the service maintains its high security and performance standards.
-
-Even if you only use code execution occasionally, subscribing helps support LibreChat's development while enhancing your experience with professional-grade features. It's a win-win that keeps the core project free while offering optional advanced capabilities for those who need them.
+The service runs as a set of independently scalable components (an API gateway, sandboxed workers, and a file server) and supports strong isolation modes (NsJail or a microVM via libkrun) so you can run untrusted code safely. See the repository's README for Docker Compose and Helm deployment instructions.
 
 ---
 
 ## Conclusion
 
-The Code Interpreter API provides a secure, convenient way to execute code and manage files without the hassle of setting up and maintaining execution environments. Whether you're using it through LibreChat's Agents or integrating it directly into your applications, it offers a robust solution for code execution needs.
+The Code Interpreter API provides a secure, convenient way to execute code and manage files in an isolated sandbox. Whether you're using it through LibreChat's Agents or integrating it directly into your applications, it offers a robust solution for code execution needs.
 
-For detailed technical specifications and API reference, please visit our [API Documentation](https://code.librechat.ai/docs).
+For detailed technical specifications, deployment guides, and the API reference, see the [code-interpreter repository](https://github.com/ClickHouse/code-interpreter).
 
 #LibreChat #CodeExecution #API #Development


### PR DESCRIPTION
## Summary

I reframed the Code Interpreter docs around the open-source service that powers it ([ClickHouse/code-interpreter](https://github.com/ClickHouse/code-interpreter)) and removed the `code.librechat.ai` hosted-service references, since the implementation is now open source (Apache 2.0) and self-hostable.

- Replaced the **Subscription** section with an "Open source" callout pointing to `ClickHouse/code-interpreter`.
- Rewrote **Getting Started** to deploy the service (Docker Compose / Helm) and wire LibreChat to it via `LIBRECHAT_CODE_BASEURL` + `LIBRECHAT_CODE_API_KEY`.
- Pointed **Direct API Integration** and the renamed **Self-hosted base URL** section (was "Enterprise") at a self-hosted instance instead of the hosted pricing page.
- Replaced the **Why a Paid API?** section (which claimed the service was closed-source) with an **Open Source & Self-Hosting** section describing the components and isolation modes (NsJail / microVM via libkrun).
- Dropped the `code.librechat.ai` plan tiers from **Limitations** in favor of a deployment-dependent note, and reconciled the **Security & Convenience** and **Conclusion** copy so the page no longer implies a zero-setup managed service.
- Updated the Code Interpreter mention in `agents.mdx` to reference the open-source service rather than a `code.librechat.ai` subscription.

## Change Type

- [x] Documentation update

## Testing

- Ran `prettier` across both changed files.
- Confirmed no `code.librechat.ai` references remain in the English docs sources.
- Localized pages (`code_interpreter.{de,es,fr,ja,zh}.mdx`, `agents.{de,es,fr}.mdx`) and the `.i18n-cache` are pipeline outputs; they regenerate from these English sources via `npm run translate`, so I left them untouched.
- The dated `content/blog/2025-02-20_2025_roadmap.mdx` reference was left as a historical record.

## Notes

- This is a content/messaging change; please sanity-check the framing before merge, especially whether a hosted option should still be mentioned (I dropped all `code.librechat.ai` mentions per the request).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
