### PR TITLE
docs: add Eden AI as a custom endpoint

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/edenai.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/edenai.mdx
@@ -1,0 +1,40 @@
+---
+title: Eden AI
+description: Configure Eden AI as a custom endpoint in LibreChat.
+---
+
+Eden AI is an EU-based, GDPR-compliant unified API that routes to 700+ models from OpenAI, Anthropic, Google, Mistral, Cohere, and other providers through a single OpenAI-compatible endpoint, with EU data residency.
+
+## Get an API key
+
+Create an account at [app.edenai.run](https://app.edenai.run/) and generate a key from your account settings. Add it to your `.env` file:
+
+```bash filename=".env"
+EDENAI_KEY=your-eden-ai-key-here
+```
+
+## Configuration
+
+Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "Eden AI"
+      apiKey: "${EDENAI_KEY}"
+      baseURL: "https://api.edenai.run/v3"
+      models:
+        default: ["openai/gpt-4o-mini", "mistral/mistral-large-latest", "anthropic/claude-sonnet-4-5"]
+        fetch: false
+      titleConvo: true
+      titleModel: "openai/gpt-4o-mini"
+      modelDisplayLabel: "Eden AI"
+```
+
+Models use Eden AI's `provider/model` naming convention (for example `openai/gpt-4o-mini`, `mistral/mistral-large-latest`). Browse the full list in the [Eden AI models catalog](https://www.edenai.co/models).
+
+To let each user supply their own key through the LibreChat UI instead of reading one from `.env`, set `apiKey: "user_provided"`. Users then see a key input field when they select the endpoint.
+
+## Notes
+
+- Eden AI exposes a standard OpenAI-compatible `/models` endpoint, so `fetch: true` works as well — but it returns 700+ models. Pinning a curated `default` list with `fetch: false` keeps the model selector manageable.
+- EU data residency: several models are also offered as EU-hosted regional variants.
+- One key gives access to many providers; switch models by changing the `provider/model` string, no extra configuration needed.

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -9,6 +9,7 @@
     "cohere",
     "databricks",
     "deepseek",
+    "edenai",
     "fireworks",
     "groq",
     "helicone",


### PR DESCRIPTION
## Summary

Adds **Eden AI** as a custom endpoint under `ai_endpoints`.

[Eden AI](https://www.edenai.co/) is an EU-based, GDPR-compliant unified API exposing an OpenAI-compatible endpoint — 700+ models across providers (OpenAI, Anthropic, Mistral, Google, Cohere, …) through a single key, with EU data residency.

- New page `ai_endpoints/edenai.mdx` with a `librechat.yaml` example (`baseURL: https://api.edenai.run/v3`, `provider/model` model IDs), plus `.env` / `user_provided` key options.
- Registered in `ai_endpoints/meta.json` (alphabetical).

Verified against the live API: `GET /models` and `POST /chat/completions` return `200` for `openai/gpt-4o-mini`, `mistral/mistral-large-latest`, and `anthropic/claude-sonnet-4-5`.

No provider icon is set yet (the nav renders fine without one) — happy to add Eden AI's official logo as an icon if you'd like it registered. DCO signed-off.
