### PR TITLE
docs: add FunASR SenseVoice STT setup

### DIFF
--- a/content/docs/configuration/stt_tts.mdx
+++ b/content/docs/configuration/stt_tts.mdx
@@ -120,15 +120,70 @@ You can specify either the full domain or just the instance name. If you provide
 
 Refer to the OpenAI Whisper section, adjusting the `url` and `model` as needed.
 
-example
-  
 ```yaml
 speech:
   stt:
     openai:
       url: 'http://host.docker.internal:8080/v1/audio/transcriptions'
       model: 'whisper'
-  ```
+```
+
+- #### FunASR with SenseVoice
+
+[FunASR](https://github.com/modelscope/FunASR) provides an OpenAI-compatible transcription endpoint. The following example uses the lightweight SenseVoice model for multilingual speech recognition, including Mandarin, Cantonese, English, Japanese, and Korean.
+
+Create a Python environment and install the server dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "funasr>=1.3.26" fastapi uvicorn python-multipart
+```
+
+Start the server on CPU:
+
+```bash
+funasr-server \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --device cpu \
+  --model sensevoice
+```
+
+The first start downloads the model. For NVIDIA GPU inference, install PyTorch and torchaudio builds that match your CUDA runtime, then use `--device cuda`.
+
+Verify the endpoint before configuring LibreChat:
+
+```bash
+curl --fail http://localhost:8000/health
+
+curl --fail http://localhost:8000/v1/audio/transcriptions \
+  -F file=@sample.wav \
+  -F model=sensevoice \
+  -F language=zh
+```
+
+A successful request returns JSON containing a `text` field.
+
+Then configure LibreChat:
+
+```yaml
+speech:
+  stt:
+    openai:
+      url: 'http://host.docker.internal:8000/v1/audio/transcriptions'
+      model: 'sensevoice'
+```
+
+FunASR does not require an API key by default. Add `apiKey` only when an authenticated reverse proxy protects the endpoint.
+
+Use the URL that matches your deployment:
+
+- LibreChat in Docker and FunASR on the Docker host: `http://host.docker.internal:8000/v1/audio/transcriptions`
+- Both processes directly on the same host: `http://127.0.0.1:8000/v1/audio/transcriptions`
+- Both services in the same Compose network: use the FunASR service name instead of `host.docker.internal`
+
+On Linux, add a `host.docker.internal:host-gateway` mapping to the LibreChat container if that hostname is not already available.
 
 
 ## TTS (Text-to-Speech)


### PR DESCRIPTION
## Summary

- add a tested FunASR/SenseVoice example to the existing OpenAI-compatible STT documentation
- document environment setup, server startup, endpoint verification, LibreChat YAML, and host/container URL choices
- clarify that the local server does not require an API key by default
- fix the adjacent OpenAI-compatible example's mis-indented closing code fence

## Why

The speech settings page already states that LibreChat supports OpenAI-compatible STT services, but it only shows a generic Whisper example. This addition gives users a reproducible self-hosted option for multilingual speech recognition, including Mandarin, Cantonese, English, Japanese, and Korean, without adding a bespoke provider to LibreChat.

## Validation

Validated after rebasing signed commit `4e726cbf645c329e74cbbbe1af14a4fa63c31adc` onto `main` at `123cfd4df61c4894d8a779264325ab2488dc32a8`:

- FunASR `1.3.27` CPU server health check: HTTP 200
- LibreChat-shaped multipart request (`file`, `model=sensevoice`, `language=zh`): HTTP 200 in 0.574s and returned `{"text":"欢迎大家来体验达摩院推出的语音识别模型"}`
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test` (21 files, 184 tests)
- `pnpm typecheck`
- `pnpm exec prettier --check content/docs/configuration/stt_tts.mdx`
- `pnpm build` (2,877 static pages generated)
- production runtime check at `/en/docs/configuration/stt_tts` for the FunASR heading, server command, OpenAI-compatible endpoint, model value, and host/container URL
- `git diff --check`

The Vercel status requires authorization from a member of the LibreChat Vercel team; the production build and runtime route pass locally at the exact PR head.
