### PR TITLE
Add Glif MCP server guide

### DIFF
--- a/content/docs/mcp_servers/glif.mdx
+++ b/content/docs/mcp_servers/glif.mdx
@@ -1,0 +1,30 @@
+---
+title: Glif MCP
+description: Configure Glif's hosted media-generation MCP server in LibreChat with per-user OAuth.
+---
+
+[Glif](https://glif.app) is a media-generation agent: generate images, video, and audio, transcribe, and run multi-step media workflows. Its hosted MCP server uses streamable HTTP with per-user OAuth — no API keys.
+
+## Configuration
+
+Add to `librechat.yaml`:
+
+```yaml
+mcpServers:
+  glif:
+    type: streamable-http
+    url: https://glif.app/api/mcp
+```
+
+On first use, LibreChat prompts each user to sign in with their Glif account (OAuth 2.1 with dynamic client registration — no client setup needed).
+
+## Tools
+
+`compose_project` creates or continues a media-generation project from natural language; Glif picks models and chains workflows server-side. Other tools cover project state (`get_project`, `list_projects`), media viewing (`view_media`), uploads (`upload_file`), and account info (`whoami`).
+
+Long-running generations (e.g. video) run async via MCP tasks, so chats aren't blocked while media renders.
+
+## Links
+
+- Install page and client guides: https://glif.app/mcp
+- Docs for agents: https://glif.app/llms.txt

--- a/content/docs/mcp_servers/index.mdx
+++ b/content/docs/mcp_servers/index.mdx
@@ -7,6 +7,9 @@ description: Step-by-step guides for configuring specific MCP servers in LibreCh
 Use these guides to configure specific MCP servers with the right transport, OAuth callbacks, scopes, environment variables, and LibreChat settings.
 
 <Cards num={3}>
+  <Cards.Card title="Glif MCP" href="/docs/mcp_servers/glif" arrow>
+    Configure Glif's hosted media-generation MCP server with per-user OAuth.
+  </Cards.Card>
   <Cards.Card title="Google Workspace MCP" href="/docs/mcp_servers/google_workspace" arrow>
     Configure Gmail, Drive, Calendar, People, and Chat remote MCP servers with Google OAuth.
   </Cards.Card>

--- a/content/docs/mcp_servers/meta.json
+++ b/content/docs/mcp_servers/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "MCP Servers",
   "icon": "Blocks",
-  "pages": ["index", "google_workspace", "salesforce"]
+  "pages": ["index", "glif", "google_workspace", "salesforce"]
 }


### PR DESCRIPTION
Vendor guide for Glif's hosted media-generation MCP server (streamable HTTP + per-user OAuth, no keys). Adds `glif.mdx` + meta/index entries, following the Google Workspace/Salesforce guide pattern.