### PR TITLE
docs: refresh Google Gemini model examples

### DIFF
--- a/content/docs/configuration/pre_configured_ai/google.mdx
+++ b/content/docs/configuration/pre_configured_ai/google.mdx
@@ -54,11 +54,10 @@ GOOGLE_MODELS=gemini-2.5-flash,gemini-2.5-pro,gemini-2.5-flash-lite,gemini-flash
 
 <Callout type="note" title="Notes:">
 
-- Use a multimodal Gemini model such as `gemini-2.5-flash` or `gemini-2.5-pro` if you want to support image or PDF inputs.
+- `gemini-flash-latest`, `gemini-flash-lite-latest`, and `gemini-pro-latest` point to the latest available model for each variant, so they are usually safer choices over time as Google deprecates older fixed model IDs.
 - Using LibreChat, PaLM2 and Codey models can only be accessed through Vertex AI, not the Generative Language API.
   - Only models that support the `generateContent` method can be used natively with LibreChat + the Gen AI API.
 - With the Google endpoint, you cannot use both Vertex AI and Generative Language API at the same time. You must choose one or the other.
-- Some older PaLM/Codey models may fail when `maxOutputTokens` is set to a high value. If you encounter this issue, try reducing the value through the conversation parameters.
 
 </Callout>
 

--- a/content/docs/configuration/pre_configured_ai/google.mdx
+++ b/content/docs/configuration/pre_configured_ai/google.mdx
@@ -49,7 +49,7 @@ The example below was last checked on **2026-07-07**.
 For example, you can start with a small set of currently available Gemini models such as:
 
 ```bash filename=".env"
-GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite
+GOOGLE_MODELS=gemini-2.5-flash,gemini-2.5-pro,gemini-2.5-flash-lite,gemini-flash-latest,gemini-flash-lite-latest,gemini-pro-latest,gemini-3-pro-preview,gemini-3-flash-preview,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite,gemini-3.5-flash
 ```
 
 <Callout type="note" title="Notes:">
@@ -179,7 +179,7 @@ The example below was last checked on **2026-07-07**.
 For example, you can start with a small set of currently available Gemini models such as:
 
 ```bash filename=".env"
-GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite
+GOOGLE_MODELS=gemini-2.5-flash,gemini-2.5-pro,gemini-2.5-flash-lite,gemini-flash-latest,gemini-flash-lite-latest,gemini-pro-latest,gemini-3-pro-preview,gemini-3-flash-preview,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite,gemini-3.5-flash
 ```
 
 <Callout type="note" title="If you are using Docker">

--- a/content/docs/configuration/pre_configured_ai/google.mdx
+++ b/content/docs/configuration/pre_configured_ai/google.mdx
@@ -40,23 +40,23 @@ Some reverse proxies do not support the `X-goog-api-key` header. You can configu
 GOOGLE_AUTH_HEADER=true
 ```
 
-Since fetching the models list isn't yet supported, you should set the models you want to use in the .env file.
+Since fetching the models list isn't yet supported, you should set the models you want to use in the `.env` file.
 
-For your convenience, these are the latest models as of 5/18/24 that can be used with the Generative Language API:
+Google updates Gemini model names frequently, so refer to the **[official Gemini models list](https://ai.google.dev/gemini-api/docs/models)** for the latest identifiers.
+
+For example, you can start with a small set of currently available Gemini models such as:
 
 ```bash filename=".env"
-GOOGLE_MODELS=gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
+GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite
 ```
 
 <Callout type="note" title="Notes:">
 
-- A gemini-pro model or `gemini-pro-vision` are required in your list for attaching images.
+- Use a multimodal Gemini model such as `gemini-2.5-flash` or `gemini-2.5-pro` if you want to support image or PDF inputs.
 - Using LibreChat, PaLM2 and Codey models can only be accessed through Vertex AI, not the Generative Language API.
   - Only models that support the `generateContent` method can be used natively with LibreChat + the Gen AI API.
-- Selecting `gemini-pro-vision` for messages with attachments is not necessary as it will be switched behind the scenes for you.
-- Since `gemini-pro-vision` does not accept non-attachment messages, messages without attachments are automatically switched to use `gemini-pro` otherwise Google responds with an error.
 - With the Google endpoint, you cannot use both Vertex AI and Generative Language API at the same time. You must choose one or the other.
-- Some PaLM/Codey models and `gemini-pro-vision` may fail when `maxOutputTokens` is set to a high value. If you encounter this issue, try reducing the value through the conversation parameters.
+- Some older PaLM/Codey models may fail when `maxOutputTokens` is set to a high value. If you encounter this issue, try reducing the value through the conversation parameters.
 
 </Callout>
 
@@ -168,12 +168,14 @@ GOOGLE_LOC=us-central1
 GOOGLE_CLOUD_LOCATION=global
 ```
 
-Since fetching the models list isn't yet supported, you should set the models you want to use in the .env file.
+Since fetching the models list isn't yet supported, you should set the models you want to use in the `.env` file.
 
-For your convenience, these are the latest models as of 5/18/24 that can be used with the Generative Language API:
+Google updates Gemini model names frequently, so refer to the **[official Gemini models list](https://ai.google.dev/gemini-api/docs/models)** for the latest identifiers.
+
+For example, you can start with a small set of currently available Gemini models such as:
 
 ```bash filename=".env"
-GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-1.0-pro-002,gemini-1.0-pro-001,gemini-pro-vision,gemini-1.0-pro
+GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite
 ```
 
 <Callout type="note" title="If you are using Docker">

--- a/content/docs/configuration/pre_configured_ai/google.mdx
+++ b/content/docs/configuration/pre_configured_ai/google.mdx
@@ -44,6 +44,8 @@ Since fetching the models list isn't yet supported, you should set the models yo
 
 Google updates Gemini model names frequently, so refer to the **[official Gemini models list](https://ai.google.dev/gemini-api/docs/models)** for the latest identifiers.
 
+The example below was last checked on **2026-07-07**.
+
 For example, you can start with a small set of currently available Gemini models such as:
 
 ```bash filename=".env"
@@ -171,6 +173,8 @@ GOOGLE_CLOUD_LOCATION=global
 Since fetching the models list isn't yet supported, you should set the models you want to use in the `.env` file.
 
 Google updates Gemini model names frequently, so refer to the **[official Gemini models list](https://ai.google.dev/gemini-api/docs/models)** for the latest identifiers.
+
+The example below was last checked on **2026-07-07**.
 
 For example, you can start with a small set of currently available Gemini models such as:
 


### PR DESCRIPTION
## Summary
- replace outdated 2024 Gemini model examples in the Google docs
- point readers to the official Gemini models list because model names change frequently
- remove old `gemini-pro` / `gemini-pro-vision` guidance in favor of current multimodal Gemini examples
- added mentions of currently available gemini 2.5, 3, 3.1 and 3.5 series models
