### PR TITLE
fix: prevent docs hydration mismatch (#707)

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,7 +1,7 @@
-import type { NextRequest } from 'next/server'
+import { NextRequest, type NextFetchEvent } from 'next/server'
 import { describe, expect, it } from 'vitest'
 import { LOCALIZED_HOME_LOCALES, LOCALE_COOKIE } from '@/lib/i18n'
-import { preferredLocale } from '../proxy'
+import proxy, { preferredLocale } from '../proxy'
 
 function requestWithPreferences({
   cookie,
@@ -43,5 +43,54 @@ describe('preferredLocale', () => {
     })
 
     expect(preferredLocale(request, LOCALIZED_HOME_LOCALES)).toBe('fr')
+  })
+})
+
+describe('docs proxy routing', () => {
+  const event = {} as NextFetchEvent
+
+  async function runProxy(path: string, headers?: HeadersInit): Promise<Response> {
+    const response = await proxy(
+      new NextRequest(`https://www.librechat.ai${path}`, { headers }),
+      event,
+    )
+    if (!response) throw new Error(`Proxy returned no response for ${path}`)
+    return response
+  }
+
+  it('passes browser requests for the explicit English route through unchanged', async () => {
+    const response = await runProxy('/docs/local/docker', { accept: 'text/html' })
+
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+  })
+
+  it('preserves content negotiation for raw Markdown', async () => {
+    const response = await runProxy('/docs/local/docker', { accept: 'text/markdown' })
+
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://www.librechat.ai/llms.mdx/docs/local/docker',
+    )
+  })
+
+  it('leaves explicit .md routes for the Next.js raw Markdown rewrite', async () => {
+    const response = await runProxy('/docs/local/docker.md', { accept: 'text/markdown' })
+
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+  })
+
+  it('redirects the prefixed default locale to the canonical English URL', async () => {
+    const response = await runProxy('/en/docs/quick_start')
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://www.librechat.ai/docs/quick_start')
+  })
+
+  it('passes localized docs routes through with their visible prefix', async () => {
+    const response = await runProxy('/it/docs/translation')
+
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
   })
 })

--- a/app/[lang]/docs/[[...slug]]/page.ts
+++ b/app/[lang]/docs/[[...slug]]/page.ts
@@ -1,0 +1,17 @@
+import { generateDocsMetadata, generateLocalizedDocsParams, renderDocsPage } from '@/lib/docs-page'
+
+interface PageProps {
+  params: Promise<{ lang: string; slug?: string[] }>
+}
+
+export default async function Page({ params }: PageProps) {
+  return renderDocsPage(await params)
+}
+
+export function generateStaticParams() {
+  return generateLocalizedDocsParams()
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  return generateDocsMetadata(await params)
+}

--- a/app/[lang]/docs/layout.ts
+++ b/app/[lang]/docs/layout.ts
@@ -1,0 +1,13 @@
+import { renderDocsLayout } from '@/lib/docs-layout'
+import type { ReactNode } from 'react'
+
+export default async function Layout({
+  params,
+  children,
+}: {
+  params: Promise<{ lang: string }>
+  children: ReactNode
+}) {
+  const { lang } = await params
+  return renderDocsLayout({ lang, children })
+}

--- a/app/docs/[[...slug]]/page.ts
+++ b/app/docs/[[...slug]]/page.ts
@@ -1,0 +1,20 @@
+import { generateDocsMetadata, generateEnglishDocsParams, renderDocsPage } from '@/lib/docs-page'
+import { i18n } from '@/lib/i18n'
+
+interface PageProps {
+  params: Promise<{ slug?: string[] }>
+}
+
+export default async function Page({ params }: PageProps) {
+  const { slug } = await params
+  return renderDocsPage({ lang: i18n.defaultLanguage, slug })
+}
+
+export function generateStaticParams() {
+  return generateEnglishDocsParams()
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params
+  return generateDocsMetadata({ lang: i18n.defaultLanguage, slug })
+}

--- a/app/docs/layout.ts
+++ b/app/docs/layout.ts
@@ -1,0 +1,7 @@
+import { i18n } from '@/lib/i18n'
+import { renderDocsLayout } from '@/lib/docs-layout'
+import type { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return renderDocsLayout({ lang: i18n.defaultLanguage, children })
+}

--- a/e2e/docs-hydration.spec.ts
+++ b/e2e/docs-hydration.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const hydrationError =
+  /(?:Minified React error #418|Hydration failed|hydration mismatch|server rendered HTML didn't match|text content does not match server-rendered HTML)/i
+
+function collectHydrationErrors(page: Page): string[] {
+  const errors: string[] = []
+
+  page.on('pageerror', (error) => {
+    if (hydrationError.test(error.message)) errors.push(error.message)
+  })
+  page.on('console', (message) => {
+    if (message.type() === 'error' && hydrationError.test(message.text())) {
+      errors.push(message.text())
+    }
+  })
+
+  return errors
+}
+
+test.describe('docs hydration', () => {
+  for (const path of ['/docs/quick_start', '/docs/local/docker', '/it/docs/translation'] as const) {
+    test(`${path} hydrates with matching navigation state`, async ({ page }) => {
+      const errors = collectHydrationErrors(page)
+
+      await page.goto(path)
+      await expect(page.locator('#nd-page')).toBeVisible()
+
+      // The breadcrumb and active sidebar item both depend on usePathname().
+      // Their post-hydration state therefore catches the original internal
+      // /en/docs/* versus public /docs/* pathname mismatch directly.
+      await expect(page.locator(`#nd-page > div:first-child a[href="${path}"]`)).toBeVisible()
+      await expect(page.locator(`#nd-sidebar a[href="${path}"][data-active="true"]`)).toBeAttached()
+
+      const canonical = await page.locator('link[rel="canonical"]').getAttribute('href')
+      expect(canonical).toBeTruthy()
+      expect(new URL(canonical!, page.url()).pathname).toBe(path)
+      expect(canonical).not.toContain('/en/docs')
+
+      // Allow effects and queued console events to flush before checking.
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+          }),
+      )
+      expect(errors).toEqual([])
+    })
+  }
+
+  test('sitemap contains canonical English docs URLs only', async ({ request }) => {
+    const indexResponse = await request.get('/sitemap.xml')
+    expect(indexResponse.ok()).toBe(true)
+
+    const documents = [await indexResponse.text()]
+    const sitemapUrls = Array.from(
+      documents[0].matchAll(/<loc>([^<]*\/sitemap-[^<]+\.xml)<\/loc>/g),
+      (match) => match[1],
+    )
+
+    for (const url of sitemapUrls) {
+      // The generated sitemap uses production absolute URLs. Keep the check on
+      // the local production build instead of accidentally querying the live site.
+      const response = await request.get(new URL(url).pathname)
+      expect(response.ok()).toBe(true)
+      documents.push(await response.text())
+    }
+
+    const sitemap = documents.join('\n')
+    expect(sitemap).toContain('/docs/quick_start')
+    expect(sitemap).not.toMatch(/\/en\/docs(?:\/|<)/)
+  })
+})

--- a/lib/docs-layout.tsx
+++ b/lib/docs-layout.tsx
@@ -1,3 +1,5 @@
+import 'server-only'
+
 import { DocsLayout } from 'fumadocs-ui/layouts/docs'
 import { DocsI18nProvider } from '@/components/DocsI18nProvider'
 import { docsSource } from '@/lib/source'
@@ -8,14 +10,7 @@ import { getUI } from '@/lib/ui-i18n'
 import { VersionSwitcher } from '@/components/VersionSwitcher'
 import type { ReactNode } from 'react'
 
-export default async function Layout({
-  params,
-  children,
-}: {
-  params: Promise<{ lang: string }>
-  children: ReactNode
-}) {
-  const { lang } = await params
+export function renderDocsLayout({ lang, children }: { lang: string; children: ReactNode }) {
   const tree = docsSource.pageTree[lang] ?? docsSource.pageTree[i18n.defaultLanguage]
   const t = getUI(lang)
   const docsHref = localizedDocsHref('/docs', lang)

--- a/lib/docs-page.tsx
+++ b/lib/docs-page.tsx
@@ -1,42 +1,52 @@
-import { docsSource } from '@/lib/source'
-import { mdxComponents } from '@/lib/mdx-components'
+import 'server-only'
+
 import { DocsHub } from '@/components/DocsHub'
-import { QuickStartHub } from '@/components/QuickStartHub'
 import { FeaturesHub } from '@/components/FeaturesHub'
-import { LocalInstallHub } from '@/components/LocalInstallHub'
-import { CredentialsGeneratorMDX } from '@/components/tools/CredentialsGeneratorMDX'
-import { YAMLValidatorMDX } from '@/components/tools/YAMLValidatorMDX'
-import { DocsPage, DocsBody, DocsTitle, DocsDescription } from 'fumadocs-ui/page'
-import { notFound, redirect } from 'next/navigation'
-import { LLMCopyButton, ViewOptions } from '@/components/page-actions'
 import { Feedback } from '@/components/Feedback'
 import { JsonLd } from '@/components/JsonLd'
-import { articleSchema, breadcrumbSchema } from '@/lib/structured-data'
-import { ogImageUrl } from '@/lib/og'
+import { LocalInstallHub } from '@/components/LocalInstallHub'
 import { MachineTranslatedBanner } from '@/components/MachineTranslatedBanner'
+import { QuickStartHub } from '@/components/QuickStartHub'
+import { LLMCopyButton, ViewOptions } from '@/components/page-actions'
+import { CredentialsGeneratorMDX } from '@/components/tools/CredentialsGeneratorMDX'
+import { YAMLValidatorMDX } from '@/components/tools/YAMLValidatorMDX'
 import { i18n, localizedDocsHref } from '@/lib/i18n'
+import { mdxComponents } from '@/lib/mdx-components'
+import { ogImageUrl } from '@/lib/og'
+import { docsSource } from '@/lib/source'
+import { articleSchema, breadcrumbSchema } from '@/lib/structured-data'
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page'
+import { notFound, redirect } from 'next/navigation'
 import type { Metadata } from 'next'
 
-interface PageProps {
-  params: Promise<{ lang: string; slug?: string[] }>
+export interface DocsRouteParams {
+  lang: string
+  slug?: string[]
 }
 
-export default async function Page(props: PageProps) {
-  const params = await props.params
+function englishDocsHref(slug?: string[]): string {
+  const slugPath = (slug ?? []).join('/')
+  return slugPath ? `/docs/${slugPath}` : '/docs'
+}
+
+function isRealTranslation(lang: string, path: string): boolean {
+  return lang !== i18n.defaultLanguage && path.endsWith(`.${lang}.mdx`)
+}
+
+export async function renderDocsPage(params: DocsRouteParams) {
   const page = docsSource.getPage(params.slug, params.lang)
   if (!page) notFound()
 
-  const slugPath = (params.slug ?? []).join('/')
-  const englishHref = slugPath ? `/docs/${slugPath}` : '/docs'
+  const englishHref = englishDocsHref(params.slug)
 
-  // generateStaticParams omits non-default locales without a translated file, but
+  // generateLocalizedDocsParams omits locales without a translated file, but
   // dynamicParams defaults to true, and the Fumadocs sidebar still emits
   // /<locale>/docs/* links for untranslated slugs (its node url uses the locale
   // even when the file resolves to the English fallback). Redirect such URLs to the
   // English page: no duplicate English content at a localized URL, and the sidebar
   // links resolve instead of 404ing. A real translation (path ends .<locale>.mdx)
   // renders normally.
-  if (params.lang !== i18n.defaultLanguage && !page.path.endsWith(`.${params.lang}.mdx`)) {
+  if (params.lang !== i18n.defaultLanguage && !isRealTranslation(params.lang, page.path)) {
     redirect(englishHref)
   }
 
@@ -55,13 +65,10 @@ export default async function Page(props: PageProps) {
     YAMLValidatorMDX: () => <YAMLValidatorMDX lang={params.lang} />,
   }
 
-  // Fumadocs 14.7.7 falls back to the English page for a non-default locale that
-  // has no foo.<locale>.mdx yet, so getPage alone can't tell a real translation
-  // from a fallback. A real translation's file path ends in `.<locale>.mdx`; a
-  // fallback ends in plain `.mdx`. Gate the banner (and the hreflang alternates
-  // below) on that so untranslated English fallbacks aren't treated as translated.
-  const isTranslated =
-    params.lang !== i18n.defaultLanguage && page.path.endsWith(`.${params.lang}.mdx`)
+  // Fumadocs falls back to the English page for a non-default locale that has
+  // no foo.<locale>.mdx yet. Gate the banner (and the hreflang alternates below)
+  // on the generated file suffix so English fallbacks aren't treated as translated.
+  const isTranslated = isRealTranslation(params.lang, page.path)
 
   // On localized pages page.path is the generated locale file (foo.de.mdx).
   // Point all GitHub links at the English source instead: the locale file is
@@ -69,14 +76,14 @@ export default async function Page(props: PageProps) {
   // excluded from the workflow trigger, so edits made directly to it are silently
   // overwritten. Fixing the source is the durable way to improve a translation.
   const localeSuffix = new RegExp(
-    `\\.(${i18n.languages.filter((l) => l !== i18n.defaultLanguage).join('|')})\\.mdx$`,
+    `\\.(${i18n.languages.filter((lang) => lang !== i18n.defaultLanguage).join('|')})\\.mdx$`,
   )
   const sourcePath = page.path.replace(localeSuffix, '.mdx')
   const githubHref = `https://github.com/LibreChat-AI/librechat.ai/blob/main/content/docs/${sourcePath}`
 
   // `lastModified` is populated only when a git last-modified loader option is
   // enabled (this site doesn't), so it's optional and absent from the strict
-  // fumadocs 16 data type — read it defensively.
+  // fumadocs data type — read it defensively.
   const lastModifiedRaw = (page.data as { lastModified?: Date | string }).lastModified
   const lastModified =
     lastModifiedRaw instanceof Date ? lastModifiedRaw.toISOString() : lastModifiedRaw
@@ -124,8 +131,7 @@ export default async function Page(props: PageProps) {
           Raw Markdown is only served for the English /docs/*.md route (see the
           next.config rewrite + proxy passthrough); a localized /<locale>/docs/*.md
           URL would 404. Point these at the English source so Copy Markdown / Open
-          in LibreChat work on translated pages too. For English pages englishHref
-          equals page.url, so this is unchanged there.
+          in LibreChat work on translated pages too.
         */}
         <LLMCopyButton markdownUrl={`${englishHref}.md`} lang={params.lang} />
         <ViewOptions markdownUrl={`${englishHref}.md`} githubUrl={githubHref} lang={params.lang} />
@@ -145,27 +151,33 @@ export default async function Page(props: PageProps) {
   )
 }
 
-export async function generateStaticParams() {
-  // Fumadocs emits one param set per page for EVERY language even when no
+export function generateEnglishDocsParams() {
+  return docsSource
+    .generateParams()
+    .filter((params) => params.lang === i18n.defaultLanguage)
+    .map(({ slug }) => ({ slug }))
+}
+
+export function generateLocalizedDocsParams() {
+  // Fumadocs emits one param set per page for every language even when no
   // localized file exists (getPage falls back to English). Materializing those
-  // would publish hundreds of duplicate-English pages at /<locale>/docs/* and
-  // list them in the sitemap. Keep the default language plus only locales that
-  // have a real translated file on disk (same discriminator as the hreflang gate).
-  return docsSource.generateParams().filter((p) => {
-    if (p.lang === i18n.defaultLanguage) return true
-    return docsSource.getPage(p.slug, p.lang)?.path.endsWith(`.${p.lang}.mdx`) ?? false
+  // would publish duplicate-English pages at /<locale>/docs/* and in the sitemap.
+  return docsSource.generateParams().filter((params) => {
+    if (params.lang === i18n.defaultLanguage) return false
+    return (
+      docsSource.getPage(params.slug, params.lang)?.path.endsWith(`.${params.lang}.mdx`) ?? false
+    )
   })
 }
 
-export async function generateMetadata(props: PageProps): Promise<Metadata> {
-  const params = await props.params
+export async function generateDocsMetadata(params: DocsRouteParams): Promise<Metadata> {
   const page = docsSource.getPage(params.slug, params.lang)
   if (!page) notFound()
-  // Match Page(): a non-default locale resolving to an English fallback redirects
-  // to the English page, so don't emit metadata for a URL that won't render here.
-  if (params.lang !== i18n.defaultLanguage && !page.path.endsWith(`.${params.lang}.mdx`)) {
-    const slugPath = (params.slug ?? []).join('/')
-    redirect(slugPath ? `/docs/${slugPath}` : '/docs')
+
+  // Match renderDocsPage(): a non-default locale resolving to an English
+  // fallback redirects to its canonical English page.
+  if (params.lang !== i18n.defaultLanguage && !isRealTranslation(params.lang, page.path)) {
+    redirect(englishDocsHref(params.slug))
   }
 
   return {
@@ -174,10 +186,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     alternates: {
       canonical: page.url,
       // Only advertise an hreflang alternate for locales that actually have a
-      // translated file. getPage falls back to the English page for a missing
-      // locale, so check the resolved file path ends in `.<locale>.mdx` instead
-      // of just truthiness, to avoid pointing crawlers at English-fallback
-      // alternates for skipped / not-yet-translated pages.
+      // translated file. getPage falls back to English for a missing locale.
       languages: Object.fromEntries(
         i18n.languages
           .filter((locale) => {
@@ -189,9 +198,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
             const slugPath = (params.slug ?? []).join('/')
             const href =
               locale === i18n.defaultLanguage
-                ? slugPath
-                  ? `/docs/${slugPath}`
-                  : '/docs'
+                ? englishDocsHref(params.slug)
                 : slugPath
                   ? `/${locale}/docs/${slugPath}`
                   : `/${locale}/docs`

--- a/proxy.ts
+++ b/proxy.ts
@@ -97,10 +97,18 @@ export default function proxy(request: NextRequest, event: NextFetchEvent) {
     return response
   }
 
-  // Locale detection + default-locale rewriting for the docs.
+  // English docs have an explicit prefix-less route. Let Next.js render the
+  // same public pathname on the server and client so Fumadocs pathname-based
+  // state (breadcrumbs and active sidebar items) hydrates deterministically.
+  if (pathname === '/docs' || pathname.startsWith('/docs/')) {
+    return NextResponse.next()
+  }
+
+  // Localized docs keep their visible locale prefix. The middleware also
+  // canonicalizes the default locale from /en/docs/* back to /docs/*.
   return i18nMiddleware(request, event)
 }
 
 export const config = {
-  matcher: ['/', '/docs/:path*', '/(zh|es|fr|de|ja|pt-BR|it|nl|pl|vi|ko|id|tr)/docs/:path*'],
+  matcher: ['/', '/docs/:path*', '/(en|zh|es|fr|de|ja|pt-BR|it|nl|pl|vi|ko|id|tr)/docs/:path*'],
 }


### PR DESCRIPTION
## Summary

Fixes a hydration mismatch between server and client on docs pages. The middleware was internally rewriting `/docs/*` requests to `/en/docs/*`, but Fumadocs breadcrumbs and active sidebar items depend on `usePathname()` to match the public URL. This caused the client to render at `/docs/*` while the server rendered at `/en/docs/*`, breaking hydration.

## Changes

- **Middleware**: Pass through `/docs/*` routes unchanged instead of rewriting them internally. Redirect `/en/docs/*` to canonical `/docs/*` for backward compatibility. Updated matcher to include `en`.
- **Route files**: Add explicit route handlers for both English (`app/docs/`) and localized (`app/[lang]/docs/`) paths that delegate to shared rendering functions.
- **Shared rendering**: Extract page and layout rendering logic to `lib/docs-page.tsx` and `lib/docs-layout.tsx`. These handle locale-specific state (component bindings, fallbacks to English for untranslated pages, hreflang alternates).
- **Tests**: Add unit tests for proxy routing behavior and e2e tests to verify hydration succeeds with matching breadcrumbs, sidebar state, and canonical URLs.

## How it works

English docs now render deterministically at `/docs/*` on both server and client. Localized docs at `/<locale>/docs/*` keep their visible locale prefix. The middleware canonicalizes `/en/docs/*` back to `/docs/*` so untranslated pages don't create duplicate content at localized URLs.