### PR TITLE
docs: add Rapid-MLX as a custom AI endpoint

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -23,6 +23,7 @@
     "openrouter",
     "perplexity",
     "portkey",
+    "rapid-mlx",
     "shuttleai",
     "togetherai",
     "truefoundry",

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/rapid-mlx.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/rapid-mlx.mdx
@@ -1,0 +1,33 @@
+---
+title: Rapid-MLX
+description: Configure Rapid-MLX as a custom endpoint in LibreChat.
+---
+
+[Rapid-MLX](https://rapidmlx.com) is an Apple-Silicon-native inference server (pure MLX) that serves models locally through an OpenAI-compatible API, so you can point LibreChat at your own Mac.
+
+Install it with `brew install rapid-mlx` (or `pip install rapid-mlx`) and start a model with `rapid-mlx serve <model>` — it listens on `http://localhost:8000` by default. Browse the model catalog at [models.rapidmlx.com](https://models.rapidmlx.com/).
+
+## Configuration
+
+The local Rapid-MLX server doesn't authenticate requests, so the API key is just a placeholder. Point `baseURL` at your running server and add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "Rapid-MLX"
+      apiKey: "rapid-mlx"
+      baseURL: "http://localhost:8000/v1/"
+      models:
+        default: [
+          "qwen3.5-9b-4bit"
+          ]
+        fetch: false # rapid-mlx serves one model at a time; list it explicitly
+      titleConvo: true
+      titleModel: "current_model"
+      summarize: false
+      summaryModel: "current_model"
+      modelDisplayLabel: "Rapid-MLX"
+```
+
+## Notes
+
+- `rapid-mlx serve <model>` runs one model at a time on `:8000`. To serve more than one model, run a separate instance on a different port and add another endpoint with its own `baseURL`.
+- Set `default` to the alias you launched (e.g. `qwen3.5-9b-4bit`). Any alias from the [Rapid-MLX catalog](https://models.rapidmlx.com/) works.


### PR DESCRIPTION
Adds a custom-endpoint page for [Rapid-MLX](https://rapidmlx.com) under `librechat_yaml/ai_endpoints`, alongside the existing local/OpenAI-compatible entries (Apple MLX, vLLM, Ollama).

Rapid-MLX is an Apple-Silicon-native inference server (pure MLX) that serves models locally on `http://localhost:8000/v1`, so it plugs into LibreChat as a `endpoints.custom` entry. Includes a ready-to-paste `librechat.yaml` block mirroring the sibling docs, and registers the page in `meta.json`. English base page only (no icon component added, to keep this docs-only).