### PR TITLE
docs: add Neon AI Gateway endpoint guide

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -18,6 +18,7 @@
     "mlx",
     "moonshot",
     "nearai",
+    "neon",
     "neurochain",
     "ollama",
     "openrouter",

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/neon.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/neon.mdx
@@ -1,0 +1,75 @@
+---
+title: Neon AI Gateway
+description: Configure Neon AI Gateway as a custom endpoint in LibreChat.
+---
+
+Neon AI Gateway is an OpenAI-compatible inference gateway provided by Neon. A single Neon credential gives you access to models from OpenAI, Google, Meta, Databricks, and Alibaba, so you do not need separate provider accounts.
+
+<Callout type="warning" title="Beta, paid plans, single region">
+
+Neon AI Gateway is in beta. It requires a paid Neon plan and is only available in the AWS US East (Ohio) region (`aws-us-east-2`), so the Neon project you use must be created there.
+
+</Callout>
+
+## Get a credential
+
+In the [Neon Console](https://console.neon.tech/), select your branch, click **Credentials** under **APP BACKEND**, then **Create credential** and check the `ai_gateway:invoke` scope. Neon shows the credential only once, so copy it before closing the dialog.
+
+You can also create one through the Neon API:
+
+```bash
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
+```
+
+Add the credential to your `.env` file:
+
+```bash filename=".env"
+NEON_AI_GATEWAY_TOKEN=nt_live_your-credential-here
+```
+
+## Find your branch host
+
+Every Neon branch has its own gateway host, so there is no single URL that covers a whole account. The Neon Console shows the host for a branch on the AI Gateway page as `NEON_AI_GATEWAY_BASE_URL`, written below as `https://<your-neon-branch-host>`. It is not the same as your database connection string.
+
+Chat completions live at `/v1/chat/completions`, so the `baseURL` is the branch host with `/v1` appended.
+
+## Configuration
+
+Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "Neon AI Gateway"
+      apiKey: "${NEON_AI_GATEWAY_TOKEN}"
+      baseURL: "https://<your-neon-branch-host>/v1"
+      models:
+        default: ["gpt-5-mini"]
+        fetch: true
+      titleConvo: true
+      titleModel: "gpt-5-mini"
+      modelDisplayLabel: "Neon"
+```
+
+To keep the host out of `librechat.yaml`, put the full URL including `/v1` in an environment variable and reference it:
+
+```yaml filename="librechat.yaml"
+      baseURL: "${NEON_GATEWAY_URL}"
+```
+
+To pin a fixed model list instead of fetching the catalog, set `fetch: false` and name the models yourself:
+
+```yaml filename="librechat.yaml"
+      models:
+        default: ["gpt-5-mini", "gemini-3-flash", "qwen3-next-80b-a3b-instruct"]
+        fetch: false
+```
+
+## Notes
+
+- Neon implements `GET /v1/models`, so `fetch: true` works and returns only the models your branch can serve. The catalog is small, so fetching it does not slow down the model list.
+- Model IDs are short, for example `gpt-5-mini`, `gemini-3-flash`, or `llama-4-maverick`. The [Neon model catalog](https://neon.com/docs/ai-gateway/models) lists context windows and pricing, and the same catalog is browsable on [Models.dev](https://models.dev/providers/neon/).
+- Because the host is per branch, add one custom endpoint per Neon branch you want to reach, each with its own `name`.
+- A `403` means the credential lacks the `ai_gateway:invoke` scope or does not cover the branch you are calling. A `429` with error code `REQUEST_LIMIT_EXCEEDED` is a Neon account quota, not a LibreChat error; check the `Retry-After` header.
+- Open-weight models are available to every project immediately, while frontier models from OpenAI and Google roll out gradually, so a model listed in the catalog may not yet be enabled on your project.


### PR DESCRIPTION
## Summary

Adds a Neon AI Gateway guide under the LibreChat YAML AI endpoints docs, plus the one sidebar entry in `ai_endpoints/meta.json`. Two files, insertion-only, no existing page or line is changed.

Neon AI Gateway is an OpenAI-compatible inference gateway, so the guide uses nothing but the `endpoints.custom` mechanism LibreChat already documents for OpenAI-compatible providers. It needs no application change, and it is modelled directly on the existing `nearai.mdx` page (#668).

The one thing that makes it different from the other custom-endpoint pages is that the gateway host is per Neon branch rather than per account, so the guide tells readers to add one custom endpoint per branch, each with its own `name`. It also covers the optional `baseURL: "${NEON_GATEWAY_URL}"` form, which works because `endpoints.custom` runs both `apiKey` and `baseURL` through `extractEnvVariable`.

`fetch: true` is used in the main example because the gateway implements `GET /v1/models`.

Two small choices worth flagging:

- **Placeholder host.** Every Neon branch host is different, so the example uses `https://<your-neon-branch-host>` rather than a real-looking hostname, matching the existing `azure.mdx` placeholder style. It sits inside code fences everywhere it appears so MDX does not read it as JSX.
- **No `icon:` frontmatter key.** I did not add a provider icon component. `resolveIcon` returns `undefined` for a missing key, so the sidebar entry degrades to text rather than breaking. Happy to add an icon in this PR if you would prefer the page to match its siblings.

## Testing

Both CI jobs were reproduced locally on this branch:

- `pnpm install --frozen-lockfile` (lockfile unchanged)
- `pnpm exec fumadocs-mdx`
- `pnpm lint:prettier` — pass
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm test` — 184 tests in 21 files pass
- `pnpm build` — pass; the page is prerendered at `/en/docs/configuration/librechat_yaml/ai_endpoints/neon` and its `llms.mdx` route
- `pnpm exec playwright test` — 23 passed
- `lychee` with the exact arguments from `.github/workflows/links.yml` — 3 links, 3 OK
- Rendered the built page and confirmed the sidebar entry lands alphabetically between NEAR AI Cloud and NeurochainAI

## Caveats

- **No live end-to-end run.** I have not driven a real LibreChat instance against a Neon branch. The configuration is verified against LibreChat's own source for the custom-endpoint path and against Neon's published documentation, not against a live chat session.
- **Not a full-feature claim.** The page documents chat completions and model listing, and deliberately claims nothing about embeddings, tool calling, structured output, or image generation. In particular, LibreChat's RAG API is a separate service with its own embeddings provider, which this endpoint does not cover; say the word if you would like an explicit sentence about that on the page.

## Translations

English only. Per the README, `.mdx` is the source of truth and the locale files are generated, so I have left the translations to the `pnpm translate` workflow rather than hand-writing them.
