### PR TITLE
fix: stop the CDN caching markdown-negotiated docs pages as HTML

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -90,6 +90,15 @@ const OG_VERSION = computeOgVersion()
  * `private, no-store` so the CDN never caches it and therefore can never serve
  * one as a document. A cached document occasionally returned to an RSC request
  * just makes Next fall back to a full navigation, which is harmless.
+ *
+ * The same collision applies to the markdown content negotiation in proxy.ts
+ * (`isMarkdownPreferred`): a `/docs/*` request with `Accept: text/markdown`
+ * (LLM/agent tooling) gets rewritten to the raw-markdown response, but that
+ * response shares its cache key with the HTML document since Cloudflare
+ * ignores `Vary` here too. Whichever one a given edge PoP sees first for a URL
+ * gets cached for it and served to everyone else hitting that PoP, including
+ * browsers, until the entry expires. Mark those responses `private, no-store`
+ * for the same reason as the RSC flight payload.
  */
 const SHARED_CDN_CACHE = 'public, s-maxage=86400, stale-while-revalidate=604800'
 const cdnCacheHeaders = [
@@ -108,6 +117,11 @@ const cdnCacheHeaders = [
   {
     source,
     has: [{ type: 'header', key: 'RSC' }],
+    headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+  },
+  {
+    source,
+    has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
     headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
   },
 ])


### PR DESCRIPTION
## Problem

`/docs/*` pages intermittently render as raw, unstyled Markdown text on a white page instead of the normal docs site, no console errors, but the response comes back `Content-Type: text/markdown; charset=utf-8`.

## Root cause

`proxy.ts` content-negotiates `/docs/*` requests: an `Accept: text/markdown` request (sent by LLM/agent tooling, not browsers) gets rewritten to the raw Markdown response (`proxy.ts:19-22`, `proxy.ts:68-72`).

`/docs/*` responses are cached at the shared CDN (Cloudflare, in front of Vercel) with `Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800`, keyed by URL only. The Markdown-negotiated response was never isolated into its own cache key, so whichever variant a given Cloudflare edge PoP saw first for a URL got served to everyone else hitting that PoP, including regular browsers, until the entry expired.

## Reproduction

1. `curl -H "Accept: text/markdown" <docs-url>?cb=<random>` -> MISS, cached as text/markdown under that URL's key.
2. `curl -H "Accept: text/html,..." <same-url>` -> HIT, still text/markdown, poisoned.
3. Loading that URL in a real browser renders the raw Markdown as the page.

Reproduced 3/3 via curl and end-to-end in a real Chromium instance via Playwright, screenshots and video attached below.

**Before (baseline):**
<img width="1280" height="800" alt="01-baseline-correct-render" src="https://github.com/user-attachments/assets/9c91fe12-86a9-4062-8f32-7e6ca112747a" />


**Before (poisoned):**
<img width="1280" height="800" alt="02-bug-raw-markdown-render" src="https://github.com/user-attachments/assets/dd0ab2de-5c11-4b66-af46-de68f16075e9" />


**Video:**

https://github.com/user-attachments/assets/f43df44e-47fa-4c2b-8d23-8f3523163fd3


**After (poisoned - but still rendering properly):**
<img width="1280" height="800" alt="01-baseline-correct-render" src="https://github.com/user-attachments/assets/9c91fe12-86a9-4062-8f32-7e6ca112747a" />


## Fix

Mirror #642: give the `Accept: text/markdown`-negotiated response its own `Cache-Control`, split out from the shared `/docs/*` rule (`next.config.mjs`), so the CDN never caches it:

```js
  {
    source,
    has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
    headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
  },
```

## Testing

Verified against a real `pnpm build` + `pnpm start` (production mode; `next dev` disables custom cache headers entirely, so it can't be used to check this):

```
$ curl -s -D - -o /dev/null "http://localhost:3333/docs/features/mcp"
Cache-Control: public, s-maxage=86400, stale-while-revalidate=604800
Content-Type: text/html; charset=utf-8

$ curl -s -D - -o /dev/null -H "Accept: text/markdown" "http://localhost:3333/docs/features/mcp"
Cache-Control: private, no-store
content-type: text/markdown; charset=utf-8
```

Not yet verified: this hasn't been exercised against a real Cloudflare deployment (preview/prod), so the closed-loop CDN behavior is an open item.
