### PR TITLE
fix(docs): pre-render default locale only to fix Vercel build OOM

### DIFF
--- a/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/app/[lang]/docs/[[...slug]]/page.tsx
@@ -145,16 +145,19 @@ export default async function Page(props: PageProps) {
   )
 }
 
+// Localized docs render on demand (and edge-cache on first hit) instead of being
+// pre-rendered. Load-bearing for generateStaticParams below, so keep it explicit.
+export const dynamicParams = true
+
 export async function generateStaticParams() {
-  // Fumadocs emits one param set per page for EVERY language even when no
-  // localized file exists (getPage falls back to English). Materializing those
-  // would publish hundreds of duplicate-English pages at /<locale>/docs/* and
-  // list them in the sitemap. Keep the default language plus only locales that
-  // have a real translated file on disk (same discriminator as the hreflang gate).
-  return docsSource.generateParams().filter((p) => {
-    if (p.lang === i18n.defaultLanguage) return true
-    return docsSource.getPage(p.slug, p.lang)?.path.endsWith(`.${p.lang}.mdx`) ?? false
-  })
+  // Pre-render the default language only. Every locale now ships a full set of
+  // translated files, so materializing all of them is locales x pages (~13 x 180 =
+  // ~2,340) and the static-generation phase exhausted the 8 GB Vercel build runner
+  // (OOM / 45-min timeout). Building just the default language keeps the page count
+  // flat no matter how many languages exist; a non-default locale renders on demand
+  // (dynamicParams above) and, when it has no translated file, redirects to English
+  // in Page() exactly as before. The hreflang/canonical gating is unchanged.
+  return docsSource.generateParams().filter((p) => p.lang === i18n.defaultLanguage)
 }
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,3 +1,47 @@
+const { readdirSync } = require('node:fs')
+const { join, relative, sep } = require('node:path')
+
+// Translated docs (content/docs/<path>.<locale>.mdx) render on demand:
+// app/[lang]/docs/[[...slug]]/page.tsx pre-renders only the default language, so
+// next-sitemap's build-output discovery never sees the localized pages. Enumerate
+// them from the content tree and add them back via additionalPaths below; without
+// this every /<locale>/docs/* URL drops out of sitemap.xml even though
+// generateMetadata still advertises hreflang alternates to it, which hurts crawler
+// discovery of the translations. Keys off the `.<locale>.mdx` naming convention
+// used elsewhere in the repo (lib/i18n/run.ts, the translate workflow path filters).
+const DOCS_DIR = join(__dirname, 'content', 'docs')
+const LOCALE_MDX = /\.([a-z]{2}(?:-[A-Z]{2})?)\.mdx$/
+
+function walkFiles(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (entry.name === '.i18n-cache') continue
+      out.push(...walkFiles(join(dir, entry.name)))
+    } else {
+      out.push(join(dir, entry.name))
+    }
+  }
+  return out
+}
+
+// Map each translated file to its on-demand URL, mirroring the docs loader
+// (baseUrl '/docs', non-default locales prefixed with the locale, `index` collapses
+// to its parent). Filenames carry no numeric ordering prefixes, so the slug is the
+// path verbatim.
+function translatedDocUrls() {
+  const urls = []
+  for (const file of walkFiles(DOCS_DIR)) {
+    const match = file.match(LOCALE_MDX)
+    if (!match) continue
+    const locale = match[1]
+    const rel = relative(DOCS_DIR, file).split(sep).join('/')
+    const slug = rel.slice(0, -`.${locale}.mdx`.length).replace(/(^|\/)index$/, '')
+    urls.push(`/${locale}/docs${slug ? `/${slug}` : ''}`)
+  }
+  return urls
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: 'https://www.librechat.ai',
@@ -14,7 +58,8 @@ module.exports = {
     if (path === '/') {
       changefreq = 'daily'
       priority = 1.0
-    } else if (path.startsWith('/docs')) {
+    } else if (/^\/([a-z]{2}(-[A-Z]{2})?\/)?docs(\/|$)/.test(path)) {
+      // English (/docs/*) and localized (/<locale>/docs/*) docs alike.
       changefreq = 'weekly'
       priority = 0.9
     } else if (path.startsWith('/blog') || path.startsWith('/changelog')) {
@@ -32,4 +77,8 @@ module.exports = {
       lastmod: new Date().toISOString(),
     }
   },
+  // Localized docs render on demand, so they aren't in the build output that
+  // next-sitemap scans. Add them explicitly (see the note at the top of the file).
+  additionalPaths: async (config) =>
+    Promise.all(translatedDocUrls().map((loc) => config.transform(config, loc))),
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev --webpack -p 3333",
-    "build": "next build --webpack",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=7168 next build --webpack",
     "postbuild": "node scripts/clean-cache.cjs",
     "start": "next start -p 3333",
     "analyze": "cross-env ANALYZE=true next build --webpack",


### PR DESCRIPTION
## Problem

Production builds on `main` fail since #683 (publishing 8 new locales). The `app/[lang]/docs/[[...slug]]` route pre-renders one page per (locale, doc), which jumped from ~1,080 to ~2,340 pages and exhausts the 8 GB Vercel build runner: sometimes a heap OOM at 10-15 min, sometimes the 45-minute build timeout. The site stays up on the last good deployment (#682), but the translations can't ship.

## Fix

- **Pre-render the default language only.** `generateStaticParams` now returns just the default locale (~180 pages). Localized docs render on demand (`dynamicParams` is the default, now explicit) and edge-cache on first hit via the existing `cdnCacheHeaders`. Build cost stays flat regardless of how many languages exist. Behaviour is otherwise unchanged: an untranslated locale still redirects to English in `Page()`, and hreflang/canonical gating is untouched.
- **Heap headroom.** `build` runs with `--max-old-space-size=7168` via `cross-env` as a safety net for the webpack compile phase.

## Verification

The Vercel preview build for this PR is the test: if it goes green, the OOM is resolved. After merge, sanity-check that a localized page (e.g. `/de/docs/...`) renders on demand.

## If the preview still OOMs

That would mean the limit is the webpack compile phase (compiling all MDX modules), which this PR does not reduce. In that case bump the Vercel build machine to a larger tier and raise the `7168` cap to match.
