### PR TITLE
docs: fix scraperProvider heading typo in web_search config

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.de.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.de.mdx
@@ -170,7 +170,7 @@ webSearch:
   ]}
 />
 
-### scraperProviderider
+### scraperProvider
 
 <OptionTable
   options={[

--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.es.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.es.mdx
@@ -170,7 +170,7 @@ webSearch:
   ]}
 />
 
-### scraperProviderider
+### scraperProvider
 
 <OptionTable
   options={[

--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.fr.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.fr.mdx
@@ -170,7 +170,7 @@ webSearch:
   ]}
 />
 
-### scraperProviderider
+### scraperProvider
 
 <OptionTable
   options={[

--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.ja.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.ja.mdx
@@ -170,7 +170,7 @@ webSearch:
   ]}
 />
 
-### scraperProviderider
+### scraperProvider
 
 <OptionTable
   options={[

--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
@@ -170,7 +170,7 @@ webSearch:
   ]}
 />
 
-### scraperProviderider
+### scraperProvider
 
 <OptionTable
   options={[


### PR DESCRIPTION
The `scraperProvider` config heading was misspelled as `scraperProviderider`, breaking the section anchor. Fixed in the English doc and the de/es/fr/ja translations.