### PR TITLE
fix: hide language switcher on blog pages

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
-    <HomeLayout {...baseOptions}>
+    <HomeLayout {...baseOptions} i18n={false}>
       <main id="main-content" tabIndex={-1} className="mx-auto w-full max-w-4xl px-4 py-16">
         {children}
       </main>

--- a/app/changelog/layout.tsx
+++ b/app/changelog/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 
 export default function ChangelogLayout({ children }: { children: ReactNode }) {
   return (
-    <HomeLayout {...baseOptions}>
+    <HomeLayout {...baseOptions} i18n={false}>
       <main id="main-content" tabIndex={-1} className="mx-auto w-full max-w-4xl px-4 py-16">
         {children}
       </main>


### PR DESCRIPTION
## Summary
- Hide the language switcher on blog and changelog pages.
- Keep localized home and docs language switching unchanged.

## Why
Blog and changelog routes are not localized, but they inherited the full Fumadocs locale list from the root provider. Changing language from those pages generated locale-prefixed URLs that do not exist.

## Validation
- pnpm exec eslint app/blog/layout.tsx app/changelog/layout.tsx
- pnpm exec fumadocs-mdx
- pnpm exec tsc --noEmit