### PR TITLE
fix(ci): use Production env for screenshot workflow

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -17,6 +17,7 @@ jobs:
   screenshots:
     name: Capture and open PR
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -28,6 +28,9 @@ against the demo's current UI.
 
 ### Required env
 
+The GitHub workflow runs in the `Production` Environment, so define these
+secrets/variables there.
+
 | Name                   | Where                              | Purpose                                 |
 | ---------------------- | ---------------------------------- | --------------------------------------- |
 | `DEMO_EMAIL`           | secret / `.env.local`              | demo account login                      |


### PR DESCRIPTION
## Summary
- Run the screenshot refresh workflow in the `Production` GitHub Environment so `DEMO_*` secrets are available.
- Document that the screenshot workflow secrets and variables must be defined in `Production`.

## Verification
- `git diff --check`

Note: local `prettier` and `vitest` could not be run because dependencies are not installed in this worktree.