### PR TITLE
feat(docs): make layout full width

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -9,6 +9,12 @@
    tokens through the preset imports above. */
 @config '../tailwind.config.js';
 
+/* Let the docs layout span the full viewport instead of fumadocs v16's
+   default 1600px cap. Unlayered so it wins over the preset's `:root` default. */
+:root {
+  --fd-layout-width: 100vw;
+}
+
 #nd-nav {
   background: hsl(var(--background) / 0.6) !important;
   -webkit-backdrop-filter: blur(16px) saturate(180%);


### PR DESCRIPTION
## Summary

Makes the documentation pages span the full screen width instead of being capped at Fumadocs v16's default `1600px`, which left large empty margins on wide displays.

## Change

Override `--fd-layout-width` in `app/global.css`:

```css
:root {
  --fd-layout-width: 100vw;
}
```

This is the approach recommended by Fumadocs' own v16 docs. It is placed unlayered (outside `@layer base`) so it reliably wins over the preset's `:root` default.

## Scope

- **Docs pages**: now full-width (sidebar + prose + TOC stretch edge-to-edge).
- **Home / Blog / Changelog**: unaffected. Those use Fumadocs' home layout, which sets its own inline `--fd-layout-width: 1400px`, so they keep their centered, constrained look.

## Verification

Tested locally on the dev server at a 1920px viewport:

- Docs content pages render edge-to-edge in both light and dark mode.
- No horizontal scrollbar. The docs layout uses `overflow-x-clip` and computes its side offset as `max(calc(50vw - var(--fd-layout-width)/2), 0px)`, which resolves to `0` at `100vw`, so the usual "`100vw` includes the scrollbar width" overflow does not occur.
- Homepage confirmed still centered and constrained.
