### PR TITLE
docs: add DaoXE to AI Endpoints

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/daoxe.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/daoxe.mdx
@@ -1,0 +1,41 @@
+---
+title: DaoXE
+description: Configure DaoXE as a custom endpoint in LibreChat.
+---
+
+DaoXE is an OpenAI-compatible, multi-protocol LLM gateway that exposes Chat Completions,
+OpenAI Responses, and Anthropic Messages (Claude native) through one endpoint, with access
+to Claude, GPT, Gemini, DeepSeek, Kimi, Qwen and Doubao behind a single API key.
+
+## Get an API key
+
+Create a key from your DaoXE account and add it to your `.env` file:
+
+```bash filename=".env"
+DAOXE_API_KEY=your-api-key
+```
+
+## Configuration
+
+Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "DaoXE"
+      apiKey: "${DAOXE_API_KEY}"
+      baseURL: "https://daoxe.com/v1"
+      models:
+        default: ["gpt-5", "claude-opus-4-5", "gemini-2.5-pro", "deepseek-chat"]
+        fetch: true
+      titleConvo: true
+      titleModel: "current_model"
+      modelDisplayLabel: "DaoXE"
+```
+
+## Notes
+
+- Model IDs are account-scoped. With `fetch: true`, LibreChat pulls the live list from
+  DaoXE's `/v1/models` endpoint, so `default` acts only as a fallback — run
+  `GET https://daoxe.com/v1/models` to see the exact IDs available to your account.
+- DaoXE also speaks the native Anthropic Messages API. To use Claude models over the
+  native protocol instead, configure a second custom endpoint with `provider: "anthropic"`
+  (verify the base URL path against your account before use).

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -7,6 +7,7 @@
     "azure",
     "cloudflare",
     "cohere",
+    "daoxe",
     "databricks",
     "deepseek",
     "fireworks",


### PR DESCRIPTION
Adds DaoXE to the list of known OpenAI-compatible custom endpoints, alongside existing gateways (APIpie, OpenRouter, Portkey, LiteLLM, Helicone).

DaoXE is an OpenAI-compatible, multi-protocol gateway (Chat Completions / OpenAI Responses / Anthropic Messages) at https://daoxe.com/v1. It supports account-scoped `GET /v1/models`, so the example uses `fetch: true`.

- New: ai_endpoints/daoxe.mdx
- Registered in ai_endpoints/meta.json (alphabetical, between cohere and databricks)

Disclosure: DaoXE is a service we operate. Not available in mainland China.

Made with [Cursor](https://cursor.com)