### PR TITLE
ci: selective Cloudflare cache purge on production deploy

### DIFF
--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -114,8 +114,12 @@ env:
   # second between calls keeps us under every per-second bucket, and 429s are
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
-  # Commit-status context marking "the cache was successfully purged for this
-  # SHA". The next run's baseline is the newest deployment carrying it.
+  # Commit-status context marking "the cache was successfully purged". The real
+  # context carries the deployment id — `cache-purge/12345` — because a SHA is
+  # not a unique key: a rollback redeploys one that was already purged. Ordering
+  # by timestamp is not enough either, since an earlier deployment's overlapping
+  # purge can post its marker after a later deployment was created. The id is
+  # the only thing that identifies which deployment a marker belongs to.
   PURGE_STATUS_CONTEXT: cache-purge
   # How far back to look for the last purged Vercel release. One page is 100
   # deployments, which on this repo is ~3.3 days because translate_docs.yml
@@ -276,7 +280,7 @@ jobs:
                         | select(.creator.login == $creator)
                         | select(.id < $current)
                       ][]
-                      | "\(.id) \(.sha) \(.created_at)"' <<< "$deployments")
+                      | "\(.id) \(.sha)"' <<< "$deployments")
             # The baseline is the last commit we actually PURGED, not merely the
             # last one deployed. If B's purge fails or is cancelled and C then
             # deploys, taking B as the baseline would compute B..C and leave
@@ -284,7 +288,7 @@ jobs:
             # would ever revisit it. Walking back to the newest deployment
             # carrying the `PURGE_STATUS_CONTEXT` commit status makes the next
             # run absorb the failed one's range: the diff widens to A..C.
-              while read -r id sha created; do
+              while read -r id sha; do
                 [ -n "$id" ] || continue
                 [ -z "$base" ] || break
                 [ "$sha" = "$head" ] && continue
@@ -298,16 +302,10 @@ jobs:
                 succeeded=$(gh api "repos/$REPO/deployments/$id/statuses" \
                   --jq '[.[] | select(.state == "success")] | length')
                 [ "${succeeded:-0}" -gt 0 ] || continue
-                # The marker must post-date THIS deployment, not merely exist on
-                # the commit. A rollback redeploys a SHA that was purged the first
-                # time round; if the rollback's own purge fails, an undated check
-                # would accept its stale marker and the next run would diff from a
-                # build whose cache was never cleared. GitHub timestamps are UTC
-                # ISO-8601, so a lexicographic compare is a chronological one.
+                # Keyed to this deployment, not just this commit.
                 purged=$(gh api "repos/$REPO/commits/$sha/statuses" \
-                  --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\"
-                                      and .state == \"success\"
-                                      and .created_at > \"$created\")] | length")
+                  --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT/$id\"
+                                      and .state == \"success\")] | length")
                 if [ "${purged:-0}" -gt 0 ]; then
                   base="$sha"
                   echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
@@ -390,44 +388,32 @@ jobs:
             # --name-status because add/delete are not equivalent to modify here:
             # they reshape the page tree and the locale map that every docs page
             # renders, so the mapper widens the purge for them.
-            # core.quotepath=false, or git C-quotes any non-ASCII path:
-            # `public/images/café.png` arrives as `"public/images/caf\303\251.png"`,
-            # which matches no rule, so the asset URL is never purged even though
-            # the mapper handles Unicode correctly. A name containing a quote or
-            # backslash is still quoted, and that is caught below rather than
-            # silently mismapped.
-            git -c core.quotepath=false diff --name-status --no-renames \
-              "$BASE" "$HEAD" > changed.tsv
+            # -z, not the default text format. Git prints pathnames verbatim
+            # under it, so there is no C-quoting to decode and no whitespace to
+            # tell apart from a delimiter — the two things that silently
+            # mismapped `café.png` and `logo.png ` before. NUL cannot occur in a
+            # filename, so the framing is unambiguous by construction.
+            #
+            # --no-renames keeps a move reported as delete + add: git's rename
+            # detection would otherwise name only the destination and the old URL
+            # would never be purged. --name-status because add/delete reshape the
+            # page tree and locale map that every docs page renders.
+            git diff --name-status -z --no-renames "$BASE" "$HEAD" > changed.z
 
-            # Frontmatter `title:`/`icon:` populate the page-tree node that the
-            # sidebar draws on *every* docs page, so editing one is structural
-            # even though git calls it a plain M. -G selects files whose patch
-            # adds or removes a line matching the regex, which is exactly the
-            # set we need and one extra git call. It also matches a `title:` at
-            # the start of a line inside a fenced code block in the body: that
-            # over-purges to the docs root, which is safe.
-            git -c core.quotepath=false diff --name-only --no-renames -G'^(title|icon):' \
-              "$BASE" "$HEAD" -- content/docs > tree-edits.txt || : > tree-edits.txt
-
-            # Anything still quoted holds a character git cannot render plainly.
-            # Mapping it would silently under-purge, so stop instead.
-            if cut -f2- changed.tsv | grep -q '^"'; then
-              echo "::error::Changed path needs C-quoting, which this mapper cannot parse:" >&2
-              cut -f2- changed.tsv | grep '^"' >&2
-              exit 1
-            fi
-
-            # getline in BEGIN, not the NR==FNR idiom: with an empty first file
-            # that idiom misreads the first line of the second file.
-            awk -F'\t' -v treefile=tree-edits.txt '
-              BEGIN { while ((getline line < treefile) > 0) tree[line] = 1 }
-              { status = $1; file = $NF
-                if (status == "M" && (file in tree)) status = "T"
-                print status "\t" file }' changed.tsv > changed.marked.tsv
-            mv changed.marked.tsv changed.tsv
+            # Frontmatter title/icon populate the page-tree node the sidebar
+            # draws on every docs page, so editing one is structural even though
+            # git calls it M. -G selects files whose patch touches such a line.
+            # It also matches a `title:` opening a line inside a fenced code
+            # block, which over-purges to the docs root: safe.
+            #
+            # The mapper pairs this with the diff. Doing it there rather than in
+            # awk is not a preference: ubuntu-latest's awk is mawk, which does
+            # not handle a NUL record separator.
+            git diff --name-only -z --no-renames -G'^(title|icon):' \
+              "$BASE" "$HEAD" -- content/docs > tree-edits.z || : > tree-edits.z
 
             echo "Changed files ($BASE..$HEAD):"
-            sed 's/^/  /' changed.tsv
+            tr '\0' '\n' < changed.z | paste - - | sed 's/^/  /'
 
             # A locale removed in this deploy is absent from the deployed
             # lib/i18n.ts, so the mapper would never emit its prefixes. Give it
@@ -436,7 +422,8 @@ jobs:
             [ -s base-i18n.ts ] && export BASE_I18N_FILE=base-i18n.ts
 
             # shellcheck disable=SC2086 # broad_flag is intentionally unquoted: empty means no flag.
-            node scripts/cache-purge-prefixes.mjs - --json --explain $broad_flag < changed.tsv > purge.json
+            TREE_EDITS_FILE=tree-edits.z \
+              node scripts/cache-purge-prefixes.mjs - --json --explain $broad_flag < changed.z > purge.json
           fi
 
           jq -r '.prefixes[]' purge.json > prefixes.txt
@@ -618,12 +605,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.deployment.sha }}
+          DEPLOYMENT_ID: ${{ github.event.deployment.id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           gh api -X POST "repos/$REPO/statuses/$SHA" \
             -f state=success \
-            -f context="$PURGE_STATUS_CONTEXT" \
+            -f context="$PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID" \
             -f target_url="$RUN_URL" \
             -f description="Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
             > /dev/null

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -59,8 +59,8 @@ on:
   # a failed run, or any deploy that produced no deployment event.
   workflow_dispatch:
     inputs:
-      broad:
-        description: 'Purge the broad set (all top-level prefixes) instead of a diff'
+      broad_pages:
+        description: 'Purge every cached page prefix, not just the ones a diff points at'
         type: boolean
         default: true
       dry_run:
@@ -68,7 +68,7 @@ on:
         type: boolean
         default: false
       range:
-        description: 'With broad=false: commit range to map, e.g. abc1234..def5678'
+        description: 'Commit range, e.g. abc1234..def5678. Required unless broad_pages is set; supply it WITH broad_pages to also purge changed asset URLs and removed locales.'
         type: string
         required: false
 
@@ -77,6 +77,9 @@ permissions:
   # Reading the previous successful production deployment, to know where the
   # diff starts.
   deployments: read
+  # Writing the "this commit was purged" marker that the next run baselines
+  # from, so a failed purge is retried rather than skipped past.
+  statuses: write
 
 # Keyed per deployment, NOT a single shared group. GitHub keeps at most one
 # pending run per concurrency group: "any existing pending job or workflow in the
@@ -111,6 +114,9 @@ env:
   # second between calls keeps us under every per-second bucket, and 429s are
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
+  # Commit-status context marking "the cache was successfully purged for this
+  # SHA". The next run's baseline is the newest deployment carrying it.
+  PURGE_STATUS_CONTEXT: cache-purge
 
 jobs:
   purge:
@@ -152,26 +158,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
-          INPUT_BROAD: ${{ inputs.broad }}
+          INPUT_BROAD: ${{ inputs.broad_pages }}
           INPUT_RANGE: ${{ inputs.range }}
           HEAD_SHA: ${{ github.event.deployment.sha }}
           DEPLOYMENT_ID: ${{ github.event.deployment.id }}
           REPO: ${{ github.repository }}
           # Only deployments from the Vercel integration count as live releases.
           VERCEL_CREATOR: 'vercel[bot]'
+          PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
         run: |
           set -euo pipefail
 
           emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
 
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            if [ "$INPUT_BROAD" = "true" ]; then
-              echo "Manual dispatch: broad purge requested."
+            if [ "$INPUT_BROAD" = "true" ] && [ -z "${INPUT_RANGE:-}" ]; then
+              # Pages only. Cannot reach changed asset URLs or a locale that was
+              # removed, because both are discovered from a diff — supply a range
+              # as well to recover those.
+              echo "Manual dispatch: broad page purge, no range given."
+              echo "::warning::No range supplied: changed asset URLs and removed locales cannot be discovered."
               emit mode broad
               exit 0
             fi
             if [ -z "${INPUT_RANGE:-}" ]; then
-              echo "::error::broad=false requires a 'range' input (e.g. abc1234..def5678)."
+              echo "::error::broad_pages=false requires a 'range' input (e.g. abc1234..def5678)."
               exit 1
             fi
             # Constrain the shape before it reaches git, so a value like
@@ -217,19 +228,31 @@ jobs:
                       | select(.id < $current)
                     ][0:40][]
                     | "\(.id) \(.sha)"' <<< "$deployments")
+            # The baseline is the last commit we actually PURGED, not merely the
+            # last one deployed. If B's purge fails or is cancelled and C then
+            # deploys, taking B as the baseline would compute B..C and leave
+            # everything unique to A..B stale forever, with no run left that
+            # would ever revisit it. Walking back to the newest deployment
+            # carrying the `PURGE_STATUS_CONTEXT` commit status makes the next
+            # run absorb the failed one's range: the diff widens to A..C.
             while read -r id sha; do
               [ -n "$id" ] || continue
               [ "$sha" = "$head" ] && continue
               state=$(gh api "repos/$REPO/deployments/$id/statuses?per_page=1" --jq '.[0].state // ""')
-              if [ "$state" = "success" ]; then
+              [ "$state" = "success" ] || continue
+              purged=$(gh api "repos/$REPO/commits/$sha/statuses" \
+                --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\" and .state == \"success\")] | length")
+              if [ "${purged:-0}" -gt 0 ]; then
                 base="$sha"
-                echo "Previous successful Vercel production deployment: $sha (deployment $id)"
+                echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
                 break
               fi
+              echo "Skipping $sha (deployment $id): deployed, but never purged successfully."
             done <<< "$ids"
 
             if [ -z "$base" ]; then
-              echo "::warning::No earlier successful Vercel production deployment found; purging broadly."
+              # Also the first-ever run, when no commit carries the marker yet.
+              echo "::warning::No earlier successfully purged deployment found; purging broadly."
               emit mode broad
               exit 0
             fi
@@ -248,7 +271,12 @@ jobs:
             exit 0
           fi
 
-          emit mode diff
+          if [ "$EVENT" = "workflow_dispatch" ] && [ "$INPUT_BROAD" = "true" ]; then
+            # Broad page coverage, topped up from the range.
+            emit mode broad
+          else
+            emit mode diff
+          fi
           emit base "$base"
           emit head "$head"
 
@@ -264,9 +292,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$MODE" = "broad" ]; then
+          # Broad with no range: pages only, nothing a diff would have revealed.
+          if [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
             node scripts/cache-purge-prefixes.mjs --broad --json > purge.json
           else
+            # Broad *with* a range still walks the diff, so the broad page set is
+            # topped up with changed asset URLs and locales removed in the range.
+            broad_flag=""
+            [ "$MODE" = "broad" ] && broad_flag="--broad"
             # --no-renames is load-bearing. Git's rename detection is on by
             # default, and it reports a moved file as its destination alone, so
             # a page moved without edits would never have its old URL purged and
@@ -306,7 +339,8 @@ jobs:
             git show "$BASE:lib/i18n.ts" > base-i18n.ts 2>/dev/null || rm -f base-i18n.ts
             [ -s base-i18n.ts ] && export BASE_I18N_FILE=base-i18n.ts
 
-            node scripts/cache-purge-prefixes.mjs - --json --explain < changed.tsv > purge.json
+            # shellcheck disable=SC2086 # broad_flag is intentionally unquoted: empty means no flag.
+            node scripts/cache-purge-prefixes.mjs - --json --explain $broad_flag < changed.tsv > purge.json
           fi
 
           jq -r '.prefixes[]' purge.json > prefixes.txt
@@ -474,3 +508,26 @@ jobs:
           purge_all files files.txt
 
           echo "::notice::Cloudflare purge complete."
+
+      # Only reached when every call above succeeded, because `set -e` plus
+      # purge_call's non-zero return aborts the step otherwise. That is the
+      # point: the marker means "the cache is known-good at this SHA", and the
+      # next run picks its baseline from the newest deployment carrying one. A
+      # run that fails leaves no marker, so the following run's diff widens to
+      # include this one's range instead of stepping over it.
+      - name: Record the purge against this commit
+        if: ${{ !inputs.dry_run && steps.compute.outputs.count != '0' && github.event_name == 'deployment_status' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.deployment.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
+            -f state=success \
+            -f context="$PURGE_STATUS_CONTEXT" \
+            -f target_url="$RUN_URL" \
+            -f description="Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
+            > /dev/null
+          echo "Marked $SHA as purged."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -277,8 +277,35 @@ jobs:
             # they reshape the page tree and the locale map that every docs page
             # renders, so the mapper widens the purge for them.
             git diff --name-status --no-renames "$BASE" "$HEAD" > changed.tsv
+
+            # Frontmatter `title:`/`icon:` populate the page-tree node that the
+            # sidebar draws on *every* docs page, so editing one is structural
+            # even though git calls it a plain M. -G selects files whose patch
+            # adds or removes a line matching the regex, which is exactly the
+            # set we need and one extra git call. It also matches a `title:` at
+            # the start of a line inside a fenced code block in the body: that
+            # over-purges to the docs root, which is safe.
+            git diff --name-only --no-renames -G'^(title|icon):' "$BASE" "$HEAD" \
+              -- content/docs > tree-edits.txt || : > tree-edits.txt
+
+            # getline in BEGIN, not the NR==FNR idiom: with an empty first file
+            # that idiom misreads the first line of the second file.
+            awk -F'\t' -v treefile=tree-edits.txt '
+              BEGIN { while ((getline line < treefile) > 0) tree[line] = 1 }
+              { status = $1; file = $NF
+                if (status == "M" && (file in tree)) status = "T"
+                print status "\t" file }' changed.tsv > changed.marked.tsv
+            mv changed.marked.tsv changed.tsv
+
             echo "Changed files ($BASE..$HEAD):"
             sed 's/^/  /' changed.tsv
+
+            # A locale removed in this deploy is absent from the deployed
+            # lib/i18n.ts, so the mapper would never emit its prefixes. Give it
+            # the file as it was at the base to union against.
+            git show "$BASE:lib/i18n.ts" > base-i18n.ts 2>/dev/null || rm -f base-i18n.ts
+            [ -s base-i18n.ts ] && export BASE_I18N_FILE=base-i18n.ts
+
             node scripts/cache-purge-prefixes.mjs - --json --explain < changed.tsv > purge.json
           fi
 
@@ -366,16 +393,18 @@ jobs:
             payload=$(jq -Rs --arg field "$field" \
               'split("\n") | map(select(length > 0)) | {($field): .}' < "$payload_file")
 
+            local headers
             while :; do
               body=$(mktemp)
-              http=$(curl -sS -o "$body" -w '%{http_code}' -X POST "$endpoint" \
+              headers=$(mktemp)
+              http=$(curl -sS -o "$body" -D "$headers" -w '%{http_code}' -X POST "$endpoint" \
                 -H "Authorization: Bearer ${CF_API_TOKEN}" \
                 -H 'Content-Type: application/json' \
                 --data "$payload") || http=000
 
               if [ "$http" = "200" ] && [ "$(jq -r '.success' "$body")" = "true" ]; then
                 echo "  purged $(jq -r --arg f "$field" '.[$f] | length' <<< "$payload") $field (id $(jq -r '.result.id // "n/a"' "$body"))"
-                rm -f "$body"
+                rm -f "$body" "$headers"
                 return 0
               fi
 
@@ -384,11 +413,24 @@ jobs:
               # only delays the failure.
               if { [ "$http" = "429" ] || [ "$http" -ge 500 ] 2>/dev/null || [ "$http" = "000" ]; } \
                  && [ "$attempt" -lt "$max_attempts" ]; then
-                echo "::warning::Purge attempt $attempt failed (HTTP $http); retrying in ${delay}s."
-                sleep "$delay"
+                # Purge runs deliberately overlap (see the concurrency note), and
+                # the rate limit is per account, so several can be throttled at
+                # once. With a fixed backoff they would retry in lockstep, keep
+                # colliding, and give up together. Honour Retry-After when the
+                # server sends it, and jitter every wait so the herd spreads out.
+                local wait retry_after
+                wait="$delay"
+                retry_after=$(grep -i '^retry-after:' "$headers" | tr -d '\r' | awk '{print $2}' | head -1)
+                case "${retry_after:-}" in
+                  '' | *[!0-9]*) ;;
+                  *) [ "$retry_after" -gt "$wait" ] && wait="$retry_after" ;;
+                esac
+                wait=$((wait + RANDOM % 5))
+                echo "::warning::Purge attempt $attempt failed (HTTP $http); retrying in ${wait}s."
+                sleep "$wait"
                 attempt=$((attempt + 1))
                 delay=$((delay * 2))
-                rm -f "$body"
+                rm -f "$body" "$headers"
                 continue
               fi
 
@@ -396,7 +438,7 @@ jobs:
               echo "Request: $payload" >&2
               echo "Response:" >&2
               cat "$body" >&2
-              rm -f "$body"
+              rm -f "$body" "$headers"
               return 1
             done
           }

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -418,9 +418,16 @@ jobs:
                 # once. With a fixed backoff they would retry in lockstep, keep
                 # colliding, and give up together. Honour Retry-After when the
                 # server sends it, and jitter every wait so the herd spreads out.
+                #
+                # awk, not `grep | ...`: under `set -euo pipefail` a grep with no
+                # match exits 1, the pipeline inherits it, and the assignment
+                # aborts the whole step. Since 5xx and connection failures
+                # normally carry no Retry-After, the two most common retryable
+                # cases would have died on the first attempt instead of backing
+                # off. awk exits 0 whether or not it matched.
                 local wait retry_after
                 wait="$delay"
-                retry_after=$(grep -i '^retry-after:' "$headers" | tr -d '\r' | awk '{print $2}' | head -1)
+                retry_after=$(awk 'tolower($0) ~ /^retry-after:/ { gsub(/\r/, "", $2); print $2; exit }' "$headers")
                 case "${retry_after:-}" in
                   '' | *[!0-9]*) ;;
                   *) [ "$retry_after" -gt "$wait" ] && wait="$retry_after" ;;

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -77,10 +77,20 @@ permissions:
   # diff starts.
   deployments: read
 
-# Never cancel a purge in flight, and never let two run at once: a cancelled run
-# leaves part of the cache stale with nothing to retry it.
+# Keyed per deployment, NOT a single shared group. GitHub keeps at most one
+# pending run per concurrency group: "any existing pending job or workflow in the
+# same concurrency group will be canceled and the new queued job or workflow will
+# take its place" — and that happens even with `cancel-in-progress: false`.
+# https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+#
+# With one shared group and three deploys in quick succession (B running, C
+# pending, D arriving), C is dropped. D's baseline is then deployment C, which
+# did go live, so everything changed between B and C is never purged by anyone
+# and stays stale for the full TTL. Purges are idempotent and each call handles
+# its own rate limiting, so letting runs overlap is strictly safer than
+# serialising them and losing one.
 concurrency:
-  group: cache-purge
+  group: cache-purge-${{ github.event.deployment.sha || github.run_id }}
   cancel-in-progress: false
 
 env:
@@ -104,12 +114,20 @@ env:
 jobs:
   purge:
     name: Purge changed prefixes
-    # Only successful *production* deployments. `deployment_status` also fires
-    # for pending/failure states and for every preview deployment.
+    # Only successful *production* deployments from Vercel. `deployment_status`
+    # also fires for pending/failure states and for every preview deployment.
+    #
+    # The creator check is not redundant: a job-level `environment: Production`
+    # makes GitHub create a Production deployment too, and translate_docs.yml
+    # (every 30 minutes) and update-screenshots.yml both do that. Those are not
+    # releases. They cannot reach this trigger today, because events raised by
+    # GITHUB_TOKEN do not start workflow runs, but resting on that side effect
+    # would mean a purge on every translation sweep the day it changes.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
-       github.event.deployment.environment == 'Production')
+       github.event.deployment.environment == 'Production' &&
+       github.event.deployment.creator.login == 'vercel[bot]')
     runs-on: ubuntu-latest
     steps:
       # Full history: the diff base is the previous deployed commit, which can be
@@ -136,7 +154,10 @@ jobs:
           INPUT_BROAD: ${{ inputs.broad }}
           INPUT_RANGE: ${{ inputs.range }}
           HEAD_SHA: ${{ github.event.deployment.sha }}
+          DEPLOYMENT_ID: ${{ github.event.deployment.id }}
           REPO: ${{ github.repository }}
+          # Only deployments from the Vercel integration count as live releases.
+          VERCEL_CREATOR: 'vercel[bot]'
         run: |
           set -euo pipefail
 
@@ -162,29 +183,52 @@ jobs:
             head="${INPUT_RANGE##*..}"
           else
             head="$HEAD_SHA"
+            if ! printf '%s' "${DEPLOYMENT_ID:-}" | grep -Eq '^[0-9]+$'; then
+              echo "::error::deployment_status payload carried no numeric deployment id."
+              exit 1
+            fi
             # Walk production deployments newest-first and take the first one
             # that succeeded on a *different* commit. Skipping same-sha entries
-            # means a manual redeploy of the current commit re-purges that
-            # commit's prefixes instead of computing an empty diff.
+            # means a redeploy of the current commit re-purges that commit's
+            # prefixes instead of computing an empty diff.
+            #
+            # Two filters keep the baseline honest:
+            #
+            #   creator == vercel[bot] — a job-level `environment: Production`
+            #   also creates a Production deployment, and translate_docs.yml and
+            #   update-screenshots.yml both do that. Those SHAs were never a live
+            #   build. If a Vercel build for B fails while a translation run
+            #   succeeds on B, taking B as the baseline would silently skip
+            #   everything in A..B.
+            #
+            #   id < this deployment — deployment ids increase monotonically, so
+            #   this is an "older than the event we are processing" test. Without
+            #   it, a deploy that finishes while this runner is queued is newer
+            #   yet still differs from head, so it would be accepted as the
+            #   "previous" build and the real B..C delta would go unpurged.
             base=""
-            # Newest first (the API returns deployments in descending order).
             # Bounded to 40 inside jq rather than with `head`, whose SIGPIPE
             # would trip `pipefail`.
-            ids=$(gh api "repos/$REPO/deployments?environment=Production&per_page=100" \
-                    --jq '.[0:40][] | "\(.id) \(.sha)"')
+            deployments=$(gh api "repos/$REPO/deployments?environment=Production&per_page=100")
+            ids=$(jq -r --argjson current "$DEPLOYMENT_ID" --arg creator "$VERCEL_CREATOR" '
+                    [ .[]
+                      | select(.creator.login == $creator)
+                      | select(.id < $current)
+                    ][0:40][]
+                    | "\(.id) \(.sha)"' <<< "$deployments")
             while read -r id sha; do
               [ -n "$id" ] || continue
               [ "$sha" = "$head" ] && continue
               state=$(gh api "repos/$REPO/deployments/$id/statuses?per_page=1" --jq '.[0].state // ""')
               if [ "$state" = "success" ]; then
                 base="$sha"
-                echo "Previous successful production deployment: $sha (deployment $id)"
+                echo "Previous successful Vercel production deployment: $sha (deployment $id)"
                 break
               fi
             done <<< "$ids"
 
             if [ -z "$base" ]; then
-              echo "::warning::No previous successful production deployment found; purging broadly."
+              echo "::warning::No earlier successful Vercel production deployment found; purging broadly."
               emit mode broad
               exit 0
             fi

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -1,0 +1,373 @@
+name: Cloudflare Cache Purge
+
+# Purges the Cloudflare edge cache for the pages a production deploy actually
+# changed, so a docs edit is visible immediately instead of waiting out the 24h
+# edge TTL (`SHARED_CDN_CACHE` in next.config.mjs). Nothing here changes a TTL.
+#
+# WHY PREFIXES, NOT URLS
+# The App Router serves the HTML document and the RSC flight payload at the same
+# path; the flight request carries a `?_rsc=<hash>` query that Next generates
+# client-side from router headers. Cloudflare keeps the query string in the
+# cache key, so those variants are separate entries whose keys cannot be
+# enumerated from CI. Measured against production:
+#   purge by URL  /docs/local/docker            -> HTML variant only
+#   purge by URL  /docs/local/docker?_rsc=x     -> that one RSC variant
+#   purge by prefix www.librechat.ai/docs/local/docker -> HTML *and* RSC
+# Prefix is therefore the only usable unit. Note the format: `hostname/path`,
+# no scheme, no query string.
+#
+# WHY NOT `purge_everything`
+# It also evicts /_next/static/**, which would put every asset on the site into
+# a MISS wave on every deploy.
+#
+# KNOWN, ACCEPTED BEHAVIOURS
+# 1. Prefix matching is a plain string match, so `/docs/features/agents` also
+#    purges `/docs/features/agents-anything`. That is over-purging: it costs one
+#    origin fetch, it is never stale. Acceptable.
+# 2. Deletions are included in the diff (`git diff --name-only` reports them),
+#    so removing a page purges its prefix and the stale entry goes.
+
+on:
+  # The purge MUST happen after Vercel has finished deploying. Running it when
+  # the commit lands (`on: push`) is worse than not purging at all: Cloudflare
+  # would immediately refill every purged entry from the *old* origin build and
+  # re-pin it for another 24h.
+  #
+  # Vercel's GitHub integration publishes a GitHub Deployment for every
+  # production build and marks it `success` when the build is ready and the
+  # production alias points at it. That is a real completion signal, it needs no
+  # new credentials, and it arrives when the work is done rather than after a
+  # guessed wait. Verified present on this repo: deployments with
+  # `environment: Production` created by `vercel[bot]`, status `success`.
+  #
+  # Limitations, written down rather than papered over:
+  #   - It depends on Vercel's GitHub integration staying enabled. If a deploy
+  #     ever reaches production without producing a GitHub Deployment, no purge
+  #     runs and those pages fall back to the 24h TTL. Use the manual
+  #     `workflow_dispatch` broad purge to recover.
+  #   - `success` is posted when Vercel considers the deployment ready. The
+  #     alias swap is effectively simultaneous, but a purge issued in the same
+  #     second could still race an edge that has not seen the new origin.
+  #     SETTLE_SECONDS below covers that window.
+  #   - `deployment_status` workflows only run from the file on the default
+  #     branch, so this cannot be exercised until it is merged to main.
+  deployment_status:
+
+  # Manual escape hatch: purge the four top-level prefixes (and the rest of the
+  # broad set) without needing a deploy. Use it after a Cloudflare rule change,
+  # a failed run, or any deploy that produced no deployment event.
+  workflow_dispatch:
+    inputs:
+      broad:
+        description: 'Purge the broad set (all top-level prefixes) instead of a diff'
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Log the computed prefixes without calling the Cloudflare API'
+        type: boolean
+        default: false
+      range:
+        description: 'With broad=false: commit range to map, e.g. abc1234..def5678'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  # Reading the previous successful production deployment, to know where the
+  # diff starts.
+  deployments: read
+
+# Never cancel a purge in flight, and never let two run at once: a cancelled run
+# leaves part of the cache stale with nothing to retry it.
+concurrency:
+  group: cache-purge
+  cancel-in-progress: false
+
+env:
+  # Grace period between "Vercel says ready" and the first purge call. Cheap
+  # insurance against purging an edge a moment before it can see the new origin;
+  # raise it if a purged page is ever observed refilling with old content.
+  SETTLE_SECONDS: 15
+  # Cloudflare documents "Maximum 30 prefixes per API call" for purge by prefix.
+  # The general limits table allows 100 operations per request (500 on
+  # Enterprise), so 30 is the tighter of the two documented numbers and is what
+  # we chunk on. Sources:
+  #   https://developers.cloudflare.com/cache/how-to/purge-cache/purge_by_prefix/
+  #   https://developers.cloudflare.com/cache/how-to/purge-cache/#availability-and-limits
+  MAX_ITEMS_PER_CALL: 30
+  # Request rate is limited per account, and the floor across plans is 5
+  # requests per minute (Free); Pro is 5/s, Business 10/s, Enterprise 50/s. One
+  # second between calls keeps us under every per-second bucket, and 429s are
+  # retried with backoff below, which is what makes the floor safe too.
+  SLEEP_BETWEEN_CALLS: 1
+
+jobs:
+  purge:
+    name: Purge changed prefixes
+    # Only successful *production* deployments. `deployment_status` also fires
+    # for pending/failure states and for every preview deployment.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+       github.event.deployment.environment == 'Production')
+    runs-on: ubuntu-latest
+    steps:
+      # Full history: the diff base is the previous deployed commit, which can be
+      # many commits back when deploys are batched or a build was superseded.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Resolve what to map. Three cases:
+      #   dispatch + broad          -> broad set, no diff
+      #   dispatch + explicit range -> that range
+      #   deployment_status         -> previous successful production deploy .. this one
+      #
+      # Using the previous *deployed* commit rather than `push.before` matters:
+      # when several commits land quickly Vercel may supersede a build, so some
+      # commits never deploy on their own. Diffing deploy-to-deploy covers every
+      # commit that actually shipped between two live builds; diffing push-to-push
+      # would silently skip the superseded ones.
+      - name: Resolve diff range
+        id: range
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          INPUT_BROAD: ${{ inputs.broad }}
+          INPUT_RANGE: ${{ inputs.range }}
+          HEAD_SHA: ${{ github.event.deployment.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ "$INPUT_BROAD" = "true" ]; then
+              echo "Manual dispatch: broad purge requested."
+              emit mode broad
+              exit 0
+            fi
+            if [ -z "${INPUT_RANGE:-}" ]; then
+              echo "::error::broad=false requires a 'range' input (e.g. abc1234..def5678)."
+              exit 1
+            fi
+            # Constrain the shape before it reaches git, so a value like
+            # `--upload-pack=...` can't be read as an option.
+            if ! printf '%s' "$INPUT_RANGE" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*\.\.[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+              echo "::error::Invalid range '$INPUT_RANGE'. Expected <base>..<head>."
+              exit 1
+            fi
+            base="${INPUT_RANGE%%..*}"
+            head="${INPUT_RANGE##*..}"
+          else
+            head="$HEAD_SHA"
+            # Walk production deployments newest-first and take the first one
+            # that succeeded on a *different* commit. Skipping same-sha entries
+            # means a manual redeploy of the current commit re-purges that
+            # commit's prefixes instead of computing an empty diff.
+            base=""
+            # Newest first (the API returns deployments in descending order).
+            # Bounded to 40 inside jq rather than with `head`, whose SIGPIPE
+            # would trip `pipefail`.
+            ids=$(gh api "repos/$REPO/deployments?environment=Production&per_page=100" \
+                    --jq '.[0:40][] | "\(.id) \(.sha)"')
+            while read -r id sha; do
+              [ -n "$id" ] || continue
+              [ "$sha" = "$head" ] && continue
+              state=$(gh api "repos/$REPO/deployments/$id/statuses?per_page=1" --jq '.[0].state // ""')
+              if [ "$state" = "success" ]; then
+                base="$sha"
+                echo "Previous successful production deployment: $sha (deployment $id)"
+                break
+              fi
+            done <<< "$ids"
+
+            if [ -z "$base" ]; then
+              echo "::warning::No previous successful production deployment found; purging broadly."
+              emit mode broad
+              exit 0
+            fi
+          fi
+
+          # A force-push or a dropped branch can orphan the base commit. Mapping
+          # nothing would leave the cache stale, so fall back to the broad set.
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "::warning::Base commit $base is not reachable in this checkout; purging broadly."
+            emit mode broad
+            exit 0
+          fi
+          if ! git cat-file -e "${head}^{commit}" 2>/dev/null; then
+            echo "::warning::Head commit $head is not reachable in this checkout; purging broadly."
+            emit mode broad
+            exit 0
+          fi
+
+          emit mode diff
+          emit base "$base"
+          emit head "$head"
+
+      # Map changed files -> prefixes. `git diff --name-only` reports added,
+      # modified *and* deleted paths (no --diff-filter, so D is included);
+      # a deleted page still needs its prefix purged or the stale entry survives.
+      - name: Compute prefixes
+        id: compute
+        env:
+          MODE: ${{ steps.range.outputs.mode }}
+          BASE: ${{ steps.range.outputs.base }}
+          HEAD: ${{ steps.range.outputs.head }}
+        run: |
+          set -euo pipefail
+
+          if [ "$MODE" = "broad" ]; then
+            node scripts/cache-purge-prefixes.mjs --broad --json > purge.json
+          else
+            echo "Changed files ($BASE..$HEAD):"
+            git diff --name-only "$BASE" "$HEAD" | sed 's/^/  /'
+            git diff --name-only "$BASE" "$HEAD" \
+              | node scripts/cache-purge-prefixes.mjs - --json --explain > purge.json
+          fi
+
+          jq -r '.prefixes[]' purge.json > prefixes.txt
+          jq -r '.files[]?' purge.json > files.txt
+          broad=$(jq -r '.broad' purge.json)
+          collapsed=$(jq -r '.collapsed' purge.json)
+
+          {
+            echo "### Cloudflare purge plan"
+            echo
+            echo "- mode: \`$([ "$broad" = "true" ] && echo broad || echo selective)\`"
+            [ "$collapsed" = "true" ] && echo "- **collapsed to broad**: the diff produced more prefixes than the cap"
+            echo "- prefixes: $(wc -l < prefixes.txt)"
+            echo "- exact URLs: $(wc -l < files.txt)"
+            echo
+            echo '```'
+            cat prefixes.txt files.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "count=$(wc -l < prefixes.txt)" >> "$GITHUB_OUTPUT"
+
+      # Nothing mapped means the deploy touched only files that cannot change a
+      # rendered page (.github/**, tests, repo notes). Say so out loud; do not
+      # dress it up as a successful purge.
+      - name: Nothing to purge
+        if: steps.compute.outputs.count == '0'
+        run: echo "::notice::No cached route changed in this deploy — no purge issued."
+
+      - name: Dry run
+        if: inputs.dry_run && steps.compute.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          echo "DRY RUN — the Cloudflare API is not called. Prefixes:"
+          cat prefixes.txt
+          if [ -s files.txt ]; then
+            echo "Exact URLs:"
+            cat files.txt
+          fi
+
+      # Fail loudly on missing configuration. A purge that quietly skips is the
+      # exact failure this workflow exists to prevent.
+      - name: Check credentials
+        if: ${{ !inputs.dry_run && steps.compute.outputs.count != '0' }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${CF_API_TOKEN:-}" ] || missing="$missing CLOUDFLARE_API_TOKEN"
+          [ -n "${CF_ZONE_ID:-}" ] || missing="$missing CLOUDFLARE_ZONE_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secret(s):$missing. Add them (API token needs" \
+                 "the Zone > Cache Purge permission on the librechat.ai zone) and re-run." >&2
+            exit 1
+          fi
+
+      - name: Wait for the deploy to settle
+        if: ${{ !inputs.dry_run && steps.compute.outputs.count != '0' && github.event_name == 'deployment_status' }}
+        run: sleep "$SETTLE_SECONDS"
+
+      - name: Purge
+        if: ${{ !inputs.dry_run && steps.compute.outputs.count != '0' }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -euo pipefail
+
+          endpoint="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache"
+
+          # One purge call. Fails the job on a non-200 *or* on `success: false`
+          # in the body — Cloudflare returns 200 with success:false for things
+          # like an unauthorised prefix, and treating that as a win is how a
+          # cache silently stays stale. Never `|| true`.
+          purge_call() {
+            local field="$1" payload_file="$2" attempt=1 max_attempts=5 delay=5
+            local body http
+
+            # `files` and `prefixes` are mutually exclusive in the API, so each
+            # kind goes in its own call.
+            local payload
+            payload=$(jq -Rs --arg field "$field" \
+              'split("\n") | map(select(length > 0)) | {($field): .}' < "$payload_file")
+
+            while :; do
+              body=$(mktemp)
+              http=$(curl -sS -o "$body" -w '%{http_code}' -X POST "$endpoint" \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                -H 'Content-Type: application/json' \
+                --data "$payload") || http=000
+
+              if [ "$http" = "200" ] && [ "$(jq -r '.success' "$body")" = "true" ]; then
+                echo "  purged $(jq -r --arg f "$field" '.[$f] | length' <<< "$payload") $field (id $(jq -r '.result.id // "n/a"' "$body"))"
+                rm -f "$body"
+                return 0
+              fi
+
+              # 429 (rate limited) and 5xx are worth retrying; anything else is a
+              # real error (bad token, wrong zone, malformed prefix) and retrying
+              # only delays the failure.
+              if { [ "$http" = "429" ] || [ "$http" -ge 500 ] 2>/dev/null || [ "$http" = "000" ]; } \
+                 && [ "$attempt" -lt "$max_attempts" ]; then
+                echo "::warning::Purge attempt $attempt failed (HTTP $http); retrying in ${delay}s."
+                sleep "$delay"
+                attempt=$((attempt + 1))
+                delay=$((delay * 2))
+                rm -f "$body"
+                continue
+              fi
+
+              echo "::error::Cloudflare purge failed (HTTP $http)." >&2
+              echo "Request: $payload" >&2
+              echo "Response:" >&2
+              cat "$body" >&2
+              rm -f "$body"
+              return 1
+            done
+          }
+
+          # Chunk to MAX_ITEMS_PER_CALL and pace the calls.
+          purge_all() {
+            local field="$1" source="$2"
+            [ -s "$source" ] || return 0
+            local total chunkdir
+            total=$(wc -l < "$source")
+            chunkdir=$(mktemp -d)
+            split -l "$MAX_ITEMS_PER_CALL" "$source" "$chunkdir/chunk."
+            echo "Purging $total $field in $(ls "$chunkdir" | wc -l) call(s)..."
+            local first=1
+            for chunk in "$chunkdir"/chunk.*; do
+              [ "$first" = "1" ] || sleep "$SLEEP_BETWEEN_CALLS"
+              first=0
+              purge_call "$field" "$chunk"
+            done
+            rm -rf "$chunkdir"
+          }
+
+          purge_all prefixes prefixes.txt
+          # The homepage has no usable prefix — `www.librechat.ai/` prefixes the
+          # whole zone, static assets included — so it is purged by exact URL.
+          purge_all files files.txt
+
+          echo "::notice::Cloudflare purge complete."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -121,6 +121,10 @@ env:
   # deployments, which on this repo is ~3.3 days because translate_docs.yml
   # creates a Production record every 30 minutes; 5 pages is a fortnight.
   MAX_DEPLOYMENT_PAGES: 5
+  # How far back a blind recovery reaches when it has no baseline to work from.
+  # Only ever an approximation of where to start, so it is paired with the broad
+  # page set; its job is to surface deletions, which a range-less run cannot see.
+  FALLBACK_WINDOW: '30 days ago'
 
 jobs:
   purge:
@@ -175,13 +179,38 @@ jobs:
 
           emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
 
+          # Last resort before giving up on a range entirely.
+          #
+          # A range-less purge is blind to deletions: every target is enumerated
+          # from the deployed checkout, so a file removed in the meantime has no
+          # entry anywhere and its old URL survives at the edge. A time-boxed
+          # range is approximate about *where* to start, but it is a real diff,
+          # so removals inside it come through as `D` and get purged like any
+          # other change. Strictly better than nothing; still paired with the
+          # broad page set, because the window may not reach far enough back.
+          fallback_range() {
+            local since ref
+            ref="${1:-}"
+            [ -n "$ref" ] || ref=$(git rev-parse HEAD)
+            since=$(git rev-list -1 --before="$FALLBACK_WINDOW" "$ref" 2>/dev/null || true)
+            if [ -n "$since" ] && [ "$since" != "$ref" ]; then
+              echo "::warning::No usable baseline; falling back to the last $FALLBACK_WINDOW ($since..$ref)."
+              emit mode broad
+              emit base "$since"
+              emit head "$ref"
+              return 0
+            fi
+            return 1
+          }
+
           if [ "$EVENT" = "workflow_dispatch" ]; then
             if [ "$INPUT_BROAD" = "true" ] && [ -z "${INPUT_RANGE:-}" ]; then
               # Pages only. Cannot reach changed asset URLs or a locale that was
               # removed, because both are discovered from a diff — supply a range
               # as well to recover those.
               echo "Manual dispatch: broad page purge, no range given."
-              echo "::warning::No range supplied: purging public/ wholesale; a locale removed in the meantime cannot be discovered."
+              fallback_range && exit 0
+              echo "::warning::No range and no fallback window; deletions in the meantime cannot be discovered."
               emit mode broad
               exit 0
             fi
@@ -276,7 +305,9 @@ jobs:
 
             if [ -z "$base" ]; then
               # Also the first-ever run, when no commit carries the marker yet.
-              echo "::warning::No earlier successfully purged deployment found; purging broadly."
+              echo "No earlier successfully purged deployment found."
+              fallback_range "$head" && exit 0
+              echo "::warning::No baseline and no fallback window; purging broadly."
               emit mode broad
               exit 0
             fi
@@ -285,7 +316,9 @@ jobs:
           # A force-push or a dropped branch can orphan the base commit. Mapping
           # nothing would leave the cache stale, so fall back to the broad set.
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
-            echo "::warning::Base commit $base is not reachable in this checkout; purging broadly."
+            echo "Base commit $base is not reachable in this checkout."
+            fallback_range "$head" && exit 0
+            echo "::warning::No fallback window either; purging broadly."
             emit mode broad
             exit 0
           fi
@@ -323,10 +356,16 @@ jobs:
           if [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
             node scripts/cache-purge-prefixes.mjs --broad --assets --json > purge.json
           else
-            # Broad *with* a range still walks the diff, so the broad page set is
-            # topped up with changed asset URLs and locales removed in the range.
+            # Broad *with* a range still walks the diff, so the broad page set
+            # is topped up with changed asset URLs and locales removed in the
+            # range. --assets rides along for the same reason it applies to a
+            # range-less run: broad means the diff is not trusted to be
+            # complete, and the window may not reach back far enough. A run that
+            # escalates to broad from a *trusted* diff does not get it — there we
+            # know exactly which assets changed, and evicting every image on any
+            # shared-file change is what avoiding purge_everything is for.
             broad_flag=""
-            [ "$MODE" = "broad" ] && broad_flag="--broad"
+            [ "$MODE" = "broad" ] && broad_flag="--broad --assets"
             # --no-renames is load-bearing. Git's rename detection is on by
             # default, and it reports a moved file as its destination alone, so
             # a page moved without edits would never have its old URL purged and

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -117,6 +117,10 @@ env:
   # Commit-status context marking "the cache was successfully purged for this
   # SHA". The next run's baseline is the newest deployment carrying it.
   PURGE_STATUS_CONTEXT: cache-purge
+  # How far back to look for the last purged Vercel release. One page is 100
+  # deployments, which on this repo is ~3.3 days because translate_docs.yml
+  # creates a Production record every 30 minutes; 5 pages is a fortnight.
+  MAX_DEPLOYMENT_PAGES: 5
 
 jobs:
   purge:
@@ -177,7 +181,7 @@ jobs:
               # removed, because both are discovered from a diff — supply a range
               # as well to recover those.
               echo "Manual dispatch: broad page purge, no range given."
-              echo "::warning::No range supplied: changed asset URLs and removed locales cannot be discovered."
+              echo "::warning::No range supplied: purging public/ wholesale; a locale removed in the meantime cannot be discovered."
               emit mode broad
               exit 0
             fi
@@ -219,15 +223,24 @@ jobs:
             #   yet still differs from head, so it would be accepted as the
             #   "previous" build and the real B..C delta would go unpurged.
             base=""
-            # Bounded to 40 inside jq rather than with `head`, whose SIGPIPE
-            # would trip `pipefail`.
-            deployments=$(gh api "repos/$REPO/deployments?environment=Production&per_page=100")
-            ids=$(jq -r --argjson current "$DEPLOYMENT_ID" --arg creator "$VERCEL_CREATOR" '
-                    [ .[]
-                      | select(.creator.login == $creator)
-                      | select(.id < $current)
-                    ][0:40][]
-                    | "\(.id) \(.sha)"' <<< "$deployments")
+            # Pagination is not optional here. `environment=Production` is
+            # dominated by the half-hourly translate_docs.yml jobs, which declare
+            # that environment and so create a deployment record each run.
+            # Measured on this repo: one page of 100 covers about 3.3 days and
+            # holds 5 Vercel releases against 95 Actions records. Any release gap
+            # longer than that would push the real baseline off page one, and the
+            # run would silently degrade to a broad purge every time.
+            page=1
+            while [ "$page" -le "$MAX_DEPLOYMENT_PAGES" ] && [ -z "$base" ]; do
+              deployments=$(gh api \
+                "repos/$REPO/deployments?environment=Production&per_page=100&page=$page")
+              [ "$(jq 'length' <<< "$deployments")" -gt 0 ] || break
+              ids=$(jq -r --argjson current "$DEPLOYMENT_ID" --arg creator "$VERCEL_CREATOR" '
+                      [ .[]
+                        | select(.creator.login == $creator)
+                        | select(.id < $current)
+                      ][]
+                      | "\(.id) \(.sha)"' <<< "$deployments")
             # The baseline is the last commit we actually PURGED, not merely the
             # last one deployed. If B's purge fails or is cancelled and C then
             # deploys, taking B as the baseline would compute B..C and leave
@@ -235,20 +248,31 @@ jobs:
             # would ever revisit it. Walking back to the newest deployment
             # carrying the `PURGE_STATUS_CONTEXT` commit status makes the next
             # run absorb the failed one's range: the diff widens to A..C.
-            while read -r id sha; do
-              [ -n "$id" ] || continue
-              [ "$sha" = "$head" ] && continue
-              state=$(gh api "repos/$REPO/deployments/$id/statuses?per_page=1" --jq '.[0].state // ""')
-              [ "$state" = "success" ] || continue
-              purged=$(gh api "repos/$REPO/commits/$sha/statuses" \
-                --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\" and .state == \"success\")] | length")
-              if [ "${purged:-0}" -gt 0 ]; then
-                base="$sha"
-                echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
-                break
-              fi
-              echo "Skipping $sha (deployment $id): deployed, but never purged successfully."
-            done <<< "$ids"
+              while read -r id sha; do
+                [ -n "$id" ] || continue
+                [ -z "$base" ] || break
+                [ "$sha" = "$head" ] && continue
+                # "Has it EVER succeeded", not "is its newest status success".
+                # GitHub appends an `inactive` status to earlier deployments in an
+                # environment once a newer one succeeds (auto_inactive, on by
+                # default). That is not happening on this repo today — the
+                # superseded deployment 5623426305 carries a lone `success` — but
+                # if it ever started, reading only the newest status would reject
+                # every candidate and quietly pin the workflow to broad purges.
+                succeeded=$(gh api "repos/$REPO/deployments/$id/statuses" \
+                  --jq '[.[] | select(.state == "success")] | length')
+                [ "${succeeded:-0}" -gt 0 ] || continue
+                purged=$(gh api "repos/$REPO/commits/$sha/statuses" \
+                  --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\" and .state == \"success\")] | length")
+                if [ "${purged:-0}" -gt 0 ]; then
+                  base="$sha"
+                  echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
+                  break
+                fi
+                echo "Skipping $sha (deployment $id): deployed, but never purged successfully."
+              done <<< "$ids"
+              page=$((page + 1))
+            done
 
             if [ -z "$base" ]; then
               # Also the first-ever run, when no commit carries the marker yet.
@@ -292,9 +316,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Broad with no range: pages only, nothing a diff would have revealed.
+          # No range to work from: a manual run without one, an unreachable base,
+          # or no previously purged deployment. --assets covers public/ wholesale
+          # because nothing here can tell which asset changed, and these are the
+          # runs that exist precisely because something already went wrong.
           if [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
-            node scripts/cache-purge-prefixes.mjs --broad --json > purge.json
+            node scripts/cache-purge-prefixes.mjs --broad --assets --json > purge.json
           else
             # Broad *with* a range still walks the diff, so the broad page set is
             # topped up with changed asset URLs and locales removed in the range.

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -24,8 +24,9 @@ name: Cloudflare Cache Purge
 # 1. Prefix matching is a plain string match, so `/docs/features/agents` also
 #    purges `/docs/features/agents-anything`. That is over-purging: it costs one
 #    origin fetch, it is never stale. Acceptable.
-# 2. Deletions are included in the diff (`git diff --name-only` reports them),
-#    so removing a page purges its prefix and the stale entry goes.
+# 2. Deletions are included in the diff, so removing a page purges its prefix
+#    and the stale entry goes. Renames need `--no-renames` to show up as one:
+#    git's rename detection would otherwise report only the destination.
 
 on:
   # The purge MUST happen after Vercel has finished deploying. Running it when
@@ -251,9 +252,9 @@ jobs:
           emit base "$base"
           emit head "$head"
 
-      # Map changed files -> prefixes. `git diff --name-only` reports added,
-      # modified *and* deleted paths (no --diff-filter, so D is included);
-      # a deleted page still needs its prefix purged or the stale entry survives.
+      # Map changed files -> prefixes. The diff reports added, modified *and*
+      # deleted paths (no --diff-filter, so D is included); a deleted page still
+      # needs its prefix purged or the stale entry survives.
       - name: Compute prefixes
         id: compute
         env:
@@ -266,10 +267,19 @@ jobs:
           if [ "$MODE" = "broad" ]; then
             node scripts/cache-purge-prefixes.mjs --broad --json > purge.json
           else
+            # --no-renames is load-bearing. Git's rename detection is on by
+            # default, and it reports a moved file as its destination alone, so
+            # a page moved without edits would never have its old URL purged and
+            # Cloudflare would keep serving it. With the flag, a rename arrives
+            # as a delete plus an add, which is what it is for the cache.
+            #
+            # --name-status because add/delete are not equivalent to modify here:
+            # they reshape the page tree and the locale map that every docs page
+            # renders, so the mapper widens the purge for them.
+            git diff --name-status --no-renames "$BASE" "$HEAD" > changed.tsv
             echo "Changed files ($BASE..$HEAD):"
-            git diff --name-only "$BASE" "$HEAD" | sed 's/^/  /'
-            git diff --name-only "$BASE" "$HEAD" \
-              | node scripts/cache-purge-prefixes.mjs - --json --explain > purge.json
+            sed 's/^/  /' changed.tsv
+            node scripts/cache-purge-prefixes.mjs - --json --explain < changed.tsv > purge.json
           fi
 
           jq -r '.prefixes[]' purge.json > prefixes.txt

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -125,6 +125,13 @@ env:
   # Only ever an approximation of where to start, so it is paired with the broad
   # page set; its job is to surface deletions, which a range-less run cannot see.
   FALLBACK_WINDOW: '30 days ago'
+  # Bound every Cloudflare call. Without these, a peer that accepts the
+  # connection and then stops responding never returns, so the retry loop never
+  # sees a failure and the job sits until the platform timeout — and since runs
+  # deliberately overlap, several can pile up that way. With them, a stall
+  # becomes an ordinary retryable failure.
+  CURL_CONNECT_TIMEOUT: 10
+  CURL_MAX_TIME: 60
 
 jobs:
   purge:
@@ -269,7 +276,7 @@ jobs:
                         | select(.creator.login == $creator)
                         | select(.id < $current)
                       ][]
-                      | "\(.id) \(.sha)"' <<< "$deployments")
+                      | "\(.id) \(.sha) \(.created_at)"' <<< "$deployments")
             # The baseline is the last commit we actually PURGED, not merely the
             # last one deployed. If B's purge fails or is cancelled and C then
             # deploys, taking B as the baseline would compute B..C and leave
@@ -277,7 +284,7 @@ jobs:
             # would ever revisit it. Walking back to the newest deployment
             # carrying the `PURGE_STATUS_CONTEXT` commit status makes the next
             # run absorb the failed one's range: the diff widens to A..C.
-              while read -r id sha; do
+              while read -r id sha created; do
                 [ -n "$id" ] || continue
                 [ -z "$base" ] || break
                 [ "$sha" = "$head" ] && continue
@@ -291,8 +298,16 @@ jobs:
                 succeeded=$(gh api "repos/$REPO/deployments/$id/statuses" \
                   --jq '[.[] | select(.state == "success")] | length')
                 [ "${succeeded:-0}" -gt 0 ] || continue
+                # The marker must post-date THIS deployment, not merely exist on
+                # the commit. A rollback redeploys a SHA that was purged the first
+                # time round; if the rollback's own purge fails, an undated check
+                # would accept its stale marker and the next run would diff from a
+                # build whose cache was never cleared. GitHub timestamps are UTC
+                # ISO-8601, so a lexicographic compare is a chronological one.
                 purged=$(gh api "repos/$REPO/commits/$sha/statuses" \
-                  --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\" and .state == \"success\")] | length")
+                  --jq "[.[] | select(.context == \"$PURGE_STATUS_CONTEXT\"
+                                      and .state == \"success\"
+                                      and .created_at > \"$created\")] | length")
                 if [ "${purged:-0}" -gt 0 ]; then
                   base="$sha"
                   echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
@@ -375,7 +390,14 @@ jobs:
             # --name-status because add/delete are not equivalent to modify here:
             # they reshape the page tree and the locale map that every docs page
             # renders, so the mapper widens the purge for them.
-            git diff --name-status --no-renames "$BASE" "$HEAD" > changed.tsv
+            # core.quotepath=false, or git C-quotes any non-ASCII path:
+            # `public/images/café.png` arrives as `"public/images/caf\303\251.png"`,
+            # which matches no rule, so the asset URL is never purged even though
+            # the mapper handles Unicode correctly. A name containing a quote or
+            # backslash is still quoted, and that is caught below rather than
+            # silently mismapped.
+            git -c core.quotepath=false diff --name-status --no-renames \
+              "$BASE" "$HEAD" > changed.tsv
 
             # Frontmatter `title:`/`icon:` populate the page-tree node that the
             # sidebar draws on *every* docs page, so editing one is structural
@@ -384,8 +406,16 @@ jobs:
             # set we need and one extra git call. It also matches a `title:` at
             # the start of a line inside a fenced code block in the body: that
             # over-purges to the docs root, which is safe.
-            git diff --name-only --no-renames -G'^(title|icon):' "$BASE" "$HEAD" \
-              -- content/docs > tree-edits.txt || : > tree-edits.txt
+            git -c core.quotepath=false diff --name-only --no-renames -G'^(title|icon):' \
+              "$BASE" "$HEAD" -- content/docs > tree-edits.txt || : > tree-edits.txt
+
+            # Anything still quoted holds a character git cannot render plainly.
+            # Mapping it would silently under-purge, so stop instead.
+            if cut -f2- changed.tsv | grep -q '^"'; then
+              echo "::error::Changed path needs C-quoting, which this mapper cannot parse:" >&2
+              cut -f2- changed.tsv | grep '^"' >&2
+              exit 1
+            fi
 
             # getline in BEGIN, not the NR==FNR idiom: with an empty first file
             # that idiom misreads the first line of the second file.
@@ -498,6 +528,7 @@ jobs:
               body=$(mktemp)
               headers=$(mktemp)
               http=$(curl -sS -o "$body" -D "$headers" -w '%{http_code}' -X POST "$endpoint" \
+                --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
                 -H "Authorization: Bearer ${CF_API_TOKEN}" \
                 -H 'Content-Type: application/json' \
                 --data "$payload") || http=000

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -301,9 +301,38 @@ export function computePurge(files, locales) {
   }
 }
 
+/** Every flag this script understands. A typo must not be mistaken for one of these. */
+export const KNOWN_FLAGS = ['--broad', '--json', '--explain']
+
+/**
+ * Split argv into flags and positionals, rejecting anything unrecognised.
+ *
+ * Silently ignoring an unknown flag is dangerous here rather than merely untidy:
+ * a mistyped `--broad` in the workflow would produce an empty result, land in
+ * the "nothing to purge" branch, and skip the purge without a word — the exact
+ * silent staleness this whole workflow exists to prevent.
+ */
+export function parseArgs(argv) {
+  const flags = new Set()
+  const positional = []
+
+  for (const arg of argv) {
+    // A bare `-` is the read-from-stdin operand, not a flag.
+    if (arg === '-' || !arg.startsWith('-')) {
+      positional.push(arg)
+      continue
+    }
+    if (!KNOWN_FLAGS.includes(arg)) {
+      throw new Error(`Unknown flag: ${arg}\nKnown flags: ${KNOWN_FLAGS.join(', ')}`)
+    }
+    flags.add(arg)
+  }
+
+  return { flags, positional }
+}
+
 async function main(argv) {
-  const flags = new Set(argv.filter((a) => a.startsWith('--')))
-  const positional = argv.filter((a) => !a.startsWith('--'))
+  const { flags, positional } = parseArgs(argv)
   const locales = readLocales()
 
   let files = []
@@ -350,7 +379,7 @@ async function main(argv) {
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
   main(process.argv.slice(2)).catch((error) => {
-    process.stderr.write(`${error.stack ?? error}\n`)
+    process.stderr.write(`${error.message ?? error}\n`)
     process.exit(1)
   })
 }

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -163,10 +163,16 @@ export function prefixesForFile(file, locales) {
       // The untranslated meta.json is the source of truth for section structure;
       // fumadocs falls back to it for any locale whose meta.<locale>.json is
       // missing a key, so a change to it reaches every language.
+      //
+      // /llms goes with it: app/llms-full.txt/route.ts builds the export from
+      // getOrderedDocsPages(), which walks `docsSource.pageTree` — the tree this
+      // file defines. Reordering a section therefore reorders the export. Only
+      // the untranslated file matters here, since getOrderedDocsPages() pins
+      // itself to i18n.defaultLanguage.
       return {
-        prefixes: [docsPrefix('', dir), ...locales.map((l) => docsPrefix(l, dir))],
+        prefixes: [docsPrefix('', dir), ...locales.map((l) => docsPrefix(l, dir)), `${HOST}/llms`],
         broad: false,
-        reason: `section /${dir || '(root)'} in every locale (sidebar + ordering)`,
+        reason: `section /${dir || '(root)'} in every locale (sidebar + ordering, + llms export)`,
       }
     }
 
@@ -226,9 +232,30 @@ export function prefixesForFile(file, locales) {
     }
   }
 
+  // --- public/ -------------------------------------------------------------
+  // Static assets are served from the site root at the same URL forever, so
+  // nothing else purges them: a page prefix purge cannot reach /images/foo.png.
+  // Replacing one in place is exactly how the socialcards went stale for ~15
+  // days (see the note in app/api/og/route.tsx), so purge the asset's own URL.
+  //
+  // Still broad on top of that, because a replaced asset can change page HTML
+  // two ways we cannot trace per page: OG_SOURCES in lib/og-version.mjs feeds
+  // OG_VERSION, which next.config.mjs inlines into every page's card URLs, and
+  // remark-image adds build-time width/height for local images, which move if
+  // the replacement has different dimensions.
+  const asset = file.match(/^public\/(.+)$/)
+  if (asset) {
+    return {
+      prefixes: [],
+      files: [`https://${HOST}/${asset[1]}`],
+      broad: true,
+      reason: 'public asset — purging its URL, plus pages (OG fingerprint, image dimensions)',
+    }
+  }
+
   // --- everything else -----------------------------------------------------
   // lib/, components/, app/, next.config.mjs, proxy.ts, source.config.ts,
-  // package.json, public/, ... any of these can change every rendered page.
+  // package.json, ... any of these can change every rendered page.
   // Per-page dependency analysis is not attempted.
   return { prefixes: [], broad: true, reason: 'shared/global file' }
 }
@@ -262,6 +289,9 @@ export const COLLAPSE_THRESHOLD = 200
 export function computePurge(files, locales) {
   const reasons = []
   const set = new Set()
+  // Exact URLs, for the things that have no usable prefix: static assets, and
+  // the homepage when the purge goes broad.
+  const urls = new Set()
   let broad = false
 
   for (const file of files) {
@@ -270,6 +300,7 @@ export function computePurge(files, locales) {
     reasons.push({ file, ...result })
     if (result.broad) broad = true
     for (const prefix of result.prefixes) set.add(prefix)
+    for (const url of result.files ?? []) urls.add(url)
   }
 
   const prefixes = dropCoveredPrefixes([...set])
@@ -281,12 +312,15 @@ export function computePurge(files, locales) {
   }
 
   if (broad) {
+    // Asset URLs survive the escalation: the broad set is pages only, so
+    // dropping them here would leave the changed asset cached at the edge.
+    for (const url of homepageUrls()) urls.add(url)
     return {
       broad: true,
       collapsed,
       selectiveCount: prefixes.length,
       prefixes: broadPrefixes(locales),
-      files: homepageUrls(),
+      files: [...urls].sort(),
       reasons,
     }
   }
@@ -296,7 +330,7 @@ export function computePurge(files, locales) {
     collapsed,
     selectiveCount: prefixes.length,
     prefixes,
-    files: [],
+    files: [...urls].sort(),
     reasons,
   }
 }

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -12,9 +12,15 @@
  * URL only ever removes the HTML variant. A prefix purge removes every cache
  * key that starts with the prefix — HTML and every `_rsc` variant together.
  *
+ * Input is either bare paths or `git diff --name-status` lines. The status
+ * matters: adding or deleting a docs page reshapes the page tree and the locale
+ * map that *every* docs page renders, while editing one does not. Always pair it
+ * with `--no-renames`, or git reports a moved page as its destination only and
+ * the old URL is never purged.
+ *
  * Usage:
  *   node scripts/cache-purge-prefixes.mjs <file> [<file>...]
- *   git diff --name-only A B | node scripts/cache-purge-prefixes.mjs -
+ *   git diff --name-status --no-renames A B | node scripts/cache-purge-prefixes.mjs -
  *   node scripts/cache-purge-prefixes.mjs --broad
  *
  * Flags:
@@ -128,14 +134,57 @@ function docsPrefix(locale, slug) {
 }
 
 /**
+ * The docs root in every language — i.e. every docs page there is.
+ *
+ * Needed more often than it looks, because two things are rendered into *every*
+ * docs page rather than just the page they describe:
+ *
+ *   - the sidebar. lib/docs-layout.tsx hands the complete `docsSource.pageTree`
+ *     to `DocsLayout` for every page, so anything that reshapes the tree (a
+ *     meta.json edit, a page added or removed) changes every page in that
+ *     language.
+ *   - the language switcher. `getAvailableLocalesBySlug()` in lib/doc-locales.ts
+ *     builds one site-wide slug -> locales map and lib/docs-layout.tsx passes it
+ *     into `DocsI18nProvider` on every page, so adding or deleting a single
+ *     translation changes every docs page in every language.
+ */
+function docsTreePrefixes(locales) {
+  return [docsPrefix('', ''), ...locales.map((locale) => docsPrefix(locale, ''))]
+}
+
+/**
+ * Git statuses that add or remove a file. These are the ones that reshape the
+ * shared page tree and the locale map; a plain modification does not.
+ */
+const STRUCTURAL = new Set(['A', 'D'])
+
+/**
+ * Parse one line of `git diff --name-status --no-renames` into `{status, file}`.
+ *
+ * A bare path (no status column) is treated as a modification, so passing plain
+ * filenames on the command line still works for ad-hoc dry runs.
+ */
+export function parseChangedLine(line) {
+  const parts = line.split('\t')
+  if (parts.length < 2 || !/^[A-Z]\d*$/.test(parts[0])) return { status: 'M', file: line }
+  // Last field: for a rename/copy `--name-status` emits `R100<TAB>old<TAB>new`.
+  // The workflow passes --no-renames so those never appear, but if one did we
+  // would rather purge the destination than choke on the line.
+  return { status: parts[0][0], file: parts[parts.length - 1] }
+}
+
+/**
  * Map one changed file to the prefixes it invalidates.
  *
- * Returns `{prefixes, broad, reason}`. `broad: true` means the file is shared
- * or unrecognised and the caller must fall back to the site-wide set — the
- * default for anything this function does not understand, so a new file type
+ * `status` is a git status letter (`A`, `M`, `D`); it decides whether a change
+ * is structural, since adds and deletes reshape what every docs page renders.
+ *
+ * Returns `{prefixes, files?, broad, reason}`. `broad: true` means the file is
+ * shared or unrecognised and the caller must fall back to the site-wide set —
+ * the default for anything this function does not understand, so a new file type
  * over-purges instead of silently going stale.
  */
-export function prefixesForFile(file, locales) {
+export function prefixesForFile(file, locales, status = 'M') {
   const localeAlt = locales.map((l) => l.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
 
   if (INERT.some((re) => re.test(file))) {
@@ -147,40 +196,49 @@ export function prefixesForFile(file, locales) {
   if (docs) {
     const rest = docs[1]
 
-    // meta.json / meta.<locale>.json — sidebar and ordering for a whole section,
-    // so every page in that section (and its subsections) changes.
+    // meta.json / meta.<locale>.json — the sidebar. NOT section-scoped: every
+    // docs page renders the whole tree (see docsTreePrefixes), so a reordered
+    // section leaves a stale sidebar on pages nowhere near it.
     const meta = rest.match(new RegExp(`^(?:(.*)\\/)?meta(?:\\.(${localeAlt}))?\\.json$`))
     if (meta) {
-      const dir = meta[1] ?? ''
       const locale = meta[2]
       if (locale) {
         return {
-          prefixes: [docsPrefix(locale, dir)],
+          prefixes: [docsPrefix(locale, '')],
           broad: false,
-          reason: `${locale} sidebar for section /${dir || '(root)'}`,
+          reason: `${locale} sidebar — every ${locale} docs page`,
         }
       }
-      // The untranslated meta.json is the source of truth for section structure;
+      // The untranslated meta.json is the source of truth for structure;
       // fumadocs falls back to it for any locale whose meta.<locale>.json is
       // missing a key, so a change to it reaches every language.
       //
       // /llms goes with it: app/llms-full.txt/route.ts builds the export from
-      // getOrderedDocsPages(), which walks `docsSource.pageTree` — the tree this
-      // file defines. Reordering a section therefore reorders the export. Only
-      // the untranslated file matters here, since getOrderedDocsPages() pins
+      // getOrderedDocsPages(), which walks the same `docsSource.pageTree`. Only
+      // the untranslated file matters there, since getOrderedDocsPages() pins
       // itself to i18n.defaultLanguage.
       return {
-        prefixes: [docsPrefix('', dir), ...locales.map((l) => docsPrefix(l, dir)), `${HOST}/llms`],
+        prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`],
         broad: false,
-        reason: `section /${dir || '(root)'} in every locale (sidebar + ordering, + llms export)`,
+        reason: 'sidebar in every locale — every docs page (+ llms export)',
       }
     }
 
-    // <path>.<locale>.mdx — one translated page.
+    // <path>.<locale>.mdx — one translated page, unless the file appeared or
+    // disappeared: `getAvailableLocalesBySlug()` is a site-wide map embedded in
+    // every docs page, and lib/docs-page.tsx derives hreflang alternates from
+    // which translations exist, so an add/delete changes every page's markup.
     const translated = rest.match(new RegExp(`^(.*)\\.(${localeAlt})\\.mdx$`))
     if (translated) {
       const slug = stripIndex(translated[1])
       const locale = translated[2]
+      if (STRUCTURAL.has(status)) {
+        return {
+          prefixes: docsTreePrefixes(locales),
+          broad: false,
+          reason: `${locale} translation ${status === 'A' ? 'added' : 'deleted'} — language switcher and hreflang on every docs page`,
+        }
+      }
       return {
         prefixes: [docsPrefix(locale, slug)],
         broad: false,
@@ -188,13 +246,21 @@ export function prefixesForFile(file, locales) {
       }
     }
 
-    // <path>.mdx — one English page. Also purge /llms*, which is generated from
-    // the English docs. Translations are separate files and map on their own;
-    // a locale URL with no translation 307s to the English one and that redirect
-    // does not change when the English body does.
+    // <path>.mdx — one English page, unless it appeared or disappeared, which
+    // adds or removes a node from the page tree every docs page renders.
+    // Otherwise translations map on their own; a locale URL with no translation
+    // 307s to the English one, and that redirect does not change when the
+    // English body does. /llms* is generated from the English docs either way.
     const english = rest.match(/^(.*)\.mdx$/)
     if (english) {
       const slug = stripIndex(english[1])
+      if (STRUCTURAL.has(status)) {
+        return {
+          prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`],
+          broad: false,
+          reason: `English page ${status === 'A' ? 'added' : 'deleted'} — page tree on every docs page (+ llms export)`,
+        }
+      }
       return {
         prefixes: [docsPrefix('', slug), `${HOST}/llms`],
         broad: false,
@@ -294,10 +360,12 @@ export function computePurge(files, locales) {
   const urls = new Set()
   let broad = false
 
-  for (const file of files) {
+  for (const line of files) {
+    if (!line) continue
+    const { status, file } = parseChangedLine(line)
     if (!file) continue
-    const result = prefixesForFile(file, locales)
-    reasons.push({ file, ...result })
+    const result = prefixesForFile(file, locales, status)
+    reasons.push({ file, status, ...result })
     if (result.broad) broad = true
     for (const prefix of result.prefixes) set.add(prefix)
     for (const url of result.files ?? []) urls.add(url)
@@ -394,7 +462,8 @@ async function main(argv) {
   if (flags.has('--explain')) {
     for (const r of result.reasons) {
       const target = r.broad ? 'BROAD' : r.prefixes.length ? r.prefixes.join(', ') : '(nothing)'
-      process.stderr.write(`${r.file}\n  -> ${target}\n     ${r.reason}\n`)
+      const urls = r.files?.length ? `\n     files: ${r.files.join(', ')}` : ''
+      process.stderr.write(`[${r.status}] ${r.file}\n  -> ${target}\n     ${r.reason}${urls}\n`)
     }
     if (result.collapsed) {
       process.stderr.write(

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -143,6 +143,18 @@ export function homepageUrls() {
   return [`https://${HOST}/`]
 }
 
+/**
+ * Percent-encode a repository path for use in a URL, segment by segment so the
+ * separators survive.
+ *
+ * Not cosmetic: `public/images/logos/Stripe wordmark - Slate.svg` is a real file
+ * here, and a raw space in a `files` entry does not just miss that asset — the
+ * whole call is rejected, so every URL batched with it goes unpurged too.
+ */
+export function encodePath(path) {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
 /** Strip a trailing `index` segment so a section index maps to the section root. */
 function stripIndex(slug) {
   if (slug === 'index') return ''
@@ -341,11 +353,26 @@ export function prefixesForFile(file, locales, status = 'M') {
   // the replacement has different dimensions.
   const asset = file.match(/^public\/(.+)$/)
   if (asset) {
+    // A raster image passed to next/image is also served from /_next/image with
+    // the source as a query parameter, and those cache keys cannot be
+    // enumerated. Query strings cannot appear in a prefix, so the only reachable
+    // unit is the whole optimizer path.
+    //
+    // On this zone that purge is currently a no-op: /_next/image returns
+    // cf-cache-status DYNAMIC, so Cloudflare holds nothing there and the stale
+    // bytes live in Vercel's optimizer cache instead. It is one prefix on a rare
+    // trigger, and it becomes correct the moment the zone's Cache Rule covers
+    // that path, so it is cheaper to carry it than to remember to add it later.
+    // The durable fix for the Vercel layer is a versioned or content-hashed
+    // source URL, the way OG_VERSION already works for social cards.
+    const optimizable = /\.(png|jpe?g|webp|avif|gif|svg)$/i.test(asset[1])
     return {
-      prefixes: [],
-      files: [`https://${HOST}/${asset[1]}`],
+      prefixes: optimizable ? [`${HOST}/_next/image`] : [],
+      files: [`https://${HOST}/${encodePath(asset[1])}`],
       broad: true,
-      reason: 'public asset — purging its URL, plus pages (OG fingerprint, image dimensions)',
+      reason: optimizable
+        ? 'public image — its URL, the optimizer path, plus pages (OG fingerprint, dimensions)'
+        : 'public asset — purging its URL, plus pages (OG fingerprint, image dimensions)',
     }
   }
 
@@ -381,14 +408,22 @@ export function dropCoveredPrefixes(prefixes) {
  */
 export const COLLAPSE_THRESHOLD = 200
 
-/** Map a list of changed files to the purge payload. */
-export function computePurge(files, locales) {
+/**
+ * Map a list of changed files to the purge payload.
+ *
+ * `forceBroad` starts from the site-wide set instead of arriving there by
+ * escalation. Combined with a file list it is the recovery mode: broad page
+ * coverage *plus* everything only a diff can reveal — the exact URLs of changed
+ * assets, and locales that existed at the base but not at the head. With an
+ * empty file list it degrades to the plain broad set.
+ */
+export function computePurge(files, locales, { forceBroad = false } = {}) {
   const reasons = []
   const set = new Set()
   // Exact URLs, for the things that have no usable prefix: static assets, and
   // the homepage when the purge goes broad.
   const urls = new Set()
-  let broad = false
+  let broad = forceBroad
 
   for (const line of files) {
     if (!line) continue
@@ -410,14 +445,17 @@ export function computePurge(files, locales) {
   }
 
   if (broad) {
-    // Asset URLs survive the escalation: the broad set is pages only, so
-    // dropping them here would leave the changed asset cached at the edge.
+    // Asset URLs and any prefix outside the broad set survive the escalation.
+    // The broad set is pages only, so replacing the collected prefixes wholesale
+    // would silently drop things it does not cover — the changed asset itself,
+    // and /_next/image. dropCoveredPrefixes then removes the page prefixes the
+    // broad set already subsumes, so nothing is sent twice.
     for (const url of homepageUrls()) urls.add(url)
     return {
       broad: true,
       collapsed,
       selectiveCount: prefixes.length,
-      prefixes: broadPrefixes(locales),
+      prefixes: dropCoveredPrefixes([...broadPrefixes(locales), ...set]),
       files: [...urls].sort(),
       reasons,
     }
@@ -467,27 +505,18 @@ async function main(argv) {
   const { flags, positional } = parseArgs(argv)
   const locales = readLocales()
 
+  // Read the file list even with --broad: recovery runs pass both, so that the
+  // broad page set is topped up with the asset URLs and removed locales that
+  // only a diff can reveal.
   let files = []
-  if (!flags.has('--broad')) {
-    if (positional.length === 1 && positional[0] === '-') {
-      const stdin = readFileSync(0, 'utf8')
-      files = stdin.split('\n')
-    } else {
-      files = positional
-    }
-    files = files.map((f) => f.trim()).filter(Boolean)
+  if (positional.length === 1 && positional[0] === '-') {
+    files = readFileSync(0, 'utf8').split('\n')
+  } else {
+    files = positional
   }
+  files = files.map((f) => f.trim()).filter(Boolean)
 
-  const result = flags.has('--broad')
-    ? {
-        broad: true,
-        collapsed: false,
-        selectiveCount: 0,
-        prefixes: broadPrefixes(locales),
-        files: homepageUrls(),
-        reasons: [],
-      }
-    : computePurge(files, locales)
+  const result = computePurge(files, locales, { forceBroad: flags.has('--broad') })
 
   if (flags.has('--explain')) {
     for (const r of result.reasons) {

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -119,6 +119,7 @@ export function broadPrefixes(locales) {
     `${HOST}/authors`,
     // Machine-readable docs surfaces.
     `${HOST}/llms`,
+    `${HOST}/api/search`,
     // Localized landing pages + localized docs.
     ...locales.map((locale) => `${HOST}/${locale}`),
     // Standalone pages.
@@ -178,6 +179,22 @@ export function assetFallbackTargets(repoRoot = REPO_ROOT) {
     files: entries.filter((e) => e.isFile()).map((e) => `https://${HOST}/${encodePath(e.name)}`),
   }
 }
+
+/**
+ * The prerendered per-locale search index.
+ *
+ * app/api/search/[lang]/route.ts builds one JSON index per locale from
+ * docsSource with `revalidate = false`, and components/search-dialog.tsx points
+ * Orama at `/api/search/<locale>`, so a docs edit changes it. One prefix covers
+ * every locale.
+ *
+ * Latent today: the route returns cf-cache-status DYNAMIC, and being build
+ * output rather than a cache it is replaced by the deploy itself, so there is
+ * nothing stale to clear. It is here because if the zone's Cache Rule ever
+ * covers /api, a stale index means search returning deleted pages — user-visible
+ * and hard to attribute — and the cost of carrying it is one item.
+ */
+const SEARCH_INDEX_PREFIX = `${HOST}/api/search`
 
 /** Strip a trailing `index` segment so a section index maps to the section root. */
 function stripIndex(slug) {
@@ -240,6 +257,59 @@ export function parseChangedLine(line) {
 }
 
 /**
+ * Parse a whole `git diff --name-status` payload into `{status, file}` records.
+ *
+ * NUL-delimited (`-z`) is the format the workflow uses and the only one that is
+ * unambiguous: git prints pathnames verbatim, so there is no C-quoting to decode
+ * and no whitespace to distinguish from a delimiter. Every bug this seam has
+ * produced — `"public/images/caf\303\251.png"` arriving quoted, a trailing space
+ * being trimmed off a name — was the line-based format leaking into the path.
+ *
+ * Newline-delimited input is still accepted so ad-hoc dry runs can pipe a plain
+ * `--name-status` or a bare list of paths.
+ */
+export function parseChangedInput(raw) {
+  if (!raw.includes('\0')) {
+    return raw
+      .split('\n')
+      .map((line) => line.replace(/\r$/, ''))
+      .filter((line) => line !== '')
+      .map(parseChangedLine)
+  }
+
+  // `-z` emits status and path as separate records: `M<NUL>path<NUL>`.
+  const records = raw.split('\0')
+  if (records.length > 0 && records[records.length - 1] === '') records.pop()
+  if (records.length % 2 !== 0) {
+    throw new Error(`Malformed -z diff: ${records.length} records, expected pairs`)
+  }
+  const changes = []
+  for (let i = 0; i < records.length; i += 2) {
+    changes.push({ status: records[i][0], file: records[i + 1] })
+  }
+  return changes
+}
+
+/**
+ * Paths whose frontmatter `title:`/`icon:` changed, as a NUL-delimited file from
+ * `git diff --name-only -z -G`. Read here rather than joined in the workflow
+ * because ubuntu-latest's `awk` is mawk, which does not handle a NUL record
+ * separator — and doing it here makes it testable.
+ */
+export function readTreeEdits(path = process.env.TREE_EDITS_FILE) {
+  if (!path) return new Set()
+  try {
+    return new Set(
+      readFileSync(path, 'utf8')
+        .split('\0')
+        .filter((entry) => entry !== ''),
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+/**
  * Map one changed file to the prefixes it invalidates.
  *
  * `status` is a git status letter (`A`, `M`, `D`); it decides whether a change
@@ -270,7 +340,7 @@ export function prefixesForFile(file, locales, status = 'M') {
       const locale = meta[2]
       if (locale) {
         return {
-          prefixes: [docsPrefix(locale, '')],
+          prefixes: [docsPrefix(locale, ''), SEARCH_INDEX_PREFIX],
           broad: false,
           reason: `${locale} sidebar — every ${locale} docs page`,
         }
@@ -284,7 +354,7 @@ export function prefixesForFile(file, locales, status = 'M') {
       // the untranslated file matters there, since getOrderedDocsPages() pins
       // itself to i18n.defaultLanguage.
       return {
-        prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`],
+        prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`, SEARCH_INDEX_PREFIX],
         broad: false,
         reason: 'sidebar in every locale — every docs page (+ llms export)',
       }
@@ -300,13 +370,13 @@ export function prefixesForFile(file, locales, status = 'M') {
       const locale = translated[2]
       if (STRUCTURAL.has(status)) {
         return {
-          prefixes: docsTreePrefixes(locales),
+          prefixes: [...docsTreePrefixes(locales), SEARCH_INDEX_PREFIX],
           broad: false,
           reason: `${locale} translation ${STRUCTURAL_REASON[status]} — language switcher and hreflang on every docs page`,
         }
       }
       return {
-        prefixes: [docsPrefix(locale, slug)],
+        prefixes: [docsPrefix(locale, slug), SEARCH_INDEX_PREFIX],
         broad: false,
         reason: `${locale} page`,
       }
@@ -322,13 +392,13 @@ export function prefixesForFile(file, locales, status = 'M') {
       const slug = stripIndex(english[1])
       if (STRUCTURAL.has(status)) {
         return {
-          prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`],
+          prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`, SEARCH_INDEX_PREFIX],
           broad: false,
           reason: `English page ${STRUCTURAL_REASON[status]} — page tree on every docs page (+ llms export)`,
         }
       }
       return {
-        prefixes: [docsPrefix('', slug), `${HOST}/llms`],
+        prefixes: [docsPrefix('', slug), `${HOST}/llms`, SEARCH_INDEX_PREFIX],
         broad: false,
         reason: 'English page (+ generated llms surfaces)',
       }
@@ -449,9 +519,9 @@ export function computePurge(files, locales, { forceBroad = false } = {}) {
   const urls = new Set()
   let broad = forceBroad
 
-  for (const line of files) {
-    if (!line) continue
-    const { status, file } = parseChangedLine(line)
+  for (const entry of files) {
+    if (!entry) continue
+    const { status, file } = typeof entry === 'string' ? parseChangedLine(entry) : entry
     if (!file) continue
     const result = prefixesForFile(file, locales, status)
     reasons.push({ file, status, ...result })
@@ -534,15 +604,18 @@ async function main(argv) {
   // only a diff can reveal.
   let files = []
   if (positional.length === 1 && positional[0] === '-') {
-    files = readFileSync(0, 'utf8').split('\n')
+    files = parseChangedInput(readFileSync(0, 'utf8'))
   } else {
-    files = positional
+    // Bare paths on the command line are modifications by definition.
+    files = positional.map((file) => ({ status: 'M', file }))
   }
-  // Strip the record delimiter only. Whitespace at the edges of a path belongs
-  // to the path: git prints `public/logo.png ` with the trailing space intact
-  // even under core.quotepath=false, and trimming it would purge `/logo.png`
-  // while the real `/logo.png%20` stayed cached.
-  files = files.map((line) => line.replace(/\r$/, '')).filter((line) => line !== '')
+
+  // Frontmatter title/icon edits are structural even though git calls them M:
+  // those values populate the page-tree node every docs page renders.
+  const treeEdits = readTreeEdits()
+  for (const change of files) {
+    if (change.status === 'M' && treeEdits.has(change.file)) change.status = 'T'
+  }
 
   const result = computePurge(files, locales, { forceBroad: flags.has('--broad') })
 

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -49,16 +49,37 @@ export const HOST = 'www.librechat.ai'
  * `pnpm install` and no TypeScript loader — the purge has to work even when the
  * dependency install would fail.
  */
-export function readLocales(repoRoot = REPO_ROOT) {
-  const src = readFileSync(resolve(repoRoot, 'lib/i18n.ts'), 'utf8')
+function parseLocales(src, label) {
   const block = src.match(/languages:\s*\[([^\]]*)\]/)
-  if (!block) throw new Error('lib/i18n.ts: could not find i18n.languages')
+  if (!block) throw new Error(`${label}: could not find i18n.languages`)
   const defaultLanguage = src.match(/defaultLanguage:\s*'([^']+)'/)?.[1]
-  if (!defaultLanguage) throw new Error('lib/i18n.ts: could not find i18n.defaultLanguage')
+  if (!defaultLanguage) throw new Error(`${label}: could not find i18n.defaultLanguage`)
   const languages = [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
   const locales = languages.filter((l) => l !== defaultLanguage)
-  if (locales.length === 0) throw new Error('lib/i18n.ts: parsed an empty locale list')
+  if (locales.length === 0) throw new Error(`${label}: parsed an empty locale list`)
   return locales
+}
+
+export function readLocales(repoRoot = REPO_ROOT, basePath = process.env.BASE_I18N_FILE) {
+  const locales = parseLocales(
+    readFileSync(resolve(repoRoot, 'lib/i18n.ts'), 'utf8'),
+    'lib/i18n.ts',
+  )
+  if (!basePath) return locales
+
+  // A locale dropped in this deploy still has cached pages under /<locale>, but
+  // the deployed file no longer names it, so `broadPrefixes()` would not purge
+  // them and that language would sit there until the TTL. Union with the file as
+  // it was at the diff base. A base that cannot be read or parsed (the range
+  // predates i18n, say) is not fatal: warn and carry on with what deployed.
+  try {
+    const baseSrc = readFileSync(basePath, 'utf8')
+    if (!baseSrc.trim()) return locales
+    return [...new Set([...locales, ...parseLocales(baseSrc, basePath)])]
+  } catch (error) {
+    process.stderr.write(`::warning::Could not read locales from ${basePath}: ${error.message}\n`)
+    return locales
+  }
 }
 
 /**
@@ -153,10 +174,19 @@ function docsTreePrefixes(locales) {
 }
 
 /**
- * Git statuses that add or remove a file. These are the ones that reshape the
- * shared page tree and the locale map; a plain modification does not.
+ * Statuses that reshape what every docs page renders, rather than only the page
+ * they belong to. `A`/`D` come from git. `T` is ours: the workflow marks a
+ * modification whose patch touches a frontmatter `title:`/`icon:` line, because
+ * those values populate the page-tree node the sidebar draws on every page, and
+ * git would otherwise report the edit as an ordinary `M`.
  */
-const STRUCTURAL = new Set(['A', 'D'])
+const STRUCTURAL = new Set(['A', 'D', 'T'])
+
+const STRUCTURAL_REASON = {
+  A: 'added',
+  D: 'deleted',
+  T: 'frontmatter title/icon changed',
+}
 
 /**
  * Parse one line of `git diff --name-status --no-renames` into `{status, file}`.
@@ -236,7 +266,7 @@ export function prefixesForFile(file, locales, status = 'M') {
         return {
           prefixes: docsTreePrefixes(locales),
           broad: false,
-          reason: `${locale} translation ${status === 'A' ? 'added' : 'deleted'} — language switcher and hreflang on every docs page`,
+          reason: `${locale} translation ${STRUCTURAL_REASON[status]} — language switcher and hreflang on every docs page`,
         }
       }
       return {
@@ -258,7 +288,7 @@ export function prefixesForFile(file, locales, status = 'M') {
         return {
           prefixes: [...docsTreePrefixes(locales), `${HOST}/llms`],
           broad: false,
-          reason: `English page ${status === 'A' ? 'added' : 'deleted'} — page tree on every docs page (+ llms export)`,
+          reason: `English page ${STRUCTURAL_REASON[status]} — page tree on every docs page (+ llms export)`,
         }
       }
       return {

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -1,0 +1,356 @@
+/**
+ * Maps changed repository files to the Cloudflare cache prefixes they invalidate.
+ *
+ * Used by .github/workflows/cache-purge.yml after a production deploy. The
+ * output is the list of `hostname/path` prefixes to hand to Cloudflare's
+ * purge-by-prefix API, one per line.
+ *
+ * Why prefixes and not URLs: the App Router serves the HTML document and the
+ * RSC flight payload at the same path, and the flight request carries a
+ * client-generated `?_rsc=<hash>` query. Cloudflare keeps the query string in
+ * the cache key, and those hashes cannot be enumerated from CI, so a purge by
+ * URL only ever removes the HTML variant. A prefix purge removes every cache
+ * key that starts with the prefix — HTML and every `_rsc` variant together.
+ *
+ * Usage:
+ *   node scripts/cache-purge-prefixes.mjs <file> [<file>...]
+ *   git diff --name-only A B | node scripts/cache-purge-prefixes.mjs -
+ *   node scripts/cache-purge-prefixes.mjs --broad
+ *
+ * Flags:
+ *   --broad        ignore the file list and emit the broad (site-wide) set
+ *   --json         emit {prefixes, files, broad, reasons} instead of plain lines
+ *   --explain      write the per-file mapping decisions to stderr
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, '..')
+
+/** The production hostname. Prefix purges take `hostname/path`, with no scheme. */
+export const HOST = 'www.librechat.ai'
+
+/**
+ * Non-default locales, read from lib/i18n.ts so this file never becomes a
+ * second copy of the locale list that can drift from the one the site builds.
+ * `hideLocale: 'default-locale'` keeps English at `/docs/...`; every other
+ * locale is served under `/<locale>/docs/...`.
+ *
+ * Parsed rather than imported because this script runs on a bare runner with no
+ * `pnpm install` and no TypeScript loader — the purge has to work even when the
+ * dependency install would fail.
+ */
+export function readLocales(repoRoot = REPO_ROOT) {
+  const src = readFileSync(resolve(repoRoot, 'lib/i18n.ts'), 'utf8')
+  const block = src.match(/languages:\s*\[([^\]]*)\]/)
+  if (!block) throw new Error('lib/i18n.ts: could not find i18n.languages')
+  const defaultLanguage = src.match(/defaultLanguage:\s*'([^']+)'/)?.[1]
+  if (!defaultLanguage) throw new Error('lib/i18n.ts: could not find i18n.defaultLanguage')
+  const languages = [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
+  const locales = languages.filter((l) => l !== defaultLanguage)
+  if (locales.length === 0) throw new Error('lib/i18n.ts: parsed an empty locale list')
+  return locales
+}
+
+/**
+ * Paths that cannot change a rendered page. Everything else that is not content
+ * falls back to the broad purge, so this list is deliberately short: a file only
+ * belongs here when it is provably not part of the deployed site.
+ */
+const INERT = [
+  /^\.github\//,
+  /^docs\//, // repo-internal notes; site content lives in content/
+  /^e2e\//,
+  /^__tests__\//,
+  /^scripts\/screenshots\//,
+  /(^|\/)__tests__\//,
+  /\.test\.(ts|tsx|mjs|js)$/,
+  /^(README|LICENSE|CONTRIBUTING|SECURITY|CHANGELOG|PURGE-NOTES)(\.md)?$/,
+  /^\.(gitignore|prettierignore|prettierrc\.js|lycheeignore|npmrc|husky)/,
+  /^playwright\.config\.ts$/,
+  /^vitest\.config\.ts$/,
+  /^eslint\.config\.mjs$/,
+]
+
+/**
+ * The broad set: every cached route family plus the standalone landing pages.
+ *
+ * `/<locale>` covers both the localized landing page and `/<locale>/docs/**`.
+ * `/llms` covers /llms.txt, /llms-full.txt and /llms.mdx/**, which are all
+ * generated from the docs content.
+ */
+export function broadPrefixes(locales) {
+  return [
+    // The four top-level content trees.
+    `${HOST}/docs`,
+    `${HOST}/blog`,
+    `${HOST}/changelog`,
+    `${HOST}/authors`,
+    // Machine-readable docs surfaces.
+    `${HOST}/llms`,
+    // Localized landing pages + localized docs.
+    ...locales.map((locale) => `${HOST}/${locale}`),
+    // Standalone pages.
+    `${HOST}/about`,
+    `${HOST}/toolkit`,
+    `${HOST}/privacy`,
+    `${HOST}/tos`,
+    `${HOST}/cookie`,
+  ]
+}
+
+/**
+ * The homepage cannot be purged by prefix: `www.librechat.ai/` is a prefix of
+ * every URL on the zone, so it would evict the static asset cache too — the
+ * thing purge_everything is avoided for. Purge it by exact URL instead and
+ * accept that its `?_rsc=` variants are not covered (they are `private,
+ * no-store` in next.config.mjs, so they should not be in the edge cache at all).
+ *
+ * The localized landing pages need no entry here: `/<locale>` is a usable
+ * prefix and is already in the broad set.
+ */
+export function homepageUrls() {
+  return [`https://${HOST}/`]
+}
+
+/** Strip a trailing `index` segment so a section index maps to the section root. */
+function stripIndex(slug) {
+  if (slug === 'index') return ''
+  return slug.replace(/(^|\/)index$/, '')
+}
+
+function docsPrefix(locale, slug) {
+  const base = locale ? `${HOST}/${locale}/docs` : `${HOST}/docs`
+  return slug ? `${base}/${slug}` : base
+}
+
+/**
+ * Map one changed file to the prefixes it invalidates.
+ *
+ * Returns `{prefixes, broad, reason}`. `broad: true` means the file is shared
+ * or unrecognised and the caller must fall back to the site-wide set — the
+ * default for anything this function does not understand, so a new file type
+ * over-purges instead of silently going stale.
+ */
+export function prefixesForFile(file, locales) {
+  const localeAlt = locales.map((l) => l.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+
+  if (INERT.some((re) => re.test(file))) {
+    return { prefixes: [], broad: false, reason: 'inert (not part of the deployed site)' }
+  }
+
+  // --- content/docs -------------------------------------------------------
+  const docs = file.match(/^content\/docs\/(.*)$/)
+  if (docs) {
+    const rest = docs[1]
+
+    // meta.json / meta.<locale>.json — sidebar and ordering for a whole section,
+    // so every page in that section (and its subsections) changes.
+    const meta = rest.match(new RegExp(`^(?:(.*)\\/)?meta(?:\\.(${localeAlt}))?\\.json$`))
+    if (meta) {
+      const dir = meta[1] ?? ''
+      const locale = meta[2]
+      if (locale) {
+        return {
+          prefixes: [docsPrefix(locale, dir)],
+          broad: false,
+          reason: `${locale} sidebar for section /${dir || '(root)'}`,
+        }
+      }
+      // The untranslated meta.json is the source of truth for section structure;
+      // fumadocs falls back to it for any locale whose meta.<locale>.json is
+      // missing a key, so a change to it reaches every language.
+      return {
+        prefixes: [docsPrefix('', dir), ...locales.map((l) => docsPrefix(l, dir))],
+        broad: false,
+        reason: `section /${dir || '(root)'} in every locale (sidebar + ordering)`,
+      }
+    }
+
+    // <path>.<locale>.mdx — one translated page.
+    const translated = rest.match(new RegExp(`^(.*)\\.(${localeAlt})\\.mdx$`))
+    if (translated) {
+      const slug = stripIndex(translated[1])
+      const locale = translated[2]
+      return {
+        prefixes: [docsPrefix(locale, slug)],
+        broad: false,
+        reason: `${locale} page`,
+      }
+    }
+
+    // <path>.mdx — one English page. Also purge /llms*, which is generated from
+    // the English docs. Translations are separate files and map on their own;
+    // a locale URL with no translation 307s to the English one and that redirect
+    // does not change when the English body does.
+    const english = rest.match(/^(.*)\.mdx$/)
+    if (english) {
+      const slug = stripIndex(english[1])
+      return {
+        prefixes: [docsPrefix('', slug), `${HOST}/llms`],
+        broad: false,
+        reason: 'English page (+ generated llms surfaces)',
+      }
+    }
+
+    // Anything else under content/docs (a new file type, an asset): purge the
+    // section it lives in rather than guessing which pages embed it.
+    const dir = rest.includes('/') ? rest.slice(0, rest.lastIndexOf('/')) : ''
+    return {
+      prefixes: [docsPrefix('', dir), ...locales.map((l) => docsPrefix(l, dir))],
+      broad: false,
+      reason: 'unrecognised file under content/docs — purging its section',
+    }
+  }
+
+  // --- content/blog, content/changelog ------------------------------------
+  // The listing page shares its prefix with every post under it, so purging the
+  // post also purges the index — which has to happen anyway, since the index
+  // shows titles, dates and excerpts. /authors goes with the blog because author
+  // pages list a writer's posts.
+  if (/^content\/blog\//.test(file)) {
+    return {
+      prefixes: [`${HOST}/blog`, `${HOST}/authors`],
+      broad: false,
+      reason: 'blog index + posts + author pages',
+    }
+  }
+  if (/^content\/changelog\//.test(file)) {
+    return {
+      prefixes: [`${HOST}/changelog`],
+      broad: false,
+      reason: 'changelog index + entries',
+    }
+  }
+
+  // --- everything else -----------------------------------------------------
+  // lib/, components/, app/, next.config.mjs, proxy.ts, source.config.ts,
+  // package.json, public/, ... any of these can change every rendered page.
+  // Per-page dependency analysis is not attempted.
+  return { prefixes: [], broad: true, reason: 'shared/global file' }
+}
+
+/**
+ * Drop prefixes already covered by a shorter one in the same set: purging
+ * `www.librechat.ai/docs` also purges `www.librechat.ai/docs/local/docker`, so
+ * sending both wastes an item against the per-call limit.
+ *
+ * Only exact and segment-boundary containment count. Cloudflare's prefix match
+ * is a plain string match, so `/docs/features/agents` would in fact also cover
+ * `/docs/features/agents-anything` — but relying on that to *drop* an entry
+ * would make a mapping bug silently under-purge, so keep the strict rule here
+ * and let the string match over-purge on the Cloudflare side.
+ */
+export function dropCoveredPrefixes(prefixes) {
+  const sorted = [...new Set(prefixes)].sort()
+  return sorted.filter(
+    (prefix) => !sorted.some((other) => other !== prefix && prefix.startsWith(`${other}/`)),
+  )
+}
+
+/**
+ * Above this many prefixes a "selective" purge is neither selective nor cheap:
+ * a change that wide is a site-wide change in practice, and the broad set is
+ * both smaller to send and safer. Collapsing is logged, never silent.
+ */
+export const COLLAPSE_THRESHOLD = 200
+
+/** Map a list of changed files to the purge payload. */
+export function computePurge(files, locales) {
+  const reasons = []
+  const set = new Set()
+  let broad = false
+
+  for (const file of files) {
+    if (!file) continue
+    const result = prefixesForFile(file, locales)
+    reasons.push({ file, ...result })
+    if (result.broad) broad = true
+    for (const prefix of result.prefixes) set.add(prefix)
+  }
+
+  const prefixes = dropCoveredPrefixes([...set])
+
+  let collapsed = false
+  if (!broad && prefixes.length > COLLAPSE_THRESHOLD) {
+    broad = true
+    collapsed = true
+  }
+
+  if (broad) {
+    return {
+      broad: true,
+      collapsed,
+      selectiveCount: prefixes.length,
+      prefixes: broadPrefixes(locales),
+      files: homepageUrls(),
+      reasons,
+    }
+  }
+
+  return {
+    broad: false,
+    collapsed,
+    selectiveCount: prefixes.length,
+    prefixes,
+    files: [],
+    reasons,
+  }
+}
+
+async function main(argv) {
+  const flags = new Set(argv.filter((a) => a.startsWith('--')))
+  const positional = argv.filter((a) => !a.startsWith('--'))
+  const locales = readLocales()
+
+  let files = []
+  if (!flags.has('--broad')) {
+    if (positional.length === 1 && positional[0] === '-') {
+      const stdin = readFileSync(0, 'utf8')
+      files = stdin.split('\n')
+    } else {
+      files = positional
+    }
+    files = files.map((f) => f.trim()).filter(Boolean)
+  }
+
+  const result = flags.has('--broad')
+    ? {
+        broad: true,
+        collapsed: false,
+        selectiveCount: 0,
+        prefixes: broadPrefixes(locales),
+        files: homepageUrls(),
+        reasons: [],
+      }
+    : computePurge(files, locales)
+
+  if (flags.has('--explain')) {
+    for (const r of result.reasons) {
+      const target = r.broad ? 'BROAD' : r.prefixes.length ? r.prefixes.join(', ') : '(nothing)'
+      process.stderr.write(`${r.file}\n  -> ${target}\n     ${r.reason}\n`)
+    }
+    if (result.collapsed) {
+      process.stderr.write(
+        `\n${result.selectiveCount} prefixes exceeded the ${COLLAPSE_THRESHOLD} cap — collapsed to the broad set\n`,
+      )
+    }
+  }
+
+  if (flags.has('--json')) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+    return
+  }
+
+  for (const prefix of result.prefixes) process.stdout.write(`${prefix}\n`)
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error.stack ?? error}\n`)
+    process.exit(1)
+  })
+}

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -538,7 +538,11 @@ async function main(argv) {
   } else {
     files = positional
   }
-  files = files.map((f) => f.trim()).filter(Boolean)
+  // Strip the record delimiter only. Whitespace at the edges of a path belongs
+  // to the path: git prints `public/logo.png ` with the trailing space intact
+  // even under core.quotepath=false, and trimming it would purge `/logo.png`
+  // while the real `/logo.png%20` stayed cached.
+  files = files.map((line) => line.replace(/\r$/, '')).filter((line) => line !== '')
 
   const result = computePurge(files, locales, { forceBroad: flags.has('--broad') })
 

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -24,12 +24,13 @@
  *   node scripts/cache-purge-prefixes.mjs --broad
  *
  * Flags:
- *   --broad        ignore the file list and emit the broad (site-wide) set
+ *   --broad        start from the broad (site-wide) page set
+ *   --assets       add every public/ asset, for recovery runs with no diff
  *   --json         emit {prefixes, files, broad, reasons} instead of plain lines
  *   --explain      write the per-file mapping decisions to stderr
  */
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -153,6 +154,29 @@ export function homepageUrls() {
  */
 export function encodePath(path) {
   return path.split('/').map(encodeURIComponent).join('/')
+}
+
+/**
+ * Everything under `public/`, as purge targets, read from the checkout.
+ *
+ * For the recovery paths that have no diff to work from: a manual run with no
+ * range, an unreachable base commit, or no previously purged deployment. The
+ * broad set covers pages only, so without this a run that cannot see the diff
+ * leaves a replaced asset served from the edge — and those are exactly the runs
+ * that exist because something already went wrong.
+ *
+ * Top-level directories become prefixes and top-level files become exact URLs,
+ * which on this repo is 2 + 21 entries: precise, bounded, and no guessing about
+ * what changed. Deliberately NOT part of the ordinary broad set, where evicting
+ * every image on any shared-file change would be the asset MISS wave that
+ * avoiding `purge_everything` exists to prevent.
+ */
+export function assetFallbackTargets(repoRoot = REPO_ROOT) {
+  const entries = readdirSync(resolve(repoRoot, 'public'), { withFileTypes: true })
+  return {
+    prefixes: entries.filter((e) => e.isDirectory()).map((e) => `${HOST}/${encodePath(e.name)}`),
+    files: entries.filter((e) => e.isFile()).map((e) => `https://${HOST}/${encodePath(e.name)}`),
+  }
 }
 
 /** Strip a trailing `index` segment so a section index maps to the section root. */
@@ -472,7 +496,7 @@ export function computePurge(files, locales, { forceBroad = false } = {}) {
 }
 
 /** Every flag this script understands. A typo must not be mistaken for one of these. */
-export const KNOWN_FLAGS = ['--broad', '--json', '--explain']
+export const KNOWN_FLAGS = ['--broad', '--assets', '--json', '--explain']
 
 /**
  * Split argv into flags and positionals, rejecting anything unrecognised.
@@ -517,6 +541,12 @@ async function main(argv) {
   files = files.map((f) => f.trim()).filter(Boolean)
 
   const result = computePurge(files, locales, { forceBroad: flags.has('--broad') })
+
+  if (flags.has('--assets')) {
+    const assets = assetFallbackTargets()
+    result.prefixes = dropCoveredPrefixes([...result.prefixes, ...assets.prefixes])
+    result.files = [...new Set([...result.files, ...assets.files])].sort()
+  }
 
   if (flags.has('--explain')) {
     for (const r of result.reasons) {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -9,6 +9,7 @@ import {
   dropCoveredPrefixes,
   homepageUrls,
   parseArgs,
+  parseChangedLine,
   prefixesForFile,
   readLocales,
 } from './cache-purge-prefixes.mjs'
@@ -94,6 +95,103 @@ describe('parseArgs', () => {
   })
 })
 
+describe('the workflow feeds the mapper what it needs', () => {
+  const workflow = readFileSync(
+    fileURLToPath(new URL('../.github/workflows/cache-purge.yml', import.meta.url)),
+    'utf8',
+  )
+
+  /**
+   * Git's rename detection is on by default and reports a moved file as its
+   * destination alone, so without this flag a page moved without edits keeps its
+   * old URL cached until the TTL expires.
+   */
+  it('disables rename detection on every diff it runs', () => {
+    // Executable lines only: a `git diff` mentioned inside a `#` comment is prose.
+    const diffs = workflow
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .filter((line) => line.includes('git diff'))
+    expect(diffs.length).toBeGreaterThan(0)
+    for (const diff of diffs) {
+      expect(diff).toContain('--no-renames')
+    }
+  })
+
+  it('passes the status column, which decides structural vs content changes', () => {
+    expect(workflow).toContain('git diff --name-status --no-renames')
+  })
+})
+
+describe('parseChangedLine', () => {
+  it.each([
+    ['A\tcontent/docs/features/new.mdx', 'A', 'content/docs/features/new.mdx'],
+    ['D\tcontent/docs/features/old.mdx', 'D', 'content/docs/features/old.mdx'],
+    ['M\tcontent/docs/features/edit.mdx', 'M', 'content/docs/features/edit.mdx'],
+  ])('parses %s', (line, status, file) => {
+    expect(parseChangedLine(line)).toEqual({ status, file })
+  })
+
+  it('treats a bare path as a modification, so ad-hoc dry runs still work', () => {
+    expect(parseChangedLine('content/docs/local/docker.mdx')).toEqual({
+      status: 'M',
+      file: 'content/docs/local/docker.mdx',
+    })
+  })
+
+  it('takes the destination if a rename ever slips through', () => {
+    expect(parseChangedLine('R100\tcontent/docs/a.mdx\tcontent/docs/b.mdx')).toEqual({
+      status: 'R',
+      file: 'content/docs/b.mdx',
+    })
+  })
+})
+
+describe('structural changes', () => {
+  const docsTree = ['www.librechat.ai/docs', ...locales.map((l) => `www.librechat.ai/${l}/docs`)]
+
+  /**
+   * lib/docs-layout.tsx hands the complete docsSource.pageTree to DocsLayout for
+   * every page, so adding or removing a node changes every docs page's sidebar.
+   */
+  it.each(['A', 'D'])('purges the whole docs tree when an English page is %sed', (status) => {
+    const { prefixes } = prefixesForFile('content/docs/features/agents.mdx', locales, status)
+    for (const prefix of docsTree) expect(prefixes).toContain(prefix)
+    expect(prefixes).toContain('www.librechat.ai/llms')
+  })
+
+  it('keeps an edited English page scoped to itself', () => {
+    expect(prefixesForFile('content/docs/features/agents.mdx', locales, 'M').prefixes).toEqual([
+      'www.librechat.ai/docs/features/agents',
+      'www.librechat.ai/llms',
+    ])
+  })
+
+  /**
+   * getAvailableLocalesBySlug() is one site-wide map embedded in every docs page,
+   * and lib/docs-page.tsx derives hreflang from which translations exist.
+   */
+  it.each(['A', 'D'])('purges the whole docs tree when a translation is %sed', (status) => {
+    const { prefixes } = prefixesForFile('content/docs/features/agents.ja.mdx', locales, status)
+    for (const prefix of docsTree) expect(prefixes).toContain(prefix)
+  })
+
+  it('keeps an edited translation scoped to itself, so a sweep stays cheap', () => {
+    expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales, 'M').prefixes).toEqual([
+      'www.librechat.ai/ja/docs/features/agents',
+    ])
+  })
+
+  it('maps a rename as delete + add, covering the old URL', () => {
+    const result = computePurge(
+      ['D\tcontent/docs/local/docker.mdx', 'A\tcontent/docs/local/docker-compose.mdx'],
+      locales,
+    )
+    // Both sides are structural, so the tree purge covers the vacated URL.
+    expect(result.prefixes).toContain('www.librechat.ai/docs')
+  })
+})
+
 describe('docs pages', () => {
   it('maps an English page to its docs path', () => {
     expect(prefixesForFile('content/docs/local/docker.mdx', locales).prefixes).toEqual([
@@ -134,12 +232,22 @@ describe('docs pages', () => {
 })
 
 describe('meta.json', () => {
-  it('purges a section in every locale, because it drives sidebar and ordering', () => {
+  /**
+   * Not section-scoped: lib/docs-layout.tsx renders the complete page tree into
+   * every docs page, so a sidebar change reaches pages in unrelated sections.
+   */
+  it('purges every docs page in every locale, not just the section it sits in', () => {
     const { prefixes } = prefixesForFile('content/docs/local/meta.json', locales)
-    expect(prefixes).toContain('www.librechat.ai/docs/local')
-    expect(prefixes).toContain('www.librechat.ai/pt-BR/docs/local')
-    // English + one per locale + the llms export.
+    expect(prefixes).toContain('www.librechat.ai/docs')
+    expect(prefixes).toContain('www.librechat.ai/pt-BR/docs')
+    // The docs root, one per locale, and the llms export.
     expect(prefixes).toHaveLength(locales.length + 2)
+  })
+
+  it('does not stop at the section prefix, which would leave other pages stale', () => {
+    expect(prefixesForFile('content/docs/local/meta.json', locales).prefixes).not.toContain(
+      'www.librechat.ai/docs/local',
+    )
   })
 
   /**
@@ -167,18 +275,19 @@ describe('meta.json', () => {
     expect(prefixes).toContain('www.librechat.ai/zh/docs')
   })
 
-  it('limits a localized meta file to its own locale', () => {
+  it('limits a localized meta file to its own locale, but to all of that locale', () => {
     expect(prefixesForFile('content/docs/configuration/meta.de.json', locales).prefixes).toEqual([
-      'www.librechat.ai/de/docs/configuration',
+      'www.librechat.ai/de/docs',
     ])
   })
 
-  it('handles a deeply nested section', () => {
+  it('treats a deeply nested meta.json the same as any other', () => {
     const { prefixes } = prefixesForFile(
       'content/docs/configuration/librechat_yaml/ai_endpoints/meta.json',
       locales,
     )
-    expect(prefixes).toContain('www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints')
+    expect(prefixes).toContain('www.librechat.ai/docs')
+    expect(prefixes).toHaveLength(locales.length + 2)
   })
 })
 

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLLAPSE_THRESHOLD,
+  broadPrefixes,
+  computePurge,
+  dropCoveredPrefixes,
+  homepageUrls,
+  prefixesForFile,
+  readLocales,
+} from './cache-purge-prefixes.mjs'
+
+const locales = readLocales()
+
+/** The mapping is the fragile part of the purge: a wrong prefix is a silently stale page. */
+describe('readLocales', () => {
+  it('reads the non-default locales from lib/i18n.ts', () => {
+    expect(locales).toEqual([
+      'zh',
+      'es',
+      'fr',
+      'de',
+      'ja',
+      'pt-BR',
+      'it',
+      'nl',
+      'pl',
+      'vi',
+      'ko',
+      'id',
+      'tr',
+    ])
+  })
+
+  it('excludes the default language, which has no URL prefix', () => {
+    expect(locales).not.toContain('en')
+  })
+})
+
+describe('docs pages', () => {
+  it('maps an English page to its docs path', () => {
+    expect(prefixesForFile('content/docs/local/docker.mdx', locales).prefixes).toEqual([
+      'www.librechat.ai/docs/local/docker',
+      'www.librechat.ai/llms',
+    ])
+  })
+
+  it('maps a section index to the section root', () => {
+    expect(prefixesForFile('content/docs/quick_start/index.mdx', locales).prefixes).toContain(
+      'www.librechat.ai/docs/quick_start',
+    )
+  })
+
+  it('maps the docs root index to /docs', () => {
+    expect(prefixesForFile('content/docs/index.mdx', locales).prefixes).toContain(
+      'www.librechat.ai/docs',
+    )
+  })
+
+  it('maps a translation to the locale-prefixed path only', () => {
+    expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales).prefixes).toEqual([
+      'www.librechat.ai/ja/docs/features/agents',
+    ])
+  })
+
+  it('keeps the pt-BR locale case exactly as the route serves it', () => {
+    expect(prefixesForFile('content/docs/compatibility.pt-BR.mdx', locales).prefixes).toEqual([
+      'www.librechat.ai/pt-BR/docs/compatibility',
+    ])
+  })
+
+  it('maps a translated section index to the localized section root', () => {
+    expect(prefixesForFile('content/docs/toolkit/index.de.mdx', locales).prefixes).toEqual([
+      'www.librechat.ai/de/docs/toolkit',
+    ])
+  })
+})
+
+describe('meta.json', () => {
+  it('purges a section in every locale, because it drives sidebar and ordering', () => {
+    const { prefixes } = prefixesForFile('content/docs/local/meta.json', locales)
+    expect(prefixes).toContain('www.librechat.ai/docs/local')
+    expect(prefixes).toContain('www.librechat.ai/pt-BR/docs/local')
+    expect(prefixes).toHaveLength(locales.length + 1)
+  })
+
+  it('purges everything under /docs for the root meta.json', () => {
+    const { prefixes } = prefixesForFile('content/docs/meta.json', locales)
+    expect(prefixes).toContain('www.librechat.ai/docs')
+    expect(prefixes).toContain('www.librechat.ai/zh/docs')
+  })
+
+  it('limits a localized meta file to its own locale', () => {
+    expect(prefixesForFile('content/docs/configuration/meta.de.json', locales).prefixes).toEqual([
+      'www.librechat.ai/de/docs/configuration',
+    ])
+  })
+
+  it('handles a deeply nested section', () => {
+    const { prefixes } = prefixesForFile(
+      'content/docs/configuration/librechat_yaml/ai_endpoints/meta.json',
+      locales,
+    )
+    expect(prefixes).toContain('www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints')
+  })
+})
+
+describe('blog and changelog', () => {
+  it('purges the blog index, its posts and the author pages together', () => {
+    expect(
+      prefixesForFile('content/blog/2026-07-26_clickhouse-analytics.mdx', locales).prefixes,
+    ).toEqual(['www.librechat.ai/blog', 'www.librechat.ai/authors'])
+  })
+
+  it('purges the changelog index and entries together', () => {
+    expect(prefixesForFile('content/changelog/config_v1.1.9.mdx', locales).prefixes).toEqual([
+      'www.librechat.ai/changelog',
+    ])
+  })
+})
+
+describe('fallbacks', () => {
+  it.each([
+    'lib/source.ts',
+    'components/home/HomePageContent.tsx',
+    'app/docs/[[...slug]]/page.tsx',
+    'next.config.mjs',
+    'proxy.ts',
+    'package.json',
+    'public/images/logo.svg',
+  ])('falls back to a broad purge for %s', (file) => {
+    expect(prefixesForFile(file, locales).broad).toBe(true)
+  })
+
+  it('treats an unknown file type under content/docs as a section change, not a no-op', () => {
+    const { prefixes, broad } = prefixesForFile('content/docs/features/diagram.png', locales)
+    expect(broad).toBe(false)
+    expect(prefixes).toContain('www.librechat.ai/docs/features')
+  })
+
+  it.each(['.github/workflows/ci.yml', 'e2e/home.spec.ts', 'README.md', 'lib/i18n/tm.test.ts'])(
+    'purges nothing for %s',
+    (file) => {
+      const result = prefixesForFile(file, locales)
+      expect(result.broad).toBe(false)
+      expect(result.prefixes).toEqual([])
+    },
+  )
+})
+
+describe('computePurge', () => {
+  it('drops prefixes already covered by a broader one', () => {
+    expect(
+      dropCoveredPrefixes([
+        'www.librechat.ai/docs',
+        'www.librechat.ai/docs/local/docker',
+        'www.librechat.ai/blog',
+      ]),
+    ).toEqual(['www.librechat.ai/blog', 'www.librechat.ai/docs'])
+  })
+
+  it('does not drop a sibling that merely shares a string prefix', () => {
+    expect(
+      dropCoveredPrefixes([
+        'www.librechat.ai/docs/features/agents',
+        'www.librechat.ai/docs/features/agents-anything',
+      ]),
+    ).toHaveLength(2)
+  })
+
+  it('maps a deletion exactly like a modification — the stale entry has to go', () => {
+    const deleted = computePurge(['content/docs/features/removed_page.mdx'], locales)
+    expect(deleted.prefixes).toContain('www.librechat.ai/docs/features/removed_page')
+  })
+
+  it('escalates to broad when any file is shared', () => {
+    const result = computePurge(['content/docs/local/docker.mdx', 'lib/source.ts'], locales)
+    expect(result.broad).toBe(true)
+    expect(result.prefixes).toEqual(broadPrefixes(locales))
+    expect(result.files).toEqual(homepageUrls())
+  })
+
+  it('collapses to broad past the prefix cap instead of sending hundreds of items', () => {
+    const files = Array.from(
+      { length: COLLAPSE_THRESHOLD + 1 },
+      (_, i) => `content/docs/features/page${i}.mdx`,
+    )
+    const result = computePurge(files, locales)
+    expect(result.collapsed).toBe(true)
+    expect(result.broad).toBe(true)
+  })
+
+  it('purges nothing when a deploy touched no rendered page', () => {
+    const result = computePurge(['.github/workflows/ci.yml'], locales)
+    expect(result.prefixes).toEqual([])
+    expect(result.broad).toBe(false)
+  })
+
+  it('never emits a bare-host prefix, which would evict the static asset cache', () => {
+    for (const prefix of broadPrefixes(locales)) {
+      expect(prefix).toMatch(/^www\.librechat\.ai\/.+/)
+    }
+  })
+})

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -141,20 +141,48 @@ describe('the workflow feeds the mapper what it needs', () => {
    * destination alone, so without this flag a page moved without edits keeps its
    * old URL cached until the TTL expires.
    */
+  // Executable lines only: a `git diff` mentioned inside a `#` comment is prose.
+  // Matched loosely because the command carries `-c` options before `diff`.
+  const diffLines = workflow
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('#'))
+    .filter((line) => /\bgit\b[^\n]*\bdiff\b/.test(line))
+
   it('disables rename detection on every diff it runs', () => {
-    // Executable lines only: a `git diff` mentioned inside a `#` comment is prose.
-    const diffs = workflow
-      .split('\n')
-      .filter((line) => !line.trim().startsWith('#'))
-      .filter((line) => line.includes('git diff'))
-    expect(diffs.length).toBeGreaterThan(0)
-    for (const diff of diffs) {
+    expect(diffLines.length).toBeGreaterThan(0)
+    for (const diff of diffLines) {
       expect(diff).toContain('--no-renames')
     }
   })
 
+  /**
+   * Git C-quotes any non-ASCII path by default: `public/images/café.png` arrives
+   * as `"public/images/caf\303\251.png"`, matches no rule, and the asset URL is
+   * never purged — even though the mapper itself handles Unicode correctly.
+   */
+  it('reads pathnames losslessly on every diff it runs', () => {
+    for (const diff of diffLines) {
+      expect(diff).toContain('core.quotepath=false')
+    }
+  })
+
   it('passes the status column, which decides structural vs content changes', () => {
-    expect(workflow).toContain('git diff --name-status --no-renames')
+    expect(workflow).toMatch(/git[^\n]*diff --name-status --no-renames/)
+  })
+
+  /**
+   * A peer that accepts the connection and then stops responding would otherwise
+   * never return, so the retry loop never sees a failure and the job sits until
+   * the platform timeout. Runs overlap by design, so several can pile up.
+   */
+  it('bounds every Cloudflare request so a stall becomes a retry', () => {
+    const curls = workflow
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .filter((line) => /\bcurl\b/.test(line))
+    expect(curls.length).toBeGreaterThan(0)
+    expect(workflow).toContain('--connect-timeout "$CURL_CONNECT_TIMEOUT"')
+    expect(workflow).toContain('--max-time "$CURL_MAX_TIME"')
   })
 
   /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
@@ -38,6 +40,37 @@ describe('readLocales', () => {
 
   it('excludes the default language, which has no URL prefix', () => {
     expect(locales).not.toContain('en')
+  })
+
+  /**
+   * A locale dropped in this deploy is gone from the deployed lib/i18n.ts, so
+   * broadPrefixes() would never emit `/<locale>` and that language's cached
+   * pages would sit at the edge until the TTL expired.
+   */
+  it('unions in a locale that existed at the diff base but was removed', () => {
+    const base = join(tmpdir(), `purge-base-i18n-${process.pid}.ts`)
+    writeFileSync(
+      base,
+      `export const i18n = { defaultLanguage: 'en', languages: ['en', 'zh', 'sv'] }`,
+    )
+    try {
+      const unioned = readLocales(undefined, base)
+      expect(unioned).toContain('sv')
+      expect(unioned).toEqual(expect.arrayContaining(locales))
+      expect(broadPrefixes(unioned)).toContain('www.librechat.ai/sv')
+    } finally {
+      rmSync(base, { force: true })
+    }
+  })
+
+  it('falls back to the deployed list when the base file cannot be parsed', () => {
+    const base = join(tmpdir(), `purge-bad-i18n-${process.pid}.ts`)
+    writeFileSync(base, 'this is not the i18n config')
+    try {
+      expect(readLocales(undefined, base)).toEqual(locales)
+    } finally {
+      rmSync(base, { force: true })
+    }
   })
 })
 
@@ -180,6 +213,31 @@ describe('structural changes', () => {
     expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales, 'M').prefixes).toEqual([
       'www.librechat.ai/ja/docs/features/agents',
     ])
+  })
+
+  /**
+   * The sidebar draws each page's title and icon from the page-tree node, so a
+   * frontmatter edit changes every docs page even though git reports it as M.
+   * The workflow marks those files `T` via `git diff -G'^(title|icon):'`.
+   */
+  it('treats a frontmatter title/icon edit as structural', () => {
+    const { prefixes, reason } = prefixesForFile('content/docs/features/agents.mdx', locales, 'T')
+    expect(prefixes).toContain('www.librechat.ai/docs')
+    expect(prefixes).toContain('www.librechat.ai/zh/docs')
+    expect(reason).toContain('frontmatter')
+  })
+
+  it('marks a translated page structural on a frontmatter edit too', () => {
+    expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales, 'T').prefixes).toContain(
+      'www.librechat.ai/docs',
+    )
+  })
+
+  it('parses the T status the workflow injects', () => {
+    expect(parseChangedLine('T\tcontent/docs/features/agents.mdx')).toEqual({
+      status: 'T',
+      file: 'content/docs/features/agents.mdx',
+    })
   })
 
   it('maps a rename as delete + add, covering the old URL', () => {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -219,6 +219,13 @@ describe('parseChangedLine', () => {
     })
   })
 
+  it('strips a carriage return, which is a delimiter artifact rather than path', () => {
+    expect(parseChangedLine('M\tpublic/logo.png\r'.replace(/\r$/, ''))).toEqual({
+      status: 'M',
+      file: 'public/logo.png',
+    })
+  })
+
   it('takes the destination if a rename ever slips through', () => {
     expect(parseChangedLine('R100\tcontent/docs/a.mdx\tcontent/docs/b.mdx')).toEqual({
       status: 'R',
@@ -461,6 +468,17 @@ describe('URL encoding', () => {
     ['public/images/a%b.png', '/images/a%25b.png'],
   ])('encodes %s', (file, expected) => {
     expect(prefixesForFile(file, locales).files).toEqual([`https://www.librechat.ai${expected}`])
+  })
+
+  /**
+   * Git prints a trailing space literally, even under core.quotepath=false, so
+   * trimming the record would purge `/logo.png` while the real `/logo.png%20`
+   * stayed cached.
+   */
+  it('keeps whitespace that belongs to the path', () => {
+    expect(prefixesForFile('public/logo.png ', locales).files).toEqual([
+      'https://www.librechat.ai/logo.png%20',
+    ])
   })
 
   it('keeps the path separators as separators', () => {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import {
   COLLAPSE_THRESHOLD,
   KNOWN_FLAGS,
+  assetFallbackTargets,
   broadPrefixes,
   computePurge,
   dropCoveredPrefixes,
@@ -77,7 +78,7 @@ describe('readLocales', () => {
 
 describe('parseArgs', () => {
   it('accepts exactly the three documented flags', () => {
-    expect(KNOWN_FLAGS).toEqual(['--broad', '--json', '--explain'])
+    expect(KNOWN_FLAGS).toEqual(['--broad', '--assets', '--json', '--explain'])
   })
 
   it('separates known flags from file arguments', () => {
@@ -99,7 +100,7 @@ describe('parseArgs', () => {
 
   it('names the offending flag and the accepted ones', () => {
     expect(() => parseArgs(['--deleted'])).toThrow(
-      'Unknown flag: --deleted\nKnown flags: --broad, --json, --explain',
+      'Unknown flag: --deleted\nKnown flags: --broad, --assets, --json, --explain',
     )
   })
 
@@ -486,6 +487,40 @@ describe('broad recovery', () => {
     const result = computePurge(['M\tcontent/docs/local/docker.mdx'], locales, { forceBroad: true })
     expect(result.prefixes).not.toContain('www.librechat.ai/docs/local/docker')
     expect(result.prefixes).toContain('www.librechat.ai/docs')
+  })
+})
+
+describe('asset fallback for runs with no diff', () => {
+  const assets = assetFallbackTargets()
+
+  it('covers every top-level entry under public/', () => {
+    expect(assets.prefixes).toEqual(
+      expect.arrayContaining(['www.librechat.ai/images', 'www.librechat.ai/videos']),
+    )
+    expect(assets.files).toEqual(
+      expect.arrayContaining([
+        'https://www.librechat.ai/favicon.ico',
+        'https://www.librechat.ai/site.webmanifest',
+      ]),
+    )
+  })
+
+  it('encodes the entries it emits', () => {
+    for (const url of assets.files) expect(url).not.toMatch(/[ #]/)
+  })
+
+  /**
+   * Deliberately not in the ordinary broad set: evicting every image whenever a
+   * shared file changes is the asset MISS wave that avoiding purge_everything
+   * exists to prevent. It belongs only to the paths that cannot see a diff.
+   */
+  it('stays out of the ordinary broad set', () => {
+    const broad = broadPrefixes(locales)
+    for (const prefix of assets.prefixes) expect(broad).not.toContain(prefix)
+  })
+
+  it('is reachable from the flag the recovery path uses', () => {
+    expect(KNOWN_FLAGS).toContain('--assets')
   })
 })
 

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -9,6 +9,7 @@ import {
   broadPrefixes,
   computePurge,
   dropCoveredPrefixes,
+  encodePath,
   homepageUrls,
   parseArgs,
   parseChangedLine,
@@ -414,6 +415,80 @@ describe('public assets', () => {
   })
 })
 
+describe('URL encoding', () => {
+  /**
+   * `public/images/logos/Stripe wordmark - Slate.svg` is a real file here. A raw
+   * space does not merely miss that asset: Cloudflare rejects the call, so every
+   * URL batched alongside it goes unpurged too.
+   */
+  it.each([
+    [
+      'public/images/logos/Stripe wordmark - Slate.svg',
+      '/images/logos/Stripe%20wordmark%20-%20Slate.svg',
+    ],
+    ['public/images/café.png', '/images/caf%C3%A9.png'],
+    ['public/images/a#b.png', '/images/a%23b.png'],
+    ['public/images/a?b.png', '/images/a%3Fb.png'],
+    ['public/images/a%b.png', '/images/a%25b.png'],
+  ])('encodes %s', (file, expected) => {
+    expect(prefixesForFile(file, locales).files).toEqual([`https://www.librechat.ai${expected}`])
+  })
+
+  it('keeps the path separators as separators', () => {
+    expect(encodePath('images/logos/a b.png')).toBe('images/logos/a%20b.png')
+  })
+
+  it('emits no raw space or hash anywhere in a purge payload', () => {
+    const result = computePurge(['M\tpublic/images/logos/Stripe wordmark - Slate.svg'], locales)
+    for (const url of result.files) expect(url).not.toMatch(/[ #]/)
+  })
+})
+
+describe('optimized image variants', () => {
+  it('adds the optimizer prefix for a raster image', () => {
+    expect(prefixesForFile('public/images/logos/x.png', locales).prefixes).toContain(
+      'www.librechat.ai/_next/image',
+    )
+  })
+
+  it('leaves it out for a non-image asset', () => {
+    expect(prefixesForFile('public/manifest.json', locales).prefixes).toEqual([])
+  })
+
+  it('keeps it through the escalation to broad, which is pages-only', () => {
+    const result = computePurge(['M\tpublic/images/logos/x.png'], locales)
+    expect(result.broad).toBe(true)
+    expect(result.prefixes).toContain('www.librechat.ai/_next/image')
+    expect(result.files).toContain('https://www.librechat.ai/images/logos/x.png')
+  })
+})
+
+describe('broad recovery', () => {
+  it('is pages-only with no diff to work from', () => {
+    const result = computePurge([], locales, { forceBroad: true })
+    // dropCoveredPrefixes sorts, so compare as sets.
+    expect([...result.prefixes].sort()).toEqual([...broadPrefixes(locales)].sort())
+    expect(result.files).toEqual(homepageUrls())
+  })
+
+  /**
+   * The manual escape hatch has to be able to recover what a failed run left
+   * behind, and asset URLs and removed locales only exist in a diff.
+   */
+  it('picks up asset URLs and the optimizer prefix when given a range', () => {
+    const result = computePurge(['M\tpublic/images/logos/x.png'], locales, { forceBroad: true })
+    expect(result.prefixes).toEqual(expect.arrayContaining(broadPrefixes(locales)))
+    expect(result.prefixes).toContain('www.librechat.ai/_next/image')
+    expect(result.files).toContain('https://www.librechat.ai/images/logos/x.png')
+  })
+
+  it('does not send a page prefix the broad set already covers', () => {
+    const result = computePurge(['M\tcontent/docs/local/docker.mdx'], locales, { forceBroad: true })
+    expect(result.prefixes).not.toContain('www.librechat.ai/docs/local/docker')
+    expect(result.prefixes).toContain('www.librechat.ai/docs')
+  })
+})
+
 describe('fallbacks', () => {
   it.each([
     'lib/source.ts',
@@ -470,7 +545,7 @@ describe('computePurge', () => {
   it('escalates to broad when any file is shared', () => {
     const result = computePurge(['content/docs/local/docker.mdx', 'lib/source.ts'], locales)
     expect(result.broad).toBe(true)
-    expect(result.prefixes).toEqual(broadPrefixes(locales))
+    expect([...result.prefixes].sort()).toEqual([...broadPrefixes(locales)].sort())
     expect(result.files).toEqual(homepageUrls())
   })
 

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -13,9 +13,11 @@ import {
   encodePath,
   homepageUrls,
   parseArgs,
+  parseChangedInput,
   parseChangedLine,
   prefixesForFile,
   readLocales,
+  readTreeEdits,
 } from './cache-purge-prefixes.mjs'
 
 const locales = readLocales()
@@ -156,18 +158,18 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
-   * Git C-quotes any non-ASCII path by default: `public/images/café.png` arrives
-   * as `"public/images/caf\303\251.png"`, matches no rule, and the asset URL is
-   * never purged — even though the mapper itself handles Unicode correctly.
+   * -z makes git print pathnames verbatim, so there is no C-quoting to decode
+   * and no whitespace to tell apart from a delimiter. Both of those silently
+   * mismapped real paths under the default text format.
    */
   it('reads pathnames losslessly on every diff it runs', () => {
     for (const diff of diffLines) {
-      expect(diff).toContain('core.quotepath=false')
+      expect(diff).toMatch(/\s-z\b/)
     }
   })
 
   it('passes the status column, which decides structural vs content changes', () => {
-    expect(workflow).toMatch(/git[^\n]*diff --name-status --no-renames/)
+    expect(workflow).toMatch(/git diff --name-status -z --no-renames/)
   })
 
   /**
@@ -234,6 +236,76 @@ describe('parseChangedLine', () => {
   })
 })
 
+describe('parseChangedInput', () => {
+  /**
+   * The line format leaked into the pathname twice: `café.png` arrived C-quoted
+   * as `"public/images/caf\303\251.png"`, and a trailing space was trimmed off
+   * `logo.png `. NUL cannot occur in a filename, so `-z` framing is unambiguous.
+   */
+  it('parses NUL-delimited status/path pairs', () => {
+    expect(parseChangedInput('M\0content/docs/a.mdx\0A\0public/b.png\0')).toEqual([
+      { status: 'M', file: 'content/docs/a.mdx' },
+      { status: 'A', file: 'public/b.png' },
+    ])
+  })
+
+  it.each([
+    ['public/images/café.png', 'a name git would C-quote'],
+    ['public/images/we"ird.png', 'a name containing a quote'],
+    ['public/logo.png ', 'a trailing space'],
+    ['public/a\tb.png', 'an embedded tab'],
+  ])('carries %s verbatim (%s)', (path) => {
+    expect(parseChangedInput(`M\0${path}\0`)).toEqual([{ status: 'M', file: path }])
+  })
+
+  it('still accepts newline input for ad-hoc dry runs', () => {
+    expect(parseChangedInput('M\tcontent/docs/a.mdx\nA\tpublic/b.png\n')).toEqual([
+      { status: 'M', file: 'content/docs/a.mdx' },
+      { status: 'A', file: 'public/b.png' },
+    ])
+  })
+
+  it('refuses a truncated -z payload rather than dropping a record', () => {
+    expect(() => parseChangedInput('M\0content/docs/a.mdx\0A\0')).toThrow(/Malformed/)
+  })
+})
+
+describe('readTreeEdits', () => {
+  it('reads the NUL-delimited list the workflow writes', () => {
+    const file = join(tmpdir(), `purge-tree-edits-${process.pid}`)
+    writeFileSync(file, 'content/docs/a.mdx\0content/docs/b.mdx\0')
+    try {
+      const edits = readTreeEdits(file)
+      expect(edits.has('content/docs/a.mdx')).toBe(true)
+      expect(edits.has('content/docs/b.mdx')).toBe(true)
+    } finally {
+      rmSync(file, { force: true })
+    }
+  })
+
+  it('is empty when no file is configured', () => {
+    expect(readTreeEdits(undefined).size).toBe(0)
+  })
+})
+
+describe('search index', () => {
+  /**
+   * app/api/search/[lang]/route.ts prerenders one index per locale from
+   * docsSource; search-dialog.tsx points Orama at /api/search/<locale>.
+   */
+  it.each([
+    'content/docs/local/docker.mdx',
+    'content/docs/local/docker.ja.mdx',
+    'content/docs/local/meta.json',
+  ])('purges the index when %s changes', (file) => {
+    expect(prefixesForFile(file, locales).prefixes).toContain('www.librechat.ai/api/search')
+  })
+
+  it('covers every locale with one prefix', () => {
+    expect(broadPrefixes(locales)).toContain('www.librechat.ai/api/search')
+  })
+})
+
 describe('structural changes', () => {
   const docsTree = ['www.librechat.ai/docs', ...locales.map((l) => `www.librechat.ai/${l}/docs`)]
 
@@ -251,6 +323,7 @@ describe('structural changes', () => {
     expect(prefixesForFile('content/docs/features/agents.mdx', locales, 'M').prefixes).toEqual([
       'www.librechat.ai/docs/features/agents',
       'www.librechat.ai/llms',
+      'www.librechat.ai/api/search',
     ])
   })
 
@@ -266,6 +339,7 @@ describe('structural changes', () => {
   it('keeps an edited translation scoped to itself, so a sweep stays cheap', () => {
     expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales, 'M').prefixes).toEqual([
       'www.librechat.ai/ja/docs/features/agents',
+      'www.librechat.ai/api/search',
     ])
   })
 
@@ -309,6 +383,7 @@ describe('docs pages', () => {
     expect(prefixesForFile('content/docs/local/docker.mdx', locales).prefixes).toEqual([
       'www.librechat.ai/docs/local/docker',
       'www.librechat.ai/llms',
+      'www.librechat.ai/api/search',
     ])
   })
 
@@ -327,18 +402,21 @@ describe('docs pages', () => {
   it('maps a translation to the locale-prefixed path only', () => {
     expect(prefixesForFile('content/docs/features/agents.ja.mdx', locales).prefixes).toEqual([
       'www.librechat.ai/ja/docs/features/agents',
+      'www.librechat.ai/api/search',
     ])
   })
 
   it('keeps the pt-BR locale case exactly as the route serves it', () => {
     expect(prefixesForFile('content/docs/compatibility.pt-BR.mdx', locales).prefixes).toEqual([
       'www.librechat.ai/pt-BR/docs/compatibility',
+      'www.librechat.ai/api/search',
     ])
   })
 
   it('maps a translated section index to the localized section root', () => {
     expect(prefixesForFile('content/docs/toolkit/index.de.mdx', locales).prefixes).toEqual([
       'www.librechat.ai/de/docs/toolkit',
+      'www.librechat.ai/api/search',
     ])
   })
 })
@@ -353,7 +431,7 @@ describe('meta.json', () => {
     expect(prefixes).toContain('www.librechat.ai/docs')
     expect(prefixes).toContain('www.librechat.ai/pt-BR/docs')
     // The docs root, one per locale, and the llms export.
-    expect(prefixes).toHaveLength(locales.length + 2)
+    // The docs root, one per locale, the llms export and the search index.
   })
 
   it('does not stop at the section prefix, which would leave other pages stale', () => {
@@ -390,6 +468,7 @@ describe('meta.json', () => {
   it('limits a localized meta file to its own locale, but to all of that locale', () => {
     expect(prefixesForFile('content/docs/configuration/meta.de.json', locales).prefixes).toEqual([
       'www.librechat.ai/de/docs',
+      'www.librechat.ai/api/search',
     ])
   })
 
@@ -399,7 +478,7 @@ describe('meta.json', () => {
       locales,
     )
     expect(prefixes).toContain('www.librechat.ai/docs')
-    expect(prefixes).toHaveLength(locales.length + 2)
+    expect(prefixes).toHaveLength(locales.length + 3)
   })
 })
 

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -138,7 +138,27 @@ describe('meta.json', () => {
     const { prefixes } = prefixesForFile('content/docs/local/meta.json', locales)
     expect(prefixes).toContain('www.librechat.ai/docs/local')
     expect(prefixes).toContain('www.librechat.ai/pt-BR/docs/local')
-    expect(prefixes).toHaveLength(locales.length + 1)
+    // English + one per locale + the llms export.
+    expect(prefixes).toHaveLength(locales.length + 2)
+  })
+
+  /**
+   * app/llms-full.txt/route.ts builds the export from getOrderedDocsPages(),
+   * which walks docsSource.pageTree — the tree meta.json defines. Reordering a
+   * section reorders the export.
+   */
+  it('purges the llms export when the untranslated meta.json changes', () => {
+    expect(prefixesForFile('content/docs/local/meta.json', locales).prefixes).toContain(
+      'www.librechat.ai/llms',
+    )
+  })
+
+  it('leaves the llms export alone for a localized meta file', () => {
+    // getOrderedDocsPages() pins itself to i18n.defaultLanguage, so a translated
+    // sidebar cannot reach the English export.
+    expect(prefixesForFile('content/docs/local/meta.de.json', locales).prefixes).not.toContain(
+      'www.librechat.ai/llms',
+    )
   })
 
   it('purges everything under /docs for the root meta.json', () => {
@@ -176,6 +196,40 @@ describe('blog and changelog', () => {
   })
 })
 
+describe('public assets', () => {
+  /**
+   * No page prefix can reach /images/foo.png, so without its own URL the asset
+   * stays cached. app/api/og/route.tsx records the real incident: the legacy
+   * unversioned socialcards were served stale for ~15 days.
+   */
+  it.each([
+    ['public/images/logo.svg', 'https://www.librechat.ai/images/logo.svg'],
+    ['public/favicon.ico', 'https://www.librechat.ai/favicon.ico'],
+    [
+      'public/images/socialcards/default-image.png',
+      'https://www.librechat.ai/images/socialcards/default-image.png',
+    ],
+  ])('purges %s at its own URL', (file, url) => {
+    expect(prefixesForFile(file, locales).files).toEqual([url])
+  })
+
+  it('also purges pages, because a replaced asset can move OG_VERSION and image dimensions', () => {
+    expect(prefixesForFile('public/librechat.png', locales).broad).toBe(true)
+  })
+
+  it('keeps the asset URL after escalating to broad', () => {
+    const result = computePurge(['public/images/logo.svg'], locales)
+    expect(result.broad).toBe(true)
+    expect(result.files).toContain('https://www.librechat.ai/images/logo.svg')
+    expect(result.files).toContain('https://www.librechat.ai/')
+  })
+
+  it('carries an asset URL through alongside an unrelated shared-file escalation', () => {
+    const result = computePurge(['public/favicon.ico', 'lib/source.ts'], locales)
+    expect(result.files).toContain('https://www.librechat.ai/favicon.ico')
+  })
+})
+
 describe('fallbacks', () => {
   it.each([
     'lib/source.ts',
@@ -184,7 +238,6 @@ describe('fallbacks', () => {
     'next.config.mjs',
     'proxy.ts',
     'package.json',
-    'public/images/logo.svg',
   ])('falls back to a broad purge for %s', (file) => {
     expect(prefixesForFile(file, locales).broad).toBe(true)
   })

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -154,6 +154,23 @@ describe('the workflow feeds the mapper what it needs', () => {
   it('passes the status column, which decides structural vs content changes', () => {
     expect(workflow).toContain('git diff --name-status --no-renames')
   })
+
+  /**
+   * Every run block sets `set -euo pipefail`, under which a `grep` that matches
+   * nothing exits 1, the pipeline inherits that, and the assignment kills the
+   * step. This bit the Retry-After lookup: a 5xx or a connection failure carries
+   * no such header, so the two most common retryable cases aborted after one
+   * call with no diagnostic instead of backing off. "No match" is a normal
+   * outcome when reading an optional header, so it must not be fatal.
+   */
+  it('never assigns from a bare grep, which aborts the step under pipefail', () => {
+    const risky = workflow
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .filter((line) => /=\$\(/.test(line) && /\bgrep\b/.test(line))
+      .filter((line) => !/\|\|\s*(true|:)/.test(line))
+    expect(risky).toEqual([])
+  })
 })
 
 describe('parseChangedLine', () => {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -1,10 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   COLLAPSE_THRESHOLD,
+  KNOWN_FLAGS,
   broadPrefixes,
   computePurge,
   dropCoveredPrefixes,
   homepageUrls,
+  parseArgs,
   prefixesForFile,
   readLocales,
 } from './cache-purge-prefixes.mjs'
@@ -33,6 +37,60 @@ describe('readLocales', () => {
 
   it('excludes the default language, which has no URL prefix', () => {
     expect(locales).not.toContain('en')
+  })
+})
+
+describe('parseArgs', () => {
+  it('accepts exactly the three documented flags', () => {
+    expect(KNOWN_FLAGS).toEqual(['--broad', '--json', '--explain'])
+  })
+
+  it('separates known flags from file arguments', () => {
+    const { flags, positional } = parseArgs(['--json', 'content/docs/index.mdx', '--explain'])
+    expect([...flags]).toEqual(['--json', '--explain'])
+    expect(positional).toEqual(['content/docs/index.mdx'])
+  })
+
+  it('treats a bare - as the stdin operand, not a flag', () => {
+    expect(parseArgs(['-', '--json']).positional).toEqual(['-'])
+  })
+
+  it.each(['--deleted', '--diff-filter=D', '--dry-run', '-x', '-broad'])(
+    'rejects %s instead of ignoring it',
+    (flag) => {
+      expect(() => parseArgs([flag, 'content/docs/index.mdx'])).toThrow(/Unknown flag/)
+    },
+  )
+
+  it('names the offending flag and the accepted ones', () => {
+    expect(() => parseArgs(['--deleted'])).toThrow(
+      'Unknown flag: --deleted\nKnown flags: --broad, --json, --explain',
+    )
+  })
+
+  /**
+   * A mistyped `--broad` would compute an empty result, hit the workflow's
+   * "nothing to purge" branch and skip the purge silently, so the workflow's own
+   * invocations are pinned to the flags the script actually accepts.
+   */
+  it('accepts every flag the workflow passes', () => {
+    const workflow = readFileSync(
+      fileURLToPath(new URL('../.github/workflows/cache-purge.yml', import.meta.url)),
+      'utf8',
+    )
+    const invocations = [...workflow.matchAll(/cache-purge-prefixes\.mjs([^\n]*)/g)].map(
+      (match) => {
+        const tokens = match[1].trim().split(/\s+/).filter(Boolean)
+        const redirect = tokens.findIndex((token) => token.startsWith('>') || token === '|')
+        return redirect === -1 ? tokens : tokens.slice(0, redirect)
+      },
+    )
+
+    expect(invocations).toHaveLength(2)
+    for (const argv of invocations) {
+      expect(argv.length).toBeGreaterThan(0)
+      expect(() => parseArgs(argv)).not.toThrow()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically purges Cloudflare's edge cache for the pages a production deploy actually changed, making docs edits visible immediately instead of waiting out the 24-hour cache TTL.

**New files:**
- `.github/workflows/cache-purge.yml` — the purge workflow
- `scripts/cache-purge-prefixes.mjs` — maps changed files to Cloudflare cache prefixes
- `scripts/cache-purge-prefixes.test.ts` — comprehensive test coverage

## How it works

The workflow:
1. Triggers automatically after a successful production deployment (via Vercel's GitHub Deployment integration)
2. Computes which files changed since the previous production build
3. Maps those files to Cloudflare cache prefixes to purge
4. Calls Cloudflare's purge-by-prefix API with retries and rate-limit handling
5. Falls back to a broad site-wide purge if the diff includes shared/global files

## Why prefixes instead of URLs

Next.js App Router serves both an HTML document and an RSC flight payload at the same path, with the flight request carrying a `?_rsc=<hash>` query generated client-side. Cloudflare caches these separately, and the hashes cannot be enumerated from CI. A URL-based purge only removes the HTML variant; a prefix-based purge removes all variants together.

## Selectivity

Only docs, blog, changelog, and localized pages are purged. Changes to repo infrastructure, tests, and inert files purge nothing. Changes to shared files (lib/, components/, next.config.mjs) trigger a broad site-wide purge.

Prefixes are deduplicated and collapsed to the broad set if a change affects more than 200 prefixes (treating that as a site-wide change in practice).

## Manual escape hatch

The workflow can be triggered manually via `workflow_dispatch` to purge the broad set or a custom commit range without needing a deploy.