### PR TITLE
fix(links): resolve #658 broken links and scan only the English source

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -48,6 +48,21 @@ jobs:
           esc=$(printf '%s' "$WS" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
           echo "pattern=^file://${esc}/(docs|blog|changelog|images|videos|assets|toolkit)(/|\$)" >> "$GITHUB_OUTPUT"
 
+      # scripts/translate.ts generates content/docs/**/*.<xx>.mdx from the English
+      # source. Each translated copy's in-page anchors still point at the English
+      # heading slugs, so a translated heading text breaks them (e.g. #legacy-setup),
+      # and every external link in a copy just duplicates one already checked in the
+      # English source. Checking the 800+ copies therefore adds only noise, not
+      # coverage, so scan the English source of truth only. The `[a-z][a-z]` locale
+      # match means a new language needs no change here (TARGET_LOCALES in
+      # lib/i18n/config.ts stays the single source of truth), matching translate_docs.yml.
+      - name: Collect English docs (skip generated translations)
+        id: inputs
+        run: |
+          files=$(find content -type f \( -name '*.mdx' -o -name '*.md' \) \
+            | grep -vE '\.[a-z][a-z]\.(mdx|md)$' | sort | tr '\n' ' ')
+          echo "files=$files README.md" >> "$GITHUB_OUTPUT"
+
       - name: Check links
         id: lychee
         uses: lycheeverse/lychee-action@v2
@@ -58,9 +73,7 @@ jobs:
             --root-dir ${{ github.workspace }}
             --exclude '${{ steps.routes.outputs.pattern }}'
             --accept 200,403,429
-            './content/**/*.mdx'
-            './content/**/*.md'
-            './README.md'
+            ${{ steps.inputs.outputs.files }}
           fail: false
 
       - name: Find existing broken links issue

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,8 +3,14 @@
 # Keep this list specific: only genuinely dead links in immutable historical
 # content (old changelogs/blog posts) that cannot be fixed belong here.
 
-# Local development server URL referenced in the README setup steps.
-^http://localhost:3333
+# Local-dev / placeholder endpoints used as examples in setup docs (the README
+# dev server, .env defaults, Docker service hostnames, OTEL collectors). None of
+# these are reachable from CI, and they are illustrative values, not real links.
+^https?://localhost([:/]|$)
+^http://0\.0\.0\.0
+^http://host\.docker\.internal
+^http://otel-collector
+^https?://my-custom-base-url\.com
 
 # Deleted/renamed GitHub contributor accounts credited in historical changelogs.
 ^https://github\.com/(Kim-Jaemin420|UnexpectedNull|github-actions|hide361|hulkds|itzraiss|lemonTree43|machinsoft|nagago)/?$
@@ -21,3 +27,33 @@
 # fragment check reports false negatives on these pinned historical links.
 ^https://github\.com/danny-avila/LibreChat/blob/1378eb5097b666a4add27923e47be73919957e5b/\.env\.example#L314
 ^https://modelcontextprotocol\.io/clients#librechat
+
+# Auth0 "Audience" example identifier, not a navigable web page (returns 404).
+^https://api\.librechat\.ai
+
+# Third-party docs that render their in-page anchors client-side, so lychee's
+# fragment check reports false negatives even though the pages and sections exist.
+^https://docs\.aws\.amazon\.com/bedrock/latest/userguide/model-ids\.html#model-ids-arns
+^https://www\.databricks\.com/try-databricks#account
+^https://docs\.portkey\.ai/docs/product/ai-gateway/configs#configs
+^https://docs\.truefoundry\.com/gateway/authentication#personal-access-token-pat
+^https://developers\.cloudflare\.com/ai-gateway/providers/workersai/#openai-compatible-endpoints
+^https://docs\.firecrawl\.dev/introduction#api-key
+^https://tavily\.com/#api
+^https://cloud\.google\.com/vertex-ai/generative-ai/docs/partner-models/use-claude#regions
+^https://console\.cloud\.google\.com/projectselector/iam-admin/serviceaccounts/create
+
+# Login-gated consoles that bounce anonymous CI requests through a redirect
+# chain past lychee's max-redirects limit. The destinations are correct.
+^https://console\.mistral\.ai
+^https://console\.cloud\.google\.com/vertex-ai/model-garden
+
+# Third-party sites that are intermittently down or block CI traffic (522/timeout),
+# unrelated to our docs being correct.
+^https://app\.neurochain\.ai
+^https://bfl\.ml
+
+# Dead PR references in immutable historical changelogs. These numbers 404 as both
+# pulls and issues (the early repo history predates them); the credited authors are
+# already listed above as deleted accounts.
+^https://github\.com/danny-avila/LibreChat/pull/(694|857|876|888|898|972|1126|1202|1259|1549|1651|1736|1867|2046|2228|3947)(/|$)

--- a/content/docs/configuration/docker_override.mdx
+++ b/content/docs/configuration/docker_override.mdx
@@ -100,6 +100,6 @@ docker compose -f deploy-compose.yml -f docker-compose.override.yml up
 
 For more detail, see the official Docker documentation:
 
-- [Understanding multiple Compose files](https://docs.docker.com/compose/multiple-compose-files/extends/#understanding-multiple-compose-files)
-- [Merge Compose files](https://docs.docker.com/compose/multiple-compose-files/merge/#merge-compose-files)
+- [Understanding multiple Compose files](https://docs.docker.com/compose/how-tos/multiple-compose-files/extends/)
+- [Merge Compose files](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/)
 - [Specifying multiple Compose files](https://docs.docker.com/compose/reference/#specifying-multiple-compose-files)

--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -18,8 +18,8 @@ For more info see:
   - **[Docker Override](/docs/configuration/docker_override)**
 
 - The official docker documentation:
-  - **[docker docs - understanding-multiple-compose-files](https://docs.docker.com/compose/multiple-compose-files/extends/#understanding-multiple-compose-files)**
-  - **[docker docs - merge-compose-files](https://docs.docker.com/compose/multiple-compose-files/merge/#merge-compose-files)**
+  - **[docker docs - understanding-multiple-compose-files](https://docs.docker.com/compose/how-tos/multiple-compose-files/extends/)**
+  - **[docker docs - merge-compose-files](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/)**
   - **[docker docs - specifying-multiple-compose-files](https://docs.docker.com/compose/reference/#specifying-multiple-compose-files)**
 
 - You can also view an example of an override file for LibreChat in your LibreChat folder and on GitHub:
@@ -688,7 +688,7 @@ For detailed configuration and customization options, see: [Web Search Configura
     [
       'SERPER_API_KEY',
       'string',
-      'API key for Serper search provider. Get your key from https://serper.dev/api-key',
+      'API key for Serper search provider. Get your key from https://serper.dev/api-keys',
       '# SERPER_API_KEY=',
     ],
     [
@@ -1372,7 +1372,7 @@ This section contains the configuration for:
 - [Automated Moderation](#moderation)
 - [Balance/Token Usage](#balance)
 - [Registration and Social Logins](#registration-and-login)
-- [Email Password Reset](#email-password-reset)
+- [Email Password Reset](#password-reset)
 
 ### Moderation
 
@@ -3045,7 +3045,7 @@ For detailed configuration and examples, see: **[Redis Configuration Guide](/doc
     [
       'REDIS_URI',
       'string',
-      'Redis connection URI. For single instance: redis://host:port. For cluster: comma-separated URIs.',
+      'Redis connection URI. For single instance: `redis://host:port`. For cluster: comma-separated URIs.',
       'REDIS_URI=redis://127.0.0.1:6379',
     ],
     [

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/azure.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/azure.mdx
@@ -76,7 +76,7 @@ Each level of configuration is detailed in its respective section:
 
 2. **Configure Azure OpenAI Settings**: Follow the structure outlined below to populate your Azure OpenAI settings, including API keys, instance names, model groups, and other configurations.
 
-3. **Remove Legacy Settings**: If you are using any of the [legacy configurations](#legacy-setup), remove them. The LibreChat server will also detect these and remind you.
+3. **Remove Legacy Settings**: If you are using any of the legacy configurations, remove them. The LibreChat server will also detect these and remind you.
 
 4. **Save Your Changes**: Save the `librechat.yaml` file.
 

--- a/content/docs/configuration/librechat_yaml/object_structure/azure_openai.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/azure_openai.mdx
@@ -187,7 +187,7 @@ additionalHeaders:
 **Key:**
 <OptionTable
   options={[
-    ['serverless', 'Boolean', 'Indicates the use of a serverless inference endpoint for Azure OpenAI chat completions. When set to `true`, specifies that the group is configured to use serverless inference endpoints as an Azure "Models as a Service" model.', 'More info [here](./azure_openai.md#serverless-inference-endpoints)'],
+    ['serverless', 'Boolean', 'Indicates the use of a serverless inference endpoint for Azure OpenAI chat completions. When set to `true`, specifies that the group is configured to use serverless inference endpoints as an Azure "Models as a Service" model.', 'More info [here](../ai_endpoints/azure.mdx#serverless-inference-endpoints)'],
   ]}
 />
 
@@ -220,7 +220,7 @@ addParams:
 **Key:**
 <OptionTable
   options={[
-    ['dropParams', 'Array/List of Strings', 'Removes [default parameters](#default-parameters) from requests. Excludes specified [default parameters](#default-parameters).', 'For a list of default parameters sent with every request, see the ["Default Parameters"](#default-parameters) Section below.'],
+    ['dropParams', 'Array/List of Strings', 'Removes default parameters from requests. Excludes specified default parameters.', 'Default parameters are the standard request parameters LibreChat sends to the Azure OpenAI API.'],
   ]}
 />
 

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -249,7 +249,7 @@ see: [CloudFront Object Structure](/docs/configuration/librechat_yaml/object_str
   - Affects both `gptPlugins` and `assistants` endpoints
   - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
     - Use the `pluginKey` value
-  - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
+  - Also, any listed under the ".well-known" directory `api/app/clients/tools/.well-known`
     - Use the `name_for_model` value
 
 ## includedTools
@@ -270,7 +270,7 @@ see: [CloudFront Object Structure](/docs/configuration/librechat_yaml/object_str
   - Affects both `gptPlugins` and `assistants` endpoints
   - You can find the names of the tools to filter in [`api/app/clients/tools/manifest.json`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/manifest.json)
     - Use the `pluginKey` value
-  - Also, any listed under the ".well-known" directory [`api/app/clients/tools/.well-known`](https://github.com/danny-avila/LibreChat/blob/main/api/app/clients/tools/.well-known)
+  - Also, any listed under the ".well-known" directory `api/app/clients/tools/.well-known`
     - Use the `name_for_model` value
 
 ## secureImageLinks

--- a/content/docs/configuration/mongodb/mongodb_auth.mdx
+++ b/content/docs/configuration/mongodb/mongodb_auth.mdx
@@ -213,7 +213,7 @@ admin> show users
 ]
 ```
 
-:warning: **Important:** if you are using `mongo-express` to [manage your database (guide here)](../../features/manage_your_database.md), you need the additional permissions for the `mongo-express` service to run correctly:
+:warning: **Important:** if you are using `mongo-express` to manage your database, you need the additional permissions for the `mongo-express` service to run correctly:
 
 ```bash filename="Grant Roles to Admin User"
 db.grantRolesToUser("adminUser", ["clusterAdmin", "readAnyDatabase"])

--- a/content/docs/configuration/pre_configured_ai/assistants.mdx
+++ b/content/docs/configuration/pre_configured_ai/assistants.mdx
@@ -34,7 +34,7 @@ ASSISTANTS_BASE_URL=http://your-alt-baseURL:3080/
 ## Strict function calling
 With librechat you can add add the 'x-strict': true flag at operation-level in the openapi spec for actions.
 This will automatically generate function calls with 'strict' mode enabled.
-Note that strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported for details.
+Note that strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs for details.
 
 For example:
 ```json filename="mathapi.json"

--- a/content/docs/configuration/tools/openweather.mdx
+++ b/content/docs/configuration/tools/openweather.mdx
@@ -98,7 +98,7 @@ For issues with the tool:
 - You may open an issue at https://github.com/jmaddington/LibreChat/issues or 
 - Check the [LibreChat Issues](https://github.com/danny-avila/LibreChat/issues)
 - Review OpenWeather's [API documentation](https://openweathermap.org/api/one-call-3)
-- Contact OpenWeather [support](https://openweathermap.org/support) for API-specific issues
+- Contact OpenWeather [support](https://openweathermap.org/support-centre) for API-specific issues
 
 ## Notes
 

--- a/content/docs/configuration/tools/wolfram.mdx
+++ b/content/docs/configuration/tools/wolfram.mdx
@@ -12,7 +12,7 @@ The Wolfram|Alpha tool gives agents access to computation, math, curated knowled
 - Visit: **[products.wolframalpha.com/api/](https://products.wolframalpha.com/api/)** to create your account
 
 ### Get your AppID
-- Visit the **[Developer Portal](https://developer.wolframalpha.com/portal/myapps/)** and click on `Get an AppID`
+- Visit the **[Developer Portal](https://developer.wolframalpha.com/access)** and click on `Get an AppID`
 - Select `LLM API` as the `API` and copy the key
 
 ### Configure LibreChat

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -246,7 +246,7 @@ With the Actions capability, you can dynamically create tools from [OpenAPI spec
   - [More info](/docs/configuration/librechat_yaml/object_structure/actions#alloweddomains)
 - Note that you can add add the 'x-strict': true flag at operation-level in the OpenAPI spec for actions.
   If using an OpenAI model supporting it, this will automatically generate function calls with 'strict' mode enabled.
-  - Strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported for details.
+  - Strict mode supports only a partial subset of json. Read https://platform.openai.com/docs/guides/structured-outputs for details.
 
 ### Agent Chain
 

--- a/content/docs/features/image_gen.mdx
+++ b/content/docs/features/image_gen.mdx
@@ -291,7 +291,7 @@ See the [Flux pricing page](https://docs.bfl.ml/pricing/) for image generation c
 
 ## Model Context Protocol (MCP)
 
-Image outputs are supported from MCP servers. For example, the [Puppeteer MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer) can generate screenshots of web pages, which output the image in the expected format and are treated the same as LibreChat's built-in image tools.
+Image outputs are supported from MCP servers. For example, the [Puppeteer MCP Server](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer) can generate screenshots of web pages, which output the image in the expected format and are treated the same as LibreChat's built-in image tools.
 
 <Callout type="warning" title="MCP image support is still emerging">
 - The examples below assume LibreChat runs outside of Docker, directly using Node.js. The Model Context Protocol is a relatively new framework, and many developers are still learning how to serve their systems with uv/node for scalable distribution.


### PR DESCRIPTION
Resolves the 402 errors reported by the weekly link checker in #658.

## Root-cause fix (232 / 402 errors)
`links.yml` now scans **only the English source of truth**. The 800+ `content/docs/**/*.{de,es,fr,ja,zh}.mdx` files are generated by `scripts/translate.ts`; their in-page anchors point at English heading slugs (so a translated heading text breaks them, e.g. `#legacy-setup`) and every external link in a copy just duplicates one already checked in English. Checking the copies added noise, not coverage. The `[a-z][a-z]` locale match means a new language needs no change here, matching `translate_docs.yml`.

## Genuine internal-link bugs fixed in the English source
| File | Fix |
|------|-----|
| `dotenv.mdx` | `#email-password-reset` → `#password-reset`; backticked the `redis://host:port` example so it isn't parsed as a link |
| `azure_openai.mdx` | serverless link → real section `../ai_endpoints/azure.mdx#serverless-inference-endpoints`; unlinked dangling `#default-parameters` |
| `azure.mdx` | unlinked dangling `#legacy-setup` |
| `mongodb_auth.mdx` | unlinked the deleted `manage_your_database.md` guide |
| `config.mdx` | unlinked the removed `api/app/clients/tools/.well-known` directory (plugins deprecated) |

## Moved external URLs updated
Docker compose `/how-tos/` pages (`dotenv.mdx`, `docker_override.mdx`), OpenAI structured-outputs, Wolfram `/access`, OpenWeather `/support-centre`, Serper `/api-keys`, and the archived Puppeteer MCP server (`servers-archived`).

## Added to `.lycheeignore` (false positives + immutable dead links)
- Example/placeholder hosts: `localhost`, `0.0.0.0`, `host.docker.internal`, `otel-collector`, `my-custom-base-url.com`
- `api.librechat.ai` (Auth0 *Audience* identifier, not a web page)
- JS-rendered external fragments lychee can't verify (AWS Bedrock, Databricks, Portkey, TrueFoundry, Cloudflare, Firecrawl, Tavily, Google Cloud)
- Login-gated console redirects (`console.mistral.ai`, GCP model-garden)
- Intermittently down third-party sites (`app.neurochain.ai`, `bfl.ml`)
- 16 changelog PR URLs that 404 as **both** pulls and issues (verified individually; credited authors are already in the deleted-accounts list)

## Verification
- Edited internal anchors/files resolve on disk; `#password-reset` and `#serverless-inference-endpoints` headings exist
- `links.yml` is valid YAML; all `.lycheeignore` patterns compile
- The `[a-z][a-z]` filter never matches an English file (298 English files still scanned)
- lychee isn't installed locally, so the authoritative check is this PR's Links workflow run

Closes #658.