### PR TITLE
fix(i18n): stabilize docs translation output

### DIFF
--- a/lib/i18n/run.test.ts
+++ b/lib/i18n/run.test.ts
@@ -185,6 +185,92 @@ describe('runTranslation', () => {
     expect(out).not.toContain('{input}nAI')
   })
 
+  it('translates OptionTable descriptions that start with angle-bracket prose', async () => {
+    const source =
+      '<Optional>: The attribute in the SAML assertion containing the user email. (default: email)'
+    const translated =
+      '<Optional>: Das Attribut in der SAML-Assertion, das die Benutzer-E-Mail enthält. (default: email)'
+    const optional: TranslateModel = {
+      generate: async ({ prompt }) => {
+        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
+        return text === source ? translated : text
+      },
+    }
+    await writeFile(
+      join(content, 'index.mdx'),
+      `---\ntitle: Hello\n---\n\n<OptionTable options={[['SAML_EMAIL_CLAIM', 'string', '${source}', 'SAML_EMAIL_CLAIM=']]} />\n`,
+    )
+    const stats = await runTranslation({
+      contentDir: content,
+      cacheDir: cache,
+      locales: ['de'],
+      model: optional,
+    })
+    expect(stats.skipped).toEqual([])
+    const out = await readFile(join(content, 'index.de.mdx'), 'utf8')
+    expect(out).toContain(translated)
+
+    const tm = await TM.load('de', cache)
+    expect(tm.get(hashText(source))).toBe(translated)
+  })
+
+  it('retries a block that changes protected tokens before accepting it', async () => {
+    let attempts = 0
+    const fixesOnRetry: TranslateModel = {
+      generate: async ({ prompt }) => {
+        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
+        if (text === 'Use `PORT` now.') {
+          attempts++
+          return attempts === 1 ? 'Nutze `ANSCHLUSS` jetzt.' : 'Nutze `PORT` jetzt.'
+        }
+        return text
+      },
+    }
+    await writeFile(
+      join(content, 'index.mdx'),
+      `---\ntitle: Hello\n---\n\n<OptionTable options={[['k', 'string', 'Use \`PORT\` now.', 'x']]} />\n`,
+    )
+    const stats = await runTranslation({
+      contentDir: content,
+      cacheDir: cache,
+      locales: ['de'],
+      model: fixesOnRetry,
+    })
+    expect(stats.skipped).toEqual([])
+    expect(attempts).toBe(2)
+    const out = await readFile(join(content, 'index.de.mdx'), 'utf8')
+    expect(out).toContain('Nutze `PORT` jetzt.')
+  })
+
+  it('falls back to the source block instead of skipping a whole file', async () => {
+    const corruptsOneBlock: TranslateModel = {
+      generate: async ({ prompt }) => {
+        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
+        if (text === 'Good text.') return 'Guter Text.'
+        if (text === 'Use `PORT` now.') return 'Nutze `ANSCHLUSS` jetzt.'
+        return text
+      },
+    }
+    await writeFile(
+      join(content, 'index.mdx'),
+      `---\ntitle: Hello\n---\n\nGood text.\n\n<OptionTable options={[['k', 'string', 'Use \`PORT\` now.', 'x']]} />\n`,
+    )
+    const stats = await runTranslation({
+      contentDir: content,
+      cacheDir: cache,
+      locales: ['de'],
+      model: corruptsOneBlock,
+    })
+    expect(stats.skipped).toEqual([])
+    const out = await readFile(join(content, 'index.de.mdx'), 'utf8')
+    expect(out).toContain('Guter Text.')
+    expect(out).toContain('Use `PORT` now.')
+
+    const tm = await TM.load('de', cache)
+    expect(tm.get(hashText('Good text.'))).toBe('Guter Text.')
+    expect(tm.get(hashText('Use `PORT` now.'))).toBeUndefined()
+  })
+
   it('skips a file on empty model output without aborting the run or caching it', async () => {
     const emptyStub: TranslateModel = {
       generate: async ({ prompt }) => {
@@ -302,14 +388,38 @@ describe('runTranslation', () => {
     expect(tm.get(hashText('A paragraph.'))).toBeUndefined() // failed → not cached
   })
 
-  it('evicts cached blocks when the file later fails validation, so it is not permanently skipped', async () => {
+  it('does not prune existing cache entries when a file is still transiently incomplete', async () => {
+    await runTranslation({ contentDir: content, cacheDir: cache, locales: ['de'], model: stub })
+    let tm = await TM.load('de', cache)
+    expect(tm.get(hashText('A paragraph.'))).toBe('A paragraph.')
+
+    const failsBeforeParagraph: TranslateModel = {
+      generate: async ({ prompt }) => {
+        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
+        if (text.startsWith('# Hello')) {
+          throw Object.assign(new Error('429 Too Many Requests'), { statusCode: 429 })
+        }
+        return text
+      },
+    }
+    const stats = await runTranslation({
+      contentDir: content,
+      cacheDir: cache,
+      locales: ['de'],
+      model: failsBeforeParagraph,
+      force: true,
+    })
+    expect(stats.skipped.some((s) => s.includes('index.mdx'))).toBe(true)
+
+    tm = await TM.load('de', cache)
+    expect(tm.get(hashText('A paragraph.'))).toBe('A paragraph.')
+  })
+
+  it('keeps an invalid block out of the cache across transient retries', async () => {
     // The partial-cache hazard under load: a structurally bad block (a heading
-    // that gains a stray code fence) is staged, then a LATER block in the same
-    // file is rate-limited — so the transient path caches the bad block before the
-    // file ever validates. On the next round the bad block is read back from cache,
-    // the file fails validation and is skipped. The bad block must be evicted, or
-    // every future run reads it back, fails validation again, and the page stays
-    // skipped forever until a forced retranslation or a manual cache delete.
+    // that gains a stray code fence) is followed by a rate-limited block. The bad
+    // heading must not be cached by the transient path; otherwise the next round
+    // would read it back and the page could never converge.
     let paragraphThrown = false
     const model: TranslateModel = {
       generate: async ({ prompt }) => {
@@ -331,16 +441,21 @@ describe('runTranslation', () => {
       locales: ['de'],
       model,
     })
-    expect(stats.skipped.some((s) => s.includes('index.mdx'))).toBe(true)
+    expect(stats.skipped).toEqual([])
+    const out = await readFile(join(content, 'index.de.mdx'), 'utf8')
+    expect(out).toContain('# Head [#head]')
+    expect(out).not.toContain('```')
     const tm = await TM.load('de', cache)
-    expect(tm.get(hashText('# Head'))).toBeUndefined() // bad block evicted, not frozen
+    expect(tm.get(hashText('# Head'))).toBeUndefined()
   })
 
-  it('removes a stale locale file when a re-translation fails validation', async () => {
+  it('updates a stale locale file when a re-translated block falls back to source', async () => {
     await runTranslation({ contentDir: content, cacheDir: cache, locales: ['de'], model: stub })
     expect(await readdir(content)).toContain('index.de.mdx')
 
-    // Source changes and the new translation fails validation (breaking stub).
+    // Source changes and the model keeps corrupting the heading with a code fence.
+    // The runner should keep the valid source heading for that block and still
+    // update the locale file rather than deleting it.
     const breaking: TranslateModel = {
       generate: async ({ prompt }) => {
         const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
@@ -354,29 +469,12 @@ describe('runTranslation', () => {
       locales: ['de'],
       model: breaking,
     })
-    expect(stats.skipped.length).toBeGreaterThan(0)
-    expect(await readdir(content)).not.toContain('index.de.mdx')
-  })
-
-  it("does not persist a file's translations when it fails validation", async () => {
-    // Stub that injects a stray code fence into heading translations, breaking the
-    // output fence count so validateTranslation rejects the file.
-    const breaking: TranslateModel = {
-      generate: async ({ prompt }) => {
-        const text = prompt.split(/Translate the following[^\n]*:\n/).pop() ?? ''
-        return text.startsWith('#') ? `${text}\n\n\`\`\`\nx\n\`\`\`` : text
-      },
-    }
-    await writeFile(join(content, 'index.mdx'), `---\ntitle: Hello\n---\n\n# Head\n`)
-    const stats = await runTranslation({
-      contentDir: content,
-      cacheDir: cache,
-      locales: ['de'],
-      model: breaking,
-    })
-    expect(stats.skipped.length).toBeGreaterThan(0)
-    expect(await readdir(content)).not.toContain('index.de.mdx')
+    expect(stats.skipped).toEqual([])
+    expect(await readdir(content)).toContain('index.de.mdx')
+    const out = await readFile(join(content, 'index.de.mdx'), 'utf8')
+    expect(out).toContain('# Changed Heading [#changed-heading]')
+    expect(out).not.toContain('```')
     const tm = await TM.load('de', cache)
-    expect(tm.get(hashText('# Head'))).toBeUndefined()
+    expect(tm.get(hashText('# Changed Heading'))).toBeUndefined()
   })
 })

--- a/lib/i18n/run.ts
+++ b/lib/i18n/run.ts
@@ -16,7 +16,7 @@ import {
   escapeJsString,
   type Segment,
 } from './segment'
-import { validateTranslation } from './validate'
+import { validatePreservedText, validateTranslation } from './validate'
 import { translate, type TranslateModel } from './engine'
 import { TM } from './tm'
 import { TARGET_LOCALES } from './config'
@@ -46,6 +46,11 @@ const FILE_CONCURRENCY = Number(process.env.TRANSLATE_CONCURRENCY) || 6
 // so a burst of provider/rate-limit errors converges instead of requiring the
 // whole workflow to be re-run by hand.
 const MAX_FILE_ROUNDS = Number(process.env.TRANSLATE_FILE_ROUNDS) || 3
+// A single corrupted block should not doom a long page after hundreds of other
+// blocks translated correctly. Retry preservation failures locally; if the model
+// still changes protected tokens, keep that one block in English and let the page
+// publish with the remaining translated content.
+const BLOCK_VALIDATION_ATTEMPTS = Number(process.env.TRANSLATE_BLOCK_VALIDATION_ATTEMPTS) || 3
 const LOCALE_ALT = TARGET_LOCALES.join('|')
 const LOCALE_RE = new RegExp(`\\.(${LOCALE_ALT})\\.mdx$`)
 const META_LOCALE_RE = new RegExp(`^meta\\.(${LOCALE_ALT})\\.json$`)
@@ -110,8 +115,12 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
       used.add(hash)
       const cached = opts.force ? undefined : tm.get(hash)
       if (cached !== undefined) {
-        stats.cachedBlocks++
-        return cached
+        const check = validatePreservedText(text, cached, kind)
+        if (check.ok) {
+          stats.cachedBlocks++
+          return cached
+        }
+        tm.delete(hash)
       }
       const pending = staged.get(hash)
       if (pending !== undefined) {
@@ -122,15 +131,26 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
         stats.translatedBlocks++
         return text
       }
-      const result = await translate({ text, locale, kind, context, model: opts.model })
-      // A model that returns nothing (refusal / reasoning-only finish) must not be
-      // cached or written as an empty block — treat it as a failure for this file.
-      if (result.trim() === '' && text.trim() !== '') {
-        throw new Error(`empty model output for a ${kind} block`)
+      let lastValidationError: string | undefined
+      for (let attempt = 0; attempt < BLOCK_VALIDATION_ATTEMPTS; attempt++) {
+        const result = await translate({ text, locale, kind, context, model: opts.model })
+        // A model that returns nothing (refusal / reasoning-only finish) must not be
+        // cached or written as an empty block — treat it as a failure for this file.
+        if (result.trim() === '' && text.trim() !== '') {
+          throw new Error(`empty model output for a ${kind} block`)
+        }
+        const check = validatePreservedText(text, result, kind)
+        if (check.ok) {
+          staged.set(hash, result)
+          stats.translatedBlocks++
+          return result
+        }
+        lastValidationError = check.error
       }
-      staged.set(hash, result)
-      stats.translatedBlocks++
-      return result
+      progress.note(
+        `${locale}: keeping source for a ${kind} block after ${BLOCK_VALIDATION_ATTEMPTS} preservation failure(s): ${lastValidationError ?? 'unknown validation error'}`,
+      )
+      return text
     }
 
     // Records the last transient error per file so it can be reported only if the
@@ -289,6 +309,7 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
     // Count each file's terminal completion exactly once for the progress UI: a
     // file may resolve 'transient' in one round and 'ok'/'skip' in a later one.
     const counted = new Set<string>()
+    let canPruneCache = true
     let pending = filtered
     for (let round = 0; ; round++) {
       const results = await Promise.all(
@@ -301,6 +322,7 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
         }
       const transient = results.filter(([, r]) => r === 'transient').map(([rel]) => rel)
       if (transient.length === 0 || round >= MAX_FILE_ROUNDS) {
+        if (transient.length > 0) canPruneCache = false
         for (const rel of transient) {
           if (!counted.has(rel)) {
             counted.add(rel)
@@ -332,7 +354,11 @@ export async function runTranslation(opts: RunOptions): Promise<RunStats> {
           : `${dir}${name.replace(`.${locale}.mdx`, '.mdx')}`
         if (!sourceSet.has(baseRel)) await unlink(join(opts.contentDir, f))
       }
-      tm.prune()
+      if (canPruneCache) {
+        tm.prune()
+      } else {
+        progress.note(`${locale}: skipped cache pruning because the locale run was incomplete`)
+      }
     }
 
     if (!opts.dryRun) await tm.save()

--- a/lib/i18n/segment.ts
+++ b/lib/i18n/segment.ts
@@ -406,6 +406,16 @@ const MD_LINK_URL_RE = /\]\(\s*([^)\s]+)/g
 // the collector) so reworded prose around an unchanged URL is not read as a change.
 const BARE_URL_RE = /\bhttps?:\/\/[^\s<>()[\]"'`]+/gi
 
+/** Collect URL-like tokens from raw text without parsing it as Markdown/MDX. */
+export function collectRawUrls(body: string): string[] {
+  const out: string[] = []
+  const withoutFences = stripFencedBlocks(body)
+  for (const m of withoutFences.matchAll(ATTR_URL_RE)) out.push(m[2])
+  for (const m of withoutFences.matchAll(MD_LINK_URL_RE)) out.push(m[1])
+  for (const m of withoutFences.matchAll(BARE_URL_RE)) out.push(m[0].replace(/[.,;:!?]+$/, ''))
+  return out
+}
+
 /**
  * Collect every destination URL anywhere in the body, in document order: Markdown
  * link/image/definition targets (AST) plus src/href attributes and raw Markdown
@@ -428,10 +438,7 @@ export function collectUrls(body: string): string[] {
     if (node.children) for (const child of node.children) visit(child as MdNode & { url?: string })
   }
   visit(tree)
-  const withoutFences = stripFencedBlocks(body)
-  for (const m of withoutFences.matchAll(ATTR_URL_RE)) out.push(m[2])
-  for (const m of withoutFences.matchAll(MD_LINK_URL_RE)) out.push(m[1])
-  for (const m of withoutFences.matchAll(BARE_URL_RE)) out.push(m[0].replace(/[.,;:!?]+$/, ''))
+  out.push(...collectRawUrls(body))
   return out
 }
 

--- a/lib/i18n/validate.test.ts
+++ b/lib/i18n/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateTranslation } from './validate'
+import { validatePreservedText, validateTranslation } from './validate'
 
 const SOURCE = `---
 title: Hello
@@ -56,6 +56,22 @@ describe('validateTranslation', () => {
     const result = validateTranslation(src, bad)
     expect(result.ok).toBe(false)
     expect(result.error).toMatch(/inline code/i)
+  })
+
+  it('validates inline fragments without parsing angle-bracket prose as JSX', () => {
+    const source =
+      '<Optional>: The attribute in the SAML assertion containing the user email. (default: email)'
+    const output =
+      '<Optional>: Das Attribut in der SAML-Assertion, das die Benutzer-E-Mail enthält. (default: email)'
+    expect(validatePreservedText(source, output, 'inline').ok).toBe(true)
+  })
+
+  it('still protects inline tokens when validating raw inline fragments', () => {
+    const source = '<Optional>: Set `SAML_EMAIL_CLAIM` from https://example.com/docs.'
+    const bad = '<Optional>: Set `SAML_EMAIL` from https://example.com/anleitung.'
+    const result = validatePreservedText(source, bad, 'inline')
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/inline code|link target/i)
   })
 
   it('rejects a rewritten link target, accepts translated link text', () => {

--- a/lib/i18n/validate.ts
+++ b/lib/i18n/validate.ts
@@ -3,6 +3,7 @@ import {
   countCodeFences,
   collectInlineCode,
   collectUrls,
+  collectRawUrls,
   collectPlaceholders,
   collectBlockStructure,
 } from './segment'
@@ -64,8 +65,88 @@ function preservedTokens(text: string): Record<string, string[]> {
   }
 }
 
+function preservedInlineTokens(text: string): Record<string, string[]> {
+  return {
+    'inline code': collectInlineCode(text).sort(),
+    'link target': collectRawUrls(text),
+    'template placeholder': collectPlaceholders(text),
+    'table structure': [],
+    'blockquote marker': [],
+    'heading level': [],
+  }
+}
+
 function sameMultiset(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((value, i) => value === b[i])
+}
+
+function validatePreservedParts(
+  sourceFenceText: string,
+  outputFenceText: string,
+  sourceTokenText = sourceFenceText,
+  outputTokenText = outputFenceText,
+): { ok: boolean; error?: string } {
+  let srcFences: number
+  let outFences: number
+  let srcTokens: Record<string, string[]>
+  let outTokens: Record<string, string[]>
+  try {
+    srcFences = countCodeFences(sourceFenceText)
+    outFences = countCodeFences(outputFenceText)
+    srcTokens = preservedTokens(sourceTokenText)
+    outTokens = preservedTokens(outputTokenText)
+  } catch (e) {
+    return { ok: false, error: `output is not parseable MDX: ${(e as Error).message}` }
+  }
+
+  if (srcFences !== outFences) {
+    return { ok: false, error: `code block count changed: ${srcFences} -> ${outFences}` }
+  }
+
+  for (const label of Object.keys(srcTokens)) {
+    if (!sameMultiset(srcTokens[label], outTokens[label])) {
+      return {
+        ok: false,
+        error: `${label} changed: [${srcTokens[label].join(', ')}] -> [${outTokens[label].join(', ')}]`,
+      }
+    }
+  }
+
+  return { ok: true }
+}
+
+function validatePreservedInlineParts(
+  source: string,
+  output: string,
+): { ok: boolean; error?: string } {
+  const srcTokens = preservedInlineTokens(source)
+  const outTokens = preservedInlineTokens(output)
+
+  for (const label of Object.keys(srcTokens)) {
+    if (!sameMultiset(srcTokens[label], outTokens[label])) {
+      return {
+        ok: false,
+        error: `${label} changed: [${srcTokens[label].join(', ')}] -> [${outTokens[label].join(', ')}]`,
+      }
+    }
+  }
+
+  return { ok: true }
+}
+
+/**
+ * Validate a single translated markdown/MDX fragment before it is cached. Long
+ * docs pages are assembled from many independently translated blocks; catching a
+ * bad block here lets the runner retry or fall back to the source block instead
+ * of rejecting the entire file after all other blocks have succeeded.
+ */
+export function validatePreservedText(
+  source: string,
+  output: string,
+  kind: 'block' | 'inline' = 'block',
+): { ok: boolean; error?: string } {
+  if (kind === 'inline') return validatePreservedInlineParts(source, output)
+  return validatePreservedParts(source, output)
 }
 
 export function validateTranslation(
@@ -91,31 +172,5 @@ export function validateTranslation(
     return { ok: false, error: `frontmatter keys changed: [${srcKeys}] -> [${outKeys}]` }
   }
 
-  let srcFences: number
-  let outFences: number
-  let srcTokens: Record<string, string[]>
-  let outTokens: Record<string, string[]>
-  try {
-    srcFences = countCodeFences(src.content)
-    outFences = countCodeFences(out.content)
-    srcTokens = preservedTokens(corpus(src))
-    outTokens = preservedTokens(corpus(out))
-  } catch (e) {
-    return { ok: false, error: `output is not parseable MDX: ${(e as Error).message}` }
-  }
-
-  if (srcFences !== outFences) {
-    return { ok: false, error: `code block count changed: ${srcFences} -> ${outFences}` }
-  }
-
-  for (const label of Object.keys(srcTokens)) {
-    if (!sameMultiset(srcTokens[label], outTokens[label])) {
-      return {
-        ok: false,
-        error: `${label} changed: [${srcTokens[label].join(', ')}] -> [${outTokens[label].join(', ')}]`,
-      }
-    }
-  }
-
-  return { ok: true }
+  return validatePreservedParts(src.content, out.content, corpus(src), corpus(out))
 }


### PR DESCRIPTION
## Summary
- Validate translated blocks before using cached output or writing generated docs.
- Retry blocks that change protected Markdown/MDX tokens, then keep the source block if retries still fail.
- Skip translation cache pruning when a locale run ends with transient failures.

## Root cause
Long docs could lose translation progress when one block failed validation or a run stopped before visiting every block. Missing cache entries caused later runs to retranslate stable text, which produced repeated wording changes in generated locale files.

## Validation
- `pnpm exec vitest run`
- `pnpm run typecheck`
- `pnpm exec eslint lib/i18n/run.ts lib/i18n/validate.ts lib/i18n/run.test.ts`
- `pnpm exec prettier --check lib/i18n/run.ts lib/i18n/validate.ts lib/i18n/run.test.ts`