### PR TITLE
fix(docs): broken docs links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -52,6 +52,7 @@
 # unrelated to our docs being correct.
 ^https://app\.neurochain\.ai
 ^https://bfl\.ml
+^https://trendshift\.io/api/badge/repositories/4685$
 
 # Dead PR references in immutable historical changelogs. These numbers 404 as both
 # pulls and issues (the early repo history predates them); the credited authors are

--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -535,7 +535,7 @@ MCP servers can be configured to use different transport mechanisms:
 - More performant alternative to the legacy HTTP+SSE transport
 - Supports proper multi-user server configurations
 
-**For production environments**, only MCP servers with ["Streamable HTTP" transports](https://modelcontextprotocol.io/specification/draft/basic/transports#streamable-http) are recommended. Unlike SSE which maintains long-running connections, Streamable HTTP offers stateless options that are better suited for scalable, multi-user deployments.
+**For production environments**, only MCP servers with ["Streamable HTTP" transports](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http) are recommended. Unlike SSE which maintains long-running connections, Streamable HTTP offers stateless options that are better suited for scalable, multi-user deployments.
 
 LibreChat is at the forefront of implementing flexible, scalable MCP server integrations to support diverse usage scenarios and help you build the AI workflows of tomorrow.
 

--- a/content/docs/features/ocr.mdx
+++ b/content/docs/features/ocr.mdx
@@ -251,7 +251,7 @@ LibreChat plans to expand OCR capabilities in future releases:
 - Enhanced document processing options
 - More granular control over OCR settings
 - Mistral plans to make their OCR API available through their cloud partners, such as GCP and AWS, and enterprise self-hosting for organizations with stringent data privacy requirements ([source](https://mistral.ai/fr/news/mistral-ocr))
-- LibreChat currently does not include the parsed image content from the OCR process in its responses, even though services like [Mistral's OCR API may provide](https://docs.mistral.ai/api/#tag/ocr) these in the result. This feature may be supported in future updates.
+- LibreChat currently does not include the parsed image content from the OCR process in its responses, even though services like [Mistral's OCR API may provide](https://docs.mistral.ai/api/endpoint/ocr) these in the result. This feature may be supported in future updates.
 
 ---
 

--- a/content/docs/features/web_search.mdx
+++ b/content/docs/features/web_search.mdx
@@ -98,7 +98,7 @@ Search providers are responsible for performing the initial web search and retur
 
 **Available Providers:**
 - **Serper**: A Google Search API that provides high-quality search results
-  - Get your API key from [Serper.dev](https://serper.dev/api-key)
+  - Get your API key from [Serper.dev](https://serper.dev/api-keys)
 - **SearXNG**: Open-source, self-hosted meta search engine
   - Self-host your own instance
   - Privacy-focused search results

--- a/content/docs/local/helm_chart.mdx
+++ b/content/docs/local/helm_chart.mdx
@@ -87,5 +87,5 @@ If you used the chart before version 2.x you may need to update the `value` stru
 3. To leverage an external MongoDB instance, refer to the [values file](https://github.com/danny-avila/LibreChat/blob/main/helm/librechat/values.yaml) of the Chart, deactivate the components accordingly and change the FQDN of the Mongodb instance. This is recommended if data already exists in this externally managed MongoDB instance.
   
 ## Community Helm Charts
-- [LibreChat Helm Chart by Blue Atlas Helm Charts](https://github.com/bat-bs/helm-charts/tree/main/charts/librechat) # will be depricated soon as its migrated here
+- [Blue Atlas Helm Charts](https://charts.blue-atlas.de/) # deprecated now that LibreChat provides an official chart
 - Submitted by [@dimaby](https://github.com/dimaby) on GitHub: [PR #2879](https://github.com/danny-avila/LibreChat/pull/2879)

--- a/content/docs/remote/digitalocean.mdx
+++ b/content/docs/remote/digitalocean.mdx
@@ -4,11 +4,11 @@ icon: DigitalOcean
 description: These instructions are designed for someone starting from scratch for a Docker Installation on a remote Ubuntu server using one of the cheapest tiers (6 USD/mo)
 ---
 
-> These instructions + the [docker guide]() are designed for someone starting from scratch for a Docker Installation on a remote Ubuntu server. You can skip to any point that is useful for you. There are probably more efficient/scalable ways, but this guide works really great for my personal use case.
+> These instructions + the [docker guide](/docs/remote/docker_linux) are designed for someone starting from scratch for a Docker Installation on a remote Ubuntu server. You can skip to any point that is useful for you. There are probably more efficient/scalable ways, but this guide works really great for my personal use case.
 
 **There are many ways to go about this, but I will present to you the best and easiest methods I'm aware of. These configurations can vary based on your liking or needs.**
 
-Digital Ocean is a great option for deployment: you can benefit off a **free [200 USD credit](https://m.do.co/c/4486923fcf00)** (for 60 days), and one of the cheapest tiers (6 USD/mo) will work for LibreChat in a low-stress, minimal-user environment. Should your resource needs increase, you can always upgrade very easily.
+Digital Ocean is a great option for deployment: you can benefit off a **free [200 USD credit](https://www.digitalocean.com/?refcode=4486923fcf00&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge)** (for 60 days), and one of the cheapest tiers (6 USD/mo) will work for LibreChat in a low-stress, minimal-user environment. Should your resource needs increase, you can always upgrade very easily.
 
 Digital Ocean is also my preferred choice for testing deployment, as it comes with useful resource monitoring and server access tools right out of the box.
 
@@ -25,17 +25,17 @@ _Note: you will need a credit card or PayPal to sign up. I'm able to use a prepa
 ## Table of Contents
 
 - **[Part I: Starting from Zero](#part-i-starting-from-zero)**
-  - [1. DigitalOcean signup](#1-click-here-or-on-the-banner-above-to-get-started-on-digitalocean)
+  - [1. DigitalOcean signup](#1-get-started-on-digitalocean)
   - [2. Access console](#2-access-your-droplet-console)
   - [3. Console user setup](#3-once-you-have-logged-in-immediately-create-a-new-non-root-user)
   - [4. Firewall Setup](#4-firewall-setup)
-- **[Part II: Installing Docker & Other Dependencies](#part-ii-installing-docker-and-other-dependencies)**
+- **[Part II: Installing Docker & Other Dependencies](/docs/remote/docker_linux)**
 
 ## Part I: Starting from Zero:
 
 ### **1. Get started on DigitalOcean**
 
-[Click here](https://m.do.co/c/4486923fcf00) or on the banner above to get started.
+[Click here](https://www.digitalocean.com/?refcode=4486923fcf00&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge) or on the banner above to get started.
 
 Once you're logged in, you will be greeted with a [nice welcome screen](https://cloud.digitalocean.com/welcome).
 

--- a/content/docs/remote/huggingface.mdx
+++ b/content/docs/remote/huggingface.mdx
@@ -113,7 +113,7 @@ Click the "Duplicate Space" button.
 
    *   **Edit the Dockerfile:** Go to your LibreChat space (the one you duplicated from the main LibreChat template). Navigate to "Files" -> "Dockerfile" and click "Edit".
 
-   *   **Uncomment and Modify Lines:**  Uncomment/edit the following lines in the Dockerfile.  These lines will contain `ENV SEARCH` and `ENV MEILI_*`.  Make sure to replace `<YOUR_MEILISEARCH_SPACE_URL>` with the actual URL of your Meilisearch deployment on Hugging Face Spaces. It should look something like https://username-meilisearch.hf.space/.  *Update the username to match your username!*
+   *   **Uncomment and Modify Lines:**  Uncomment/edit the following lines in the Dockerfile.  These lines will contain `ENV SEARCH` and `ENV MEILI_*`.  Make sure to replace `<YOUR_MEILISEARCH_SPACE_URL>` with the actual URL of your Meilisearch deployment on Hugging Face Spaces. It should look something like `https://<your-username>-meilisearch.hf.space/`.  *Update the username to match your username!*
 
        ```dockerfile
        ENV SEARCH=true


### PR DESCRIPTION
Fixes the link-check report by updating moved documentation URLs, replacing broken DigitalOcean anchors and shortlinks, and marking the historical Trendshift badge as an unstable third-party endpoint.

Validation:
- git diff --check
- focused grep for the reported stale URLs against the English docs surface