### PR TITLE
Document FILE_UPLOAD_SSE_ENABLED -  Use SSE to upload files

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -2972,36 +2972,6 @@ LibreChat supports Google Tag Manager for analytics. You will need a Google Tag 
   options={[['ANALYTICS_GTM_ID', 'string', 'Google Tag Manager ID.', 'ANALYTICS_GTM_ID=']]}
 />
 
-#### Conversation Import
-
-Configure limits for conversation file imports to prevent memory issues.
-
-<OptionTable
-  options={[
-    [
-      'CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES',
-      'number',
-      'Maximum file size in bytes for conversation imports. Default: 0 (no limit enforced). Example: 262144000 (250 MiB).',
-      '# CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000',
-    ],
-  ]}
-/>
-
-#### Inline File Previews
-
-Control how large generated files can be before LibreChat skips inline preview extraction and leaves them download-only.
-
-<OptionTable
-  options={[
-    [
-      'FILE_PREVIEW_MAX_EXTRACT_BYTES',
-      'number',
-      'Maximum source file size in bytes for code-execution artifact inline previews. Default: 2097152 (2 MiB). Rendered HTML previews are still capped separately, so very rich files may skip preview even below this value.',
-      '# FILE_PREVIEW_MAX_EXTRACT_BYTES=2097152',
-    ],
-  ]}
-/>
-
 ### MCP (Model Context Protocol)
 
 Configure Model Context Protocol settings for enhanced server management and OAuth support.
@@ -3206,6 +3176,51 @@ Configure distributed leader election for multi-instance deployments with Redis.
       'number',
       'Delay in seconds between retry attempts when renewing the lease. Default: 0.5.',
       'LEADER_RENEW_RETRY_DELAY=0.5',
+    ],
+  ]}
+/>
+
+#### Conversation Import
+
+Configure limits for conversation file imports to prevent memory issues.
+
+<OptionTable
+  options={[
+    [
+      'CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES',
+      'number',
+      'Maximum file size in bytes for conversation imports. Default: 0 (no limit enforced). Example: 262144000 (250 MiB).',
+      '# CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000',
+    ],
+  ]}
+/>
+
+#### File uploading using SSE
+
+During file upload, especially when uploading larger files to RAG, the client may remain idle while LibreChat processes the file (embeds it). Because the request is idle, gateways may cancel it and send an idle timeout HTTP status code back to the client browser (HTTP status code 408/504/524). To prevent this, you can change the upload type to an SSE upload, which will keep the connection alive at all times by continuously sending a heartbeat event back to the client. This is especially helpful when using the EMBEDDING_BATCH_SIZE environment variable with LibreChat RAG, as it allows larger files to be uploaded without running out of memory on the RAG container. FILE_UPLOAD_SSE_ENABLED defaults to false.
+
+<OptionTable
+  options={[
+    [
+      'FILE_UPLOAD_SSE_ENABLED',
+      'boolean',
+      'Use SSE during file uploads to prevent idle timeouts',
+      '# FILE_UPLOAD_SSE_ENABLED=true',
+    ],
+  ]}
+/>
+
+#### Inline File Previews
+
+Control how large generated files can be before LibreChat skips inline preview extraction and leaves them download-only.
+
+<OptionTable
+  options={[
+    [
+      'FILE_PREVIEW_MAX_EXTRACT_BYTES',
+      'number',
+      'Maximum source file size in bytes for code-execution artifact inline previews. Default: 2097152 (2 MiB). Rendered HTML previews are still capped separately, so very rich files may skip preview even below this value.',
+      '# FILE_PREVIEW_MAX_EXTRACT_BYTES=2097152',
     ],
   ]}
 />


### PR DESCRIPTION
This change documents a new FILE_UPLOAD_SSE_ENABLED property utilized by librechat [pull request 14295](https://github.com/danny-avila/LibreChat/pull/14295) but also moves   CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES and FILE_PREVIEW_MAX_EXTRACT_BYTES documentation to the "other" section and out of "analytics" since they both have nothing to do with analytics.

Use SSE to upload files in order to avoid idle timeouts.  Idle timeouts can occur for example from gateways and other services like Cloudflare when uploading large files.  For example during rag processing the file is uploaded to librechat which then sends it to rag.  While librechat is waiting for the embeddings to come back from rag the file upload is sitting idle.  Gateways tend to want to cancel the upload with an http 408, 504, or 524.  This change uses SSE to perform the upload so that while librechat is sending the file to rag, it consistently sends back a heartbeat event to the client to keep the connection alive.  This is especially useful when utilizing  EMBEDDING_BATCH_SIZE in librechat rag which will allow rag to process significantly larger files without running out of memory.

