### PR TITLE
docs: clarify agent share/public permission semantics for agents and remote agents

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -655,17 +655,43 @@ When using the object structure:
     [
       'share',
       'Boolean',
-      'Controls whether users can share agents with specific users/groups.',
+      'Grants the `SHARE` permission: the ability to share an agent with specific users, groups, or roles through the in-app share dialog. See the note below on who can actually target specific users.',
       'false',
     ],
     [
       'public',
       'Boolean',
-      'Controls whether users can share agents publicly (visible to all users).',
+      'Grants the `SHARE_PUBLIC` permission: the ability to make an agent public, meaning visible to every authenticated user on the instance. If `false`, agents can never be made public, regardless of `share`.',
       'false',
     ],
   ]}
 />
+
+The defaults preserve prior behavior: users may use and create agents, but not share them. Enable `share` and/or `public` per environment to opt into sharing.
+
+### How `share` and `public` work
+
+`share` and `public` map to the `SHARE` and `SHARE_PUBLIC` [feature permissions](/docs/features/access_control#the-access-model-at-a-glance). Two LibreChat concepts explain how they behave.
+
+The first is the set of principal types an agent can be shared with: a user (an individual account), a group (a collection of users, either local or synced from Entra ID), a role (a named permission profile such as `USER` or `ADMIN`), and public (every authenticated user on the instance).
+
+The second is the pair of built-in roles: `ADMIN`, assigned to the first registered account and able to see every user and resource, and `USER`, the default non-admin role. When these docs say "non-admin" they mean any user who is not an `ADMIN`, which is the `USER` role by default.
+
+<Callout type="warning">
+  `share: true` grants the `SHARE` permission to the role, but that permission alone does not let a
+  role share with specific users. The share dialog's people picker only shows the principal types a
+  role is allowed to view (`VIEW_USERS`, `VIEW_GROUPS`, and `VIEW_ROLES`, configured through
+  [`peoplePicker`](#peoplepicker)). Seeing individual users is normally an admin capability, so a
+  non-admin with `SHARE` can share with any groups and roles that appear in their people picker, and
+  can toggle public access when `public: true`, but usually has no way to pick individual users.
+</Callout>
+
+In practice this means:
+
+- With `share: true`, an admin can share an agent with specific users, groups, or roles, because an admin can see every user.
+- With `share: true`, a non-admin (the `USER` role) can share with the groups and roles that appear in their people picker. When `public: true` they can also choose whether their agent stays private or becomes public. Picking individual users additionally requires the `VIEW_USERS` people-picker permission, which they usually do not hold.
+
+The split between `share` and `public` is deliberate. You can let a role share with specific principals through `share` without letting them make agents visible to everyone through `public`. Which principal types appear in the people picker is itself configurable through [`peoplePicker`](#peoplepicker), and the full model is documented under [Access Control](/docs/features/access_control).
 
 **Example (boolean - simple feature toggle):**
 
@@ -691,13 +717,17 @@ interface:
   agents:
     use: true
     create: true
+    # admins can share with specific users, groups, or roles; non-admins are
+    # limited to the groups and roles they can see, not individual users
     share: true
-    public: false
+    public: false # agents cannot be made visible to all users
 ```
 
 ## remoteAgents
 
 Controls access to the Agents API (OpenAI-compatible and Open Responses API endpoints), which allows external applications to interact with LibreChat agents programmatically via API keys.
+
+The `share` and `public` sub-keys follow the same sharing model as [`agents`](#how-share-and-public-work) above. `share` grants sharing with specific principals, with the same admin versus non-admin people-picker distinction, and `public` grants visibility to all users.
 
 > **Deprecated for permission management.** Seeds the `REMOTE_AGENTS` role permissions at startup for the default `USER` role only. Prefer the [Admin Panel](/docs/features/admin_panel).
 

--- a/content/docs/features/access_control.mdx
+++ b/content/docs/features/access_control.mdx
@@ -70,7 +70,9 @@ Each role holds a matrix of **permission types × actions**:
 | `MARKETPLACE`    | `USE`                                                     |
 | `PEOPLE_PICKER`  | `VIEW_USERS`, `VIEW_GROUPS`, `VIEW_ROLES`                 |
 
-The distinction between `SHARE` and `SHARE_PUBLIC` is important: you can allow a role to share agents with _specific_ users or groups (`SHARE`) without letting them make agents visible to _everyone_ on the instance (`SHARE_PUBLIC`).
+The distinction between `SHARE` and `SHARE_PUBLIC` is important: you can allow a role to share agents with specific principals (`SHARE`) without letting them make agents visible to everyone on the instance (`SHARE_PUBLIC`).
+
+`SHARE` grants the ability to share, but which principal types a role can actually target depends on its `PEOPLE_PICKER` permissions (`VIEW_USERS`, `VIEW_GROUPS`, `VIEW_ROLES`). The share dialog's people picker only shows the principal types the role is allowed to view, so a role that holds `SHARE` but not `VIEW_USERS` can share with the groups and roles it can see, yet cannot select individual users. This is why granular, specific-user sharing is usually an admin concern: admins can see every user, while the `USER` role often cannot. To change which principal types a role can pick, use the admin panel or [`interface.peoplePicker`](/docs/configuration/librechat_yaml/object_structure/interface#peoplepicker).
 
 ### Configuring Feature Permissions
 


### PR DESCRIPTION
Explain that share grants the SHARE permission but that picking specific users depends on the VIEW_USERS people-picker permission, so specific-user sharing is usually an admin concern. Non-admins with share can still target the groups and roles they can see and toggle public when allowed.

Rewrite the share/public sub-key descriptions, add a "How share and public work" section covering principal types and the built-in roles, cross-link remoteAgents to it, and align the SHARE vs SHARE_PUBLIC note in access_control.