### PR TITLE
docs: add apiToken.sale Anthropic-compatible endpoint guide

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/apitoken.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/apitoken.mdx
@@ -1,0 +1,49 @@
+---
+title: apiToken.sale
+icon: Plug
+description: Configure apiToken.sale as a native Anthropic-compatible custom endpoint in LibreChat.
+---
+
+[apiToken.sale](https://apitoken.sale/) provides an Anthropic-compatible endpoint that uses the native Messages API. In LibreChat, configure it as a custom endpoint with `provider: "anthropic"`.
+
+## Get an API key
+
+[Create an account](https://apitoken.sale/register), generate an API key, and add it to your `.env` file:
+
+```bash filename=".env"
+APITOKEN_API_KEY=sk-pool-your-key-here
+```
+
+## Configuration
+
+Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "apiToken.sale"
+      provider: "anthropic"
+      apiKey: "${APITOKEN_API_KEY}"
+      baseURL: "https://api.apitoken.sale"
+      headers:
+        anthropic-version: "2023-06-01"
+      models:
+        default:
+          - "claude-sonnet-5"
+          - "claude-opus-4-8"
+          - "claude-opus-4-7"
+          - "claude-sonnet-4-6"
+          - "claude-haiku-4-5"
+        fetch: false
+      titleConvo: true
+      titleModel: "claude-haiku-4-5"
+      modelDisplayLabel: "apiToken.sale"
+```
+
+Restart LibreChat, select **apiToken.sale** from the endpoint selector, and choose one of the configured models.
+
+## Notes
+
+- `provider: "anthropic"` selects LibreChat's native Anthropic protocol client; it does not use an Anthropic-issued key or the Anthropic API host. The `sk-pool-...` key is issued by apiToken.sale, and requests go to the configured `https://api.apitoken.sale` base URL.
+- Keep `provider: "anthropic"`. Without it, LibreChat uses the OpenAI-compatible custom endpoint path instead of the native Anthropic `/v1/messages` client.
+- Keep `fetch: false` and list models explicitly. Native Anthropic custom endpoints do not use OpenAI-style model fetching.
+- See the current [model list](https://apitoken.sale/models) and [API documentation](https://apitoken.sale/docs) for supported model IDs and request details.
+- To let each LibreChat user enter their own key in the UI, replace the environment variable reference with `apiKey: "user_provided"`.

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "anyscale",
     "apipie",
+    "apitoken",
     "azure",
     "cloudflare",
     "cohere",


### PR DESCRIPTION
## Summary

Adds an apiToken.sale provider guide to the LibreChat YAML AI endpoints documentation and registers it in the sidebar.

The example uses LibreChat's native Anthropic custom-endpoint path:

- `provider: "anthropic"` selects the Messages API protocol
- `baseURL: "https://api.apitoken.sale"` keeps requests on the provider endpoint
- an apiToken.sale-issued key is loaded from `.env`
- supported models are listed explicitly with `models.fetch: false`

The guide also makes the credential distinction explicit: selecting the Anthropic protocol does not use an Anthropic-issued key or the Anthropic API host.

## Testing

- `pnpm lint:prettier`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 22 files, 294 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build` — 2,879 static pages generated
- All linked apiToken.sale pages return HTTP 200

### Live LibreChat proof

Validated with LibreChat v0.8.7 at `f7bc50ae5b752e50fab7f97ee00531ca1264ea05`, using the documented custom endpoint through LibreChat's real `initializeCustom` and native Anthropic model client:

- basic message: returned `LIBRECHAT_APITOKEN_OK`
- streaming: returned `LIBRECHAT_STREAM_OK`
- tool use: called `integration_check` with `{ "status": "ok" }`

The live credential was supplied only through process environment and is not present in the branch or this PR.
