### PR TITLE
Add Dustin Healy email to author profile

### DIFF
--- a/lib/authors.ts
+++ b/lib/authors.ts
@@ -53,6 +53,7 @@ export const authors: Author[] = [
       { label: 'Website', url: 'https://www.dustinhealy.com/' },
       { label: 'GitHub', url: 'https://github.com/dustinhealy' },
       { label: 'LinkedIn', url: 'https://www.linkedin.com/in/dustinhealy' },
+      { label: 'Email', url: 'mailto:dustin@librechat.ai' },
     ],
   },
   {


### PR DESCRIPTION
Adds an Email social link (mailto:dustin@librechat.ai) to Dustin Healy's author profile in `lib/authors.ts`, matching the convention used by the other authors.