### PR TITLE
docs: add vestige to MCP servers example config

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/mcp_servers.mdx
@@ -41,6 +41,14 @@ mcpServers:
       - -y
       - 'mcp-obsidian'
       - /path/to/obsidian/vault
+  vestige:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - -p
+      - 'vestige-mcp-server@latest'
+      - vestige-mcp
   streamable-http-server:
     type: streamable-http
     url: https://example.com/api/


### PR DESCRIPTION
Adds a `vestige` entry to the MCP Servers example config, next to the other local stdio examples like `mcp-obsidian`. Vestige is a local memory server that runs over stdio, so agents in LibreChat can keep context across sessions (past decisions, preferences, fixes) with everything stored on the user's own machine. There's no memory example in the block yet, and people ask how to wire one up, so it's a useful reference to have.

The entry uses the same stdio schema as the existing examples. I ran the command locally first: `npx -y -p vestige-mcp-server@latest vestige-mcp` starts the server and answers an MCP initialize request over stdio, so the snippet works as written. Docs only.
