### PR TITLE
docs(memory): document agent.enabled opt-in (ref #12886)

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/memory.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/memory.mdx
@@ -19,6 +19,7 @@ memory:
   personalize: true
   messageWindowSize: 5
   agent:
+    enabled: true
     provider: 'openAI'
     model: 'gpt-4'
     instructions: 'You are a helpful assistant that remembers user preferences and context.'
@@ -26,6 +27,22 @@ memory:
       temperature: 0.7
       max_tokens: 1000
 ```
+
+<Callout type="info">
+  As of [PR #12886](https://github.com/danny-avila/LibreChat/pull/12886), the memory
+  **agent** must set `enabled: true` for automatic memory extraction to run.
+  If the flag is omitted, LibreChat logs a startup warning and skips automatic
+  extraction. Manual memory operations (create, edit, delete, reference)
+  continue to work regardless of the flag.
+
+  The warning looks like:
+
+  ```text
+  [memory] Agent config detected without explicit `enabled: true`.
+  Automatic memory extraction is now opt-in.
+  Add `memory.agent.enabled: true` to keep automatic extraction on.
+  ```
+</Callout>
 
 ## disabled
 
@@ -193,6 +210,7 @@ When you have a pre-configured agent, you can reference it by its ID:
 ```yaml filename="memory / agent (by ID)"
 memory:
   agent:
+    enabled: true
     id: 'memory-agent-001'
 ```
 
@@ -203,6 +221,7 @@ For more control, you can define a complete agent configuration:
 ```yaml filename="memory / agent (custom)"
 memory:
   agent:
+    enabled: true
     provider: 'openAI'
     model: 'gpt-4'
     instructions: 'You are a memory assistant that helps maintain conversation context and user preferences.'
@@ -215,6 +234,21 @@ memory:
 #### Agent Configuration Fields
 
 When using custom agent configuration, the following fields are available:
+
+**enabled** (required for automatic extraction)
+
+<OptionTable
+  options={[
+    [
+      'enabled',
+      'Boolean',
+      'Explicitly enables the automatic memory-extraction agent. As of [PR #12886](https://github.com/danny-avila/LibreChat/pull/12886), an `agent` block without `enabled: true` logs a warning at startup and does not run automatic extraction. Manual memory operations remain available.',
+      'enabled: true',
+    ],
+  ]}
+/>
+
+**Default:** `false` (opt-in).
 
 **provider** (required)
 
@@ -284,6 +318,7 @@ memory:
   personalize: true
   messageWindowSize: 8
   agent:
+    enabled: true
     provider: 'openAI'
     model: 'gpt-4'
     instructions: |
@@ -330,6 +365,7 @@ memory:
   personalize: true
   messageWindowSize: 10
   agent:
+    enabled: true
     provider: 'Custom Memory Endpoint'
     model: 'gpt-4o-mini'
 ```
@@ -345,5 +381,6 @@ memory:
 - Valid keys provide granular control over what information can be stored
 - Custom `instructions` replace default memory handling instructions and should be used with `validKeys`
 - Agent configuration allows customization of memory processing behavior
+- Automatic memory extraction is opt-in: `memory.agent.enabled: true` is required (see [PR #12886](https://github.com/danny-avila/LibreChat/pull/12886)). Manual memory operations remain available even without an enabled agent
 - When disabled, all memory features are turned off regardless of other settings
 - The message window size affects how much recent context is considered for memory updates


### PR DESCRIPTION
## Summary

- Documents the breaking change from [danny-avila/LibreChat#12886](https://github.com/danny-avila/LibreChat/pull/12886) (merged 2026-05-01): `memory.agent.enabled: true` is now required for the automatic memory-extraction agent to run.
- Configs that upgrade past #12886 with an `agent` block but no explicit `enabled: true` currently log a startup warning and silently skip automatic extraction. Manual memory operations still work.
- The [Memory Configuration docs page](https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/memory) never mentioned the new property, so self-hosters (including ours) discovered the change via warning logs after memory silently stopped being written.

## Changes

- Added `enabled: true` to every `agent:` example in `memory.mdx`:
  - Top overview example
  - Agent-by-ID example
  - Custom Agent Configuration example
  - Complete Configuration Example
  - Custom Endpoints example
- Documented `enabled` as an Agent Configuration Field, noting the opt-in default and linking back to PR #12886.
- Added an info Callout under the top example that quotes the exact runtime warning users will see if the flag is missing.
- Added a bullet to the Notes section summarising the opt-in behaviour.

## Test plan

- [x] File is a single `.mdx` in `content/docs/`, no build tooling changes.
- [ ] Preview the page renders cleanly (Callout + OptionTable used identically to other pages).
- [ ] Confirm the wording in the warning-text codeblock matches the string in `packages/data-schemas/src/app/memory.ts` — this PR quotes it verbatim.

## Context / motivation

Surfaced by production logs on one of our self-hosted instances (BT). First warning fired 2026-07-14 at 15:38 UTC after a deploy picked up a LibreChat version past the merge of #12886. Zero automatic memory writes have landed since. The referenced example in `librechat.example.yaml` was updated in that PR, but this MDX page was missed.