### PR TITLE
docs: add apiUrl option for GitHub Enterprise skill sync

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/skill_sync.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/skill_sync.mdx
@@ -19,6 +19,7 @@ skillSync:
     runOnStartup: true
     sources:
       - id: librechat-skills
+        # apiUrl: 'https://github.your-company.com/api/v3'
         owner: your-org
         repo: your-skills-repo
         ref: main
@@ -82,6 +83,12 @@ Each `github.sources` entry configures one repository source.
       'String',
       'Stable unique source id. Must start with a letter or digit and contain only letters, digits, underscores, or hyphens.',
       'id: librechat-skills',
+    ],
+    [
+      'apiUrl',
+      'String',
+      'Optional GitHub API base URL for GitHub Enterprise instances. Omit to use the default (`https://api.github.com`).',
+      "apiUrl: 'https://github.your-company.com/api/v3'",
     ],
     ['owner', 'String', 'GitHub organization or user name.', 'owner: your-org'],
     ['repo', 'String', 'GitHub repository name.', 'repo: your-skills-repo'],


### PR DESCRIPTION
## Summary

- Documents the new optional `apiUrl` field on `skillSync.github.sources` entries
- Allows admins to configure a custom GitHub API base URL for GitHub Enterprise instances
- Adds the field to both the example YAML block and the source fields reference table

## Related

Feature implementation: https://github.com/langered/LibreChat/tree/feat/skill-sync-custom-github-api-url

## Test plan

- [ ] Verify the docs page renders correctly with the new table row and example comment