### PR TITLE
🛰️ feat: Add Consent-Gated Reo.dev Analytics

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,11 +17,10 @@ LOOPS_API_KEY=
 NEXT_PUBLIC_CWV_PROJECT_ID=64ddab45-756f-474b-a8c9-266d264c93d8
 NEXT_PUBLIC_CWV_ENDPOINT=
 NEXT_PUBLIC_CWV_SAMPLE_RATE=0.5
-# Reo.dev client ID for developer-intent analytics (optional, public)
-# Found in the Reo.dev dashboard under Integrations -> Documentation.
-# Leave empty to render no Reo consent controls or script. When configured,
-# Reo loads only after the visitor grants performance analytics consent.
-NEXT_PUBLIC_REO_CLIENT_ID=
+# Reo.dev client ID for developer-intent analytics (public).
+# Defaults to LibreChat's supplied ID; override it here when testing another
+# Reo.dev property. Reo loads only after performance analytics consent.
+NEXT_PUBLIC_REO_CLIENT_ID=38b2e79cdb32fa7
 
 # Crisp live chat widget ID (optional, public)
 NEXT_PUBLIC_CRISP_WEBSITE_ID=

--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,11 @@ LOOPS_API_KEY=
 NEXT_PUBLIC_CWV_PROJECT_ID=64ddab45-756f-474b-a8c9-266d264c93d8
 NEXT_PUBLIC_CWV_ENDPOINT=
 NEXT_PUBLIC_CWV_SAMPLE_RATE=0.5
+# Reo.dev client ID for developer-intent analytics (optional, public)
+# Found in the Reo.dev dashboard under Integrations -> Documentation.
+# Leave empty to load no Reo script at all. Note that Reo sets first-party
+# cookies, so review the /privacy and /cookie pages before enabling it.
+NEXT_PUBLIC_REO_CLIENT_ID=
 
 # Crisp live chat widget ID (optional, public)
 NEXT_PUBLIC_CRISP_WEBSITE_ID=

--- a/.env.template
+++ b/.env.template
@@ -19,8 +19,8 @@ NEXT_PUBLIC_CWV_ENDPOINT=
 NEXT_PUBLIC_CWV_SAMPLE_RATE=0.5
 # Reo.dev client ID for developer-intent analytics (optional, public)
 # Found in the Reo.dev dashboard under Integrations -> Documentation.
-# Leave empty to load no Reo script at all. Note that Reo sets first-party
-# cookies, so review the /privacy and /cookie pages before enabling it.
+# Leave empty to render no Reo consent controls or script. When configured,
+# Reo loads only after the visitor grants performance analytics consent.
 NEXT_PUBLIC_REO_CLIENT_ID=
 
 # Crisp live chat widget ID (optional, public)

--- a/app/cookie/page.tsx
+++ b/app/cookie/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Cookie Policy',
   description:
-    'How the LibreChat documentation website handles cookies, browser storage, and cookieless analytics.',
+    'How the LibreChat website and documentation use cookies, browser storage, and analytics.',
 }
 
 export default function CookiePolicyPage() {
@@ -26,192 +26,151 @@ export default function CookiePolicyPage() {
             <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               Cookie Policy
             </h1>
-            <p className="mt-4 text-sm text-muted-foreground">Last updated: April 26, 2026</p>
+            <p className="mt-4 text-sm text-muted-foreground">Last updated: July 29, 2026</p>
           </header>
 
           <h2>1. Overview</h2>
           <p>
-            The LibreChat documentation website (
-            <Link href="https://librechat.ai">librechat.ai</Link>, the &ldquo;Site&rdquo;) does{' '}
-            <strong>not use cookies</strong>. This Cookie Policy describes the small amount of
-            client-side storage we do use, explains how our analytics operate without cookies, and
-            describes the controls available to you. It supplements our{' '}
+            The LibreChat website and documentation (
+            <Link href="https://librechat.ai">librechat.ai</Link>, the &ldquo;Site&rdquo;) use a
+            limited number of first-party cookies and browser-storage entries. Essential preference
+            storage supports features you request. Optional Reo.dev performance analytics are
+            disabled unless you affirmatively accept them.
+          </p>
+          <p>
+            This policy supplements our <Link href="/privacy">Privacy Policy</Link> and does not
+            apply to the self-hosted LibreChat application or the public Demo.
+          </p>
+
+          <h2>2. Essential Preference Storage</h2>
+          <p>
+            When you explicitly select a documentation language, the Site sets the first-party{' '}
+            <code>NEXT_LOCALE</code> cookie for up to one year. It remembers that selection so
+            browser-language detection does not override it on a later visit. This cookie is not
+            used for analytics or advertising.
+          </p>
+          <p>
+            The Site may also store theme, navigation, feedback, and similar interface preferences
+            in <code>localStorage</code>. These values remain on your device and support features
+            you choose to use.
+          </p>
+
+          <h2>3. Cookieless Analytics and Performance Monitoring</h2>
+          <p>
+            Our self-hosted Plausible analytics and Core Web Vitals monitoring do not set cookies or
+            persistent identifiers. Their operation is described in the{' '}
             <Link href="/privacy">Privacy Policy</Link>.
           </p>
 
-          <h2>2. We Do Not Use Cookies</h2>
+          <h2>4. Optional Reo.dev Performance Analytics</h2>
           <p>
-            The Site does not set any cookies on your device, and we do not read cookies set by
-            other websites. Specifically, we do not use:
+            If configured by the Site operators, Reo.dev performance analytics help us understand
+            website and documentation usage, including pages visited and interactions with technical
+            content. The Reo.dev script is not requested and its cookies are not created until you
+            select <strong>Accept performance analytics</strong>.
           </p>
-          <ul>
-            <li>Authentication cookies (the Site has no user accounts and no login).</li>
-            <li>Advertising or marketing cookies.</li>
-            <li>Cross-site tracking cookies.</li>
-            <li>Third-party social-network cookies.</li>
-            <li>Personalization or preference cookies set by us.</li>
-          </ul>
+          <p>According to Reo.dev, its script may create these first-party cookies:</p>
+          <div className="overflow-x-auto">
+            <table>
+              <thead>
+                <tr>
+                  <th>Cookie</th>
+                  <th>Maximum duration</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <code>__sec__cid</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Stores the Reo.dev client key.</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>__sec__fid</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Stores a generated identifier used to understand Site usage.</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>__sec__ghost</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Combines Reo.dev identifiers to recognize a browser.</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>__sec__token</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Stores a token used for requests to Reo.dev.</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>__sec__crid</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Supports browser recognition confidence.</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>__sec__tid</code>
+                  </td>
+                  <td>300 days</td>
+                  <td>Helps analyze returning Site visitors.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <p>
-            Because we do not use cookies or any equivalent device-storage identifier within the
-            meaning of the EU ePrivacy Directive, we do not display a cookie banner and do not
-            require your consent for cookies.
-          </p>
-
-          <h2>3. How Our Analytics Work Without Cookies</h2>
-          <p>
-            We operate cookieless analytics and performance tooling. Both are described in detail in
-            our <Link href="/privacy">Privacy Policy</Link>; the points most relevant to cookies and
-            device storage are summarized here.
-          </p>
-
-          <h3>3.1 Plausible Analytics</h3>
-          <p>
-            We host an instance of <Link href="https://plausible.io/data-policy">Plausible</Link> at{' '}
-            <code>plausible.librechat.ai</code>. Plausible:
-          </p>
-          <ul>
-            <li>
-              Does <strong>not</strong> set cookies.
-            </li>
-            <li>
-              Does <strong>not</strong> use <code>localStorage</code> or <code>sessionStorage</code>
-              .
-            </li>
-            <li>
-              Does <strong>not</strong> use any other persistent client-side identifier such as
-              IndexedDB, ETags, or browser fingerprinting techniques.
-            </li>
-          </ul>
-          <p>
-            Visitor de-duplication is achieved on the server side using a one-way, daily-rotating
-            hash that combines a salt with the IP address and User-Agent. The salt rotates every
-            twenty-four hours and the IP address itself is never written to disk, which means the
-            hash cannot be linked across days and cannot be reversed back to a person or a device.
-          </p>
-          <p>
-            The Plausible script and its event endpoint are served from first-party paths on this
-            Site &mdash; <code>librechat.ai/js/</code> for the script and{' '}
-            <code>librechat.ai/api/e</code> for event ingestion &mdash; and proxied through a
-            Cloudflare Worker to our self-hosted Plausible instance at{' '}
-            <code>plausible.librechat.ai</code>. Some browser blocklists match on the word
-            &ldquo;plausible&rdquo; in a domain name and will block our self-hosted instance even
-            though it never sends data to a third party; serving the script and endpoint from{' '}
-            <code>librechat.ai</code> avoids this false positive. The proxy performs no additional
-            data collection. If you prefer to opt out, you can block <code>librechat.ai/api/e</code>{' '}
-            in your browser or disable JavaScript on this Site.
-          </p>
-
-          <h3>3.2 Core Web Vitals Monitoring</h3>
-          <p>
-            When performance monitoring is enabled, we collect anonymous Web Vitals measurements
-            using the open-source{' '}
-            <Link href="https://github.com/GoogleChrome/web-vitals">web-vitals</Link> library and a
-            small LibreChat client-side collector. This tool:
-          </p>
-          <ul>
-            <li>
-              Does <strong>not</strong> set cookies.
-            </li>
-            <li>
-              Does <strong>not</strong> use <code>localStorage</code> or <code>sessionStorage</code>
-              .
-            </li>
-            <li>
-              Generates a session identifier in browser memory using{' '}
-              <code>crypto.randomUUID()</code> and{' '}
-              <strong>rotates it on every page navigation</strong>, so measurements cannot be
-              correlated across page views or visits.
-            </li>
-          </ul>
-
-          <h2>4. Local Browser Storage We Do Use</h2>
-          <p>
-            For your convenience, the Site itself may write a small amount of non-identifying
-            information to your browser&apos;s <code>localStorage</code>. This data:
-          </p>
-          <ul>
-            <li>Is stored only on your device.</li>
-            <li>Is never transmitted to our servers or to any third party.</li>
-            <li>Does not identify you and is not combined with any other information.</li>
-            <li>Can be cleared at any time using your browser&apos;s site-data controls.</li>
-          </ul>
-          <p>The keys we may set include:</p>
-          <ul>
-            <li>
-              <strong>Theme preference</strong>: whether you have selected light or dark mode.
-            </li>
-            <li>
-              <strong>Navigation state</strong>: the open/closed state of collapsible documentation
-              sections so the layout is preserved as you browse.
-            </li>
-          </ul>
-
-          <h2>5. Third-Party Links and Embedded Content</h2>
-          <p>
-            The documentation links to a number of third-party resources, including the LibreChat
-            GitHub repository, package registries, integration partner sites, video platforms, and
-            community forums. Some of those third parties may set their own cookies when you visit
-            them. We do not control, and are not responsible for, the cookies or storage practices
-            of external sites; please review their cookie policies directly.
-          </p>
-          <p>
-            Where we conditionally load a small transparent pixel from{' '}
-            <Link href="https://about.scarf.sh/privacy">Scarf</Link> (<code>static.scarf.sh</code>)
-            for anonymous package-pull telemetry, that pixel does not set cookies and does not use{' '}
-            <code>localStorage</code>.
+            Reo.dev receives data over HTTPS at <code>api.reo.dev</code>. For more information, see{' '}
+            <Link href="https://docs.reo.dev/reo.dev-javascript-cookies-and-consent-guide">
+              Reo.dev&apos;s cookie and consent guide
+            </Link>{' '}
+            and its <Link href="https://www.reo.dev/customer-privacy-policy">privacy notice</Link>.
           </p>
 
-          <h2>6. Your Choices and Controls</h2>
+          <h2>5. Your Consent Choice</h2>
           <p>
-            You can further restrict the limited information described in this policy at any time
-            by:
+            Your choice is stored in <code>localStorage</code> under{' '}
+            <code>librechat_reo_consent</code>. This prevents the Site from repeatedly asking for
+            the same preference. On a first visit, Global Privacy Control or a browser Do Not Track
+            signal is treated as a rejection of optional analytics.
           </p>
-          <ul>
-            <li>
-              Configuring your browser to block third-party requests, to clear site data on close,
-              or to deny <code>localStorage</code> access for this Site.
-            </li>
-            <li>
-              Enabling <strong>Do Not Track</strong>, <strong>Global Privacy Control</strong>, or
-              tracker-blocking features in your browser.
-            </li>
-            <li>
-              Installing a content-blocking extension or browser rule that blocks requests to the
-              first-party analytics paths <code>librechat.ai/js/</code> and{' '}
-              <code>librechat.ai/api/e</code>, as well as any performance-monitoring endpoint we
-              configure.
-            </li>
-            <li>Disabling JavaScript, in which case no analytics or performance data is sent.</li>
-          </ul>
           <p>
-            Because we do not rely on cookies or persistent identifiers, exercising any of these
-            controls will not break the documentation experience.
+            You can change your choice at any time with the <strong>Cookie preferences</strong>{' '}
+            button shown on the Site. Withdrawing consent clears the Reo.dev cookies accessible to
+            the Site and reloads the page so its analytics listeners are no longer active. Rejecting
+            or withdrawing consent does not affect access to the Site.
+          </p>
+          <p>
+            You can also clear Site data using your browser controls or block requests to{' '}
+            <code>static.reo.dev</code> and <code>api.reo.dev</code>.
+          </p>
+
+          <h2>6. Third-Party Links</h2>
+          <p>
+            The Site links to third-party resources, package registries, video platforms, and
+            community sites. Those services may set their own cookies when you visit them. Their
+            practices are governed by their own privacy and cookie notices.
           </p>
 
           <h2>7. Changes to This Policy</h2>
           <p>
-            We may update this Cookie Policy from time to time to reflect changes in our tooling or
-            in applicable law. Material changes will be reflected in the &ldquo;Last updated&rdquo;
-            date at the top of this page. We do not anticipate adding cookies to the Site, and any
-            change in that posture would be communicated prominently before being deployed.
+            We may update this policy when our storage or analytics practices change. Material
+            changes will be reflected in the &ldquo;Last updated&rdquo; date and, when appropriate,
+            communicated prominently before taking effect.
           </p>
 
           <h2>8. Contact</h2>
           <p>
-            For questions about this Cookie Policy, please contact us at{' '}
+            For questions about this Cookie Policy, contact{' '}
             <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link> or open an issue in
             the{' '}
-            <Link href="https://github.com/LibreChat-AI/librechat.ai/issues">
-              project repository
-            </Link>
-            .
-          </p>
-
-          <hr />
-
-          <p className="text-sm text-muted-foreground">
-            By using this documentation site, you acknowledge that no cookies are set and that the
-            cookieless analytics described above operate as part of normal Site operation.
+            <Link href="https://github.com/LibreChat-AI/librechat.ai/issues">Site repository</Link>.
           </p>
         </article>
       </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,10 +56,11 @@ function normalizeCwvEndpoint(endpoint: string) {
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  // Sanitize Scarf pixel ID: only allow alphanumeric chars, underscores, and hyphens
-  // to prevent XSS via dangerouslySetInnerHTML injection if the env var is compromised.
-  const rawScarfId = process.env.NEXT_PUBLIC_SCARF_PIXEL_ID ?? ''
-  const scarfPixelId = /^[\w-]+$/.test(rawScarfId) ? rawScarfId : ''
+  // Sanitize the Reo.dev client ID: only allow alphanumeric chars, underscores,
+  // and hyphens to prevent XSS via dangerouslySetInnerHTML injection if the env
+  // var is compromised. Unset, which is the default, emits no script at all.
+  const rawReoClientId = process.env.NEXT_PUBLIC_REO_CLIENT_ID ?? ''
+  const reoClientId = /^[\w-]+$/.test(rawReoClientId) ? rawReoClientId : ''
   const askAIEnabled = Boolean(process.env.OPENROUTER_API_KEY)
   const plausibleEnabled = process.env.NODE_ENV === 'production'
 
@@ -128,28 +129,31 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             sampleRate={cwvSampleRate}
           />
         )}
-        {scarfPixelId && (
+        {/* Developer-intent analytics by Reo.dev, replacing the retired Scarf
+            pixel. Reo's loader appends its own tag and calls Reo.init() from the
+            onload handler, so the snippet stays inline instead of moving to
+            next/script's src + onLoad, which would turn this server component
+            into a client one. No manual re-ping on navigation, unlike the Scarf
+            pixel: that was a single image request, while reo.js instruments
+            history itself. Reo does set first-party cookies, which /privacy and
+            /cookie do not yet describe — see the PR for the follow-up. */}
+        {reoClientId && (
           <Script
-            id="scarf-pixel"
+            id="reo-init"
             strategy="afterInteractive"
             dangerouslySetInnerHTML={{
               __html: `
               (function () {
-                var PIXEL_ID = '${scarfPixelId}';
-                function sendScarfPing() {
-                  var img = new Image();
-                  img.referrerPolicy = 'no-referrer-when-downgrade';
-                  img.src = 'https://static.scarf.sh/a.png?x-pxid=' + PIXEL_ID;
-                }
-                var originalPushState = history.pushState;
-                history.pushState = function () {
-                  originalPushState.apply(this, arguments);
-                  window.dispatchEvent(new Event('scarf:locationchange'));
+                var CLIENT_ID = '${reoClientId}';
+                var script = document.createElement('script');
+                script.src = 'https://static.reo.dev/' + CLIENT_ID + '/reo.js';
+                script.defer = true;
+                script.onload = function () {
+                  if (window.Reo && typeof window.Reo.init === 'function') {
+                    window.Reo.init({ clientID: CLIENT_ID });
+                  }
                 };
-                window.addEventListener('hashchange', sendScarfPing);
-                window.addEventListener('popstate', sendScarfPing);
-                window.addEventListener('scarf:locationchange', sendScarfPing);
-                sendScarfPing();
+                document.head.appendChild(script);
               })();
             `,
             }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,7 @@ import './global.css'
 const DEFAULT_CWV_ENDPOINT = ''
 const DEFAULT_CWV_PROJECT_ID = '64ddab45-756f-474b-a8c9-266d264c93d8'
 const DEFAULT_CWV_SAMPLE_RATE = 0.5
+const DEFAULT_REO_CLIENT_ID = '38b2e79cdb32fa7'
 
 export const metadata: Metadata = {
   title: {
@@ -59,7 +60,7 @@ function normalizeCwvEndpoint(endpoint: string) {
 export default function RootLayout({ children }: { children: ReactNode }) {
   // Restrict the Reo.dev client ID to its documented identifier characters
   // before the client component interpolates it into the script URL.
-  const rawReoClientId = process.env.NEXT_PUBLIC_REO_CLIENT_ID ?? ''
+  const rawReoClientId = process.env.NEXT_PUBLIC_REO_CLIENT_ID ?? DEFAULT_REO_CLIENT_ID
   const reoClientId = /^[\w-]+$/.test(rawReoClientId) ? rawReoClientId : ''
   const askAIEnabled = Boolean(process.env.OPENROUTER_API_KEY)
   const plausibleEnabled = process.env.NODE_ENV === 'production'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Banner } from 'fumadocs-ui/components/banner'
 import { Provider } from '@/components/provider'
 import { AskAILoader } from '@/components/ai/AskAILoader'
 import { CoreWebVitalsMonitor } from '@/components/analytics/CoreWebVitalsMonitor'
+import { ReoAnalyticsConsent } from '@/components/analytics/ReoAnalyticsConsent'
 import { ogImageUrl } from '@/lib/og'
 import './global.css'
 
@@ -56,9 +57,8 @@ function normalizeCwvEndpoint(endpoint: string) {
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  // Sanitize the Reo.dev client ID: only allow alphanumeric chars, underscores,
-  // and hyphens to prevent XSS via dangerouslySetInnerHTML injection if the env
-  // var is compromised. Unset, which is the default, emits no script at all.
+  // Restrict the Reo.dev client ID to its documented identifier characters
+  // before the client component interpolates it into the script URL.
   const rawReoClientId = process.env.NEXT_PUBLIC_REO_CLIENT_ID ?? ''
   const reoClientId = /^[\w-]+$/.test(rawReoClientId) ? rawReoClientId : ''
   const askAIEnabled = Boolean(process.env.OPENROUTER_API_KEY)
@@ -129,36 +129,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             sampleRate={cwvSampleRate}
           />
         )}
-        {/* Developer-intent analytics by Reo.dev, replacing the retired Scarf
-            pixel. Reo's loader appends its own tag and calls Reo.init() from the
-            onload handler, so the snippet stays inline instead of moving to
-            next/script's src + onLoad, which would turn this server component
-            into a client one. No manual re-ping on navigation, unlike the Scarf
-            pixel: that was a single image request, while reo.js instruments
-            history itself. Reo does set first-party cookies, which /privacy and
-            /cookie do not yet describe — see the PR for the follow-up. */}
-        {reoClientId && (
-          <Script
-            id="reo-init"
-            strategy="afterInteractive"
-            dangerouslySetInnerHTML={{
-              __html: `
-              (function () {
-                var CLIENT_ID = '${reoClientId}';
-                var script = document.createElement('script');
-                script.src = 'https://static.reo.dev/' + CLIENT_ID + '/reo.js';
-                script.defer = true;
-                script.onload = function () {
-                  if (window.Reo && typeof window.Reo.init === 'function') {
-                    window.Reo.init({ clientID: CLIENT_ID });
-                  }
-                };
-                document.head.appendChild(script);
-              })();
-            `,
-            }}
-          />
-        )}
+        {/* Reo.dev is loaded client-side only after explicit performance
+            analytics consent. The consent component also provides withdrawal
+            controls and clears Reo's first-party cookies on withdrawal. */}
+        {reoClientId && <ReoAnalyticsConsent clientId={reoClientId} />}
       </body>
     </html>
   )

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -26,18 +26,18 @@ export default function PrivacyPolicyPage() {
             <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               Privacy Policy
             </h1>
-            <p className="mt-4 text-sm text-muted-foreground">Last updated: April 26, 2026</p>
+            <p className="mt-4 text-sm text-muted-foreground">Last updated: July 29, 2026</p>
           </header>
 
           <h2>1. Overview</h2>
           <p>
             This Privacy Policy describes how the LibreChat documentation website (
             <Link href="https://librechat.ai">librechat.ai</Link>, the &ldquo;Site&rdquo;) handles
-            information about its visitors. We have designed the Site to operate without setting
-            cookies, without storing directly identifying visitor profiles, and without sharing
-            visitor information with third-party advertising networks. The limited information we
-            process is used solely to understand aggregate site usage and to maintain performance
-            and reliability.
+            information about its visitors. We use privacy-preserving, cookieless tools for
+            aggregate analytics and performance monitoring. With your express consent, we may also
+            load Reo.dev performance analytics, which uses first-party cookies to understand how
+            developers use the website and documentation. We do not use advertising cookies or track
+            your activity across unrelated websites.
           </p>
           <p>
             This policy applies to the documentation website only. It does not apply to the
@@ -60,9 +60,9 @@ export default function PrivacyPolicyPage() {
 
           <h2>3. Information We Collect Automatically</h2>
           <p>
-            When you visit the Site, our self-hosted analytics and performance-monitoring tools
-            collect a small set of technical signals. None of these signals contain your name, email
-            address, account identifier, or any other directly identifying information.
+            When you visit the Site, our analytics and performance-monitoring tools may collect a
+            limited set of technical signals. The specific collection depends on your optional
+            analytics consent.
           </p>
 
           <h3>3.1 Aggregate Usage Analytics &mdash; Plausible Analytics</h3>
@@ -158,14 +158,30 @@ export default function PrivacyPolicyPage() {
             </li>
           </ul>
 
-          <h3>3.3 Open-Source Telemetry &mdash; Scarf Pixel (optional)</h3>
+          <h3>3.3 Developer-Intent Analytics &mdash; Reo.dev (optional)</h3>
           <p>
-            On certain pages, we may load a single transparent pixel from{' '}
-            <Link href="https://about.scarf.sh/privacy">Scarf</Link> (<code>static.scarf.sh</code>)
-            so that the LibreChat project can count anonymous package and documentation pulls. Scarf
-            does not set cookies, does not use <code>localStorage</code>, and provides aggregate
-            counts to the project maintainers. The Scarf pixel is conditionally enabled and is not
-            used to identify individual visitors.
+            If you accept performance analytics, the Site loads Reo.dev JavaScript from{' '}
+            <code>static.reo.dev</code>. Reo.dev receives page views and technical-content
+            interactions, together with technical signals such as your browser information, IP
+            address, referring URL, and Reo.dev identifiers. Reo.dev uses these signals to associate
+            activity across visits, analyze developer interest, and provide LibreChat with company
+            and developer-intent insights.
+          </p>
+          <p>
+            Reo.dev sets first-party identifiers with a maximum documented lifetime of 300 days. The
+            script does not load unless you consent, and rejecting optional analytics does not
+            affect the Site. You can withdraw consent at any time using the{' '}
+            <strong>Cookie preferences</strong> button. Details about the cookies and controls are
+            available in our <Link href="/cookie">Cookie Policy</Link>.
+          </p>
+          <p>
+            Reo.dev acts as a service provider processing this information for LibreChat. Its
+            broader service may enrich technical activity with company or professional information
+            from customers, integrations, licensed vendors, and public sources. See the{' '}
+            <Link href="https://www.reo.dev/customer-privacy-policy">
+              Reo.dev customer privacy notice
+            </Link>{' '}
+            for details and Reo.dev&apos;s data-subject contact information.
           </p>
 
           <h3>3.4 Server Logs</h3>
@@ -178,14 +194,13 @@ export default function PrivacyPolicyPage() {
           </p>
 
           <h2>4. Information We Do Not Collect</h2>
-          <p>The Site does not collect, request, or store:</p>
+          <p>The Site does not directly request or store:</p>
           <ul>
-            <li>Your name, email address, telephone number, or postal address.</li>
             <li>Account credentials (the Site has no user accounts and no login).</li>
             <li>Payment information.</li>
-            <li>Precise geolocation, behavioral profiles, or biometric data.</li>
+            <li>Precise GPS location or biometric data.</li>
             <li>The contents of any conversation, message, file, or document.</li>
-            <li>Information about your activity on other websites.</li>
+            <li>Information about the contents of your activity on unrelated websites.</li>
           </ul>
 
           <h2>5. Why We Process This Information &mdash; Lawful Basis</h2>
@@ -202,12 +217,16 @@ export default function PrivacyPolicyPage() {
               determined that this processing does not override your fundamental rights and
               freedoms.
             </li>
+            <li>
+              <strong>Consent</strong> (Article 6(1)(a)) for Reo.dev performance analytics and its
+              first-party identifiers. You may decline or withdraw that consent without affecting
+              access to the Site.
+            </li>
           </ul>
           <p>
             We do not rely on consent for the cookieless analytics described above because they do
-            not use cookies or equivalent identifiers. To the extent any transient technical signals
-            are treated as personal data under applicable law, we rely on the legitimate interests
-            described above.
+            not use cookies or equivalent persistent identifiers. Reo.dev is kept separate and does
+            not load before your optional analytics choice is granted.
           </p>
 
           <h2>6. How Long We Keep Information</h2>
@@ -223,6 +242,12 @@ export default function PrivacyPolicyPage() {
               not linked to any persistent identifier.
             </li>
             <li>
+              <strong>Reo.dev analytics</strong>: Reo.dev identifiers may remain on your device for
+              up to 300 days unless you withdraw consent or clear Site data. Server-side information
+              is retained according to LibreChat&apos;s service configuration and Reo.dev&apos;s
+              contractual and legal retention requirements.
+            </li>
+            <li>
               <strong>Operational server logs</strong>: retained for the minimum period required for
               security and reliability operations, after which they are automatically rotated and
               deleted.
@@ -231,11 +256,10 @@ export default function PrivacyPolicyPage() {
 
           <h2>7. International Data Transfers</h2>
           <p>
-            Our analytics ingestion endpoints are hosted on infrastructure controlled by the project
-            maintainers. Where data is transferred outside the European Economic Area or the United
-            Kingdom, the transfer is supported by appropriate safeguards (such as the European
-            Commission&apos;s Standard Contractual Clauses) and the data does not include directly
-            identifying information.
+            Our self-hosted analytics ingestion endpoints are controlled by the project maintainers.
+            Reo.dev states that user information is stored on servers in the United States. Where
+            applicable, international transfers must be supported by legally recognized safeguards
+            and the rights described below remain available.
           </p>
 
           <h2>8. Sub-Processors and Third Parties</h2>
@@ -253,14 +277,15 @@ export default function PrivacyPolicyPage() {
               maintainers, when performance monitoring is enabled.
             </li>
             <li>
-              <strong>Scarf</strong> (
-              <Link href="https://about.scarf.sh/privacy">privacy notice</Link>) for anonymous
-              package and documentation download counts, when enabled.
+              <strong>Reo.dev</strong> (
+              <Link href="https://www.reo.dev/customer-privacy-policy">privacy notice</Link>) for
+              consent-based website and documentation analytics, when enabled.
             </li>
           </ul>
           <p>
-            We do not sell, rent, or otherwise share visitor information with advertising networks,
-            data brokers, or marketing partners.
+            We do not sell personal information or use Reo.dev for cross-context behavioral
+            advertising. Reo.dev processes consented analytics information to provide its
+            developer-intent service to LibreChat.
           </p>
 
           <h2>9. Your Rights</h2>
@@ -292,39 +317,41 @@ export default function PrivacyPolicyPage() {
             </li>
           </ul>
           <p>
-            Because we do not collect identifying information, we typically cannot locate records
-            specific to an individual. If you believe we hold personal data about you and would like
-            to exercise any of these rights, please contact us at{' '}
+            Cookieless aggregate records generally cannot be linked back to an individual. Reo.dev
+            records may use persistent identifiers and may be associated with company or
+            professional information. If you would like to exercise your rights, contact us at{' '}
             <Link href="mailto:contact@librechat.ai">contact@librechat.ai</Link> with enough detail
-            for us to investigate. We do not sell personal information and do not engage in
-            cross-context behavioral advertising.
+            for us to investigate. You may also contact Reo.dev at{' '}
+            <Link href="mailto:dataprivacy@reo.dev">dataprivacy@reo.dev</Link>.
           </p>
 
           <h2>10. Browser Controls and Opt-Out</h2>
-          <p>
-            Although our analytics do not rely on cookies or persistent identifiers, you can further
-            limit data collection at any time by:
-          </p>
+          <p>You can limit analytics collection at any time by:</p>
           <ul>
             <li>
               Enabling <strong>Do Not Track</strong> or <strong>Global Privacy Control</strong> in
-              your browser; we will continue to honor these signals where practical.
+              your browser. On a first visit, either signal is treated as a rejection of optional
+              Reo.dev analytics.
+            </li>
+            <li>
+              Opening <strong>Cookie preferences</strong> to reject or withdraw consent for Reo.dev.
             </li>
             <li>
               Using a content blocker, browser rule, or privacy-focused extension to block requests
               to the first-party analytics paths <code>librechat.ai/js/</code> and{' '}
-              <code>librechat.ai/api/e</code> &mdash; as well as the performance ingestion endpoint.
+              <code>librechat.ai/api/e</code>, the performance ingestion endpoint,{' '}
+              <code>static.reo.dev</code>, or <code>api.reo.dev</code>.
             </li>
             <li>Disabling JavaScript for this Site, in which case no analytics will be sent.</li>
           </ul>
 
           <h2>11. Local Browser Storage</h2>
           <p>
-            The Site itself may store small amounts of non-identifying information in your
-            browser&apos;s <code>localStorage</code> for usability purposes &mdash; for example,
-            your light/dark theme preference and the open/closed state of navigation sections. This
-            information stays in your browser, is not transmitted to our servers, and can be cleared
-            at any time through your browser&apos;s site-data controls.
+            The Site stores small amounts of information in your browser for usability purposes,
+            including theme and navigation preferences, an explicit language choice, and your
+            optional-analytics consent choice. Preference values stay on your device and can be
+            cleared through your browser&apos;s site-data controls. See the{' '}
+            <Link href="/cookie">Cookie Policy</Link> for names and durations.
           </p>
 
           <h2>12. Children&apos;s Privacy</h2>

--- a/app/tos/page.tsx
+++ b/app/tos/page.tsx
@@ -26,7 +26,7 @@ export default function TermsOfServicePage() {
             <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
               Terms of Service
             </h1>
-            <p className="mt-4 text-sm text-muted-foreground">Last updated: April 26, 2026</p>
+            <p className="mt-4 text-sm text-muted-foreground">Last updated: July 29, 2026</p>
           </header>
 
           <h2>1. Agreement</h2>
@@ -154,10 +154,10 @@ export default function TermsOfServicePage() {
           <p>
             Your privacy is governed by our <Link href="/privacy">Privacy Policy</Link> and{' '}
             <Link href="/cookie">Cookie Policy</Link>, which are incorporated into these Terms by
-            reference. In summary, the Site does not set cookies, does not collect personal data for
-            marketing, and uses only privacy-preserving, self-hosted analytics and performance
-            measurements that cannot identify you. By using the Site you acknowledge the data
-            handling described in those policies.
+            reference. The Site uses privacy-preserving, self-hosted analytics and, only with your
+            affirmative consent, may use Reo.dev first-party cookies for website and documentation
+            performance analytics. You can reject or later withdraw optional analytics without
+            losing access to the Site.
           </p>
 
           <h2>8. Third-Party Services and Links</h2>

--- a/components/analytics/ReoAnalyticsConsent.tsx
+++ b/components/analytics/ReoAnalyticsConsent.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+const CONSENT_KEY = 'librechat_reo_consent'
+const CONSENT_GRANTED = 'granted'
+const CONSENT_DENIED = 'denied'
+const REO_SCRIPT_ID = 'reo-analytics'
+const REO_COOKIE_NAMES = [
+  '__sec__cid',
+  '__sec__fid',
+  '__sec__ghost',
+  '__sec__token',
+  '__sec__crid',
+  '__sec__tid',
+]
+
+type Consent = typeof CONSENT_GRANTED | typeof CONSENT_DENIED | null
+
+declare global {
+  interface Navigator {
+    globalPrivacyControl?: boolean
+  }
+
+  interface Window {
+    Reo?: {
+      init: (options: { clientID: string }) => void
+    }
+  }
+}
+
+function storedConsent(): Consent {
+  try {
+    const value = window.localStorage.getItem(CONSENT_KEY)
+    return value === CONSENT_GRANTED || value === CONSENT_DENIED ? value : null
+  } catch {
+    return null
+  }
+}
+
+function persistConsent(value: Exclude<Consent, null>) {
+  try {
+    window.localStorage.setItem(CONSENT_KEY, value)
+  } catch {
+    // Consent still applies for this page when storage is unavailable.
+  }
+}
+
+function privacySignalEnabled() {
+  return navigator.globalPrivacyControl === true || navigator.doNotTrack === '1'
+}
+
+function clearReoCookies() {
+  const { hostname } = window.location
+  const registrableDomain = hostname.endsWith('.librechat.ai') ? '.librechat.ai' : hostname
+  const domains = new Set(['', hostname, registrableDomain])
+
+  for (const name of REO_COOKIE_NAMES) {
+    for (const domain of domains) {
+      document.cookie = `${name}=; Max-Age=0; path=/; SameSite=Lax${domain ? `; domain=${domain}` : ''}`
+    }
+  }
+}
+
+function loadReo(clientId: string) {
+  if (document.getElementById(REO_SCRIPT_ID)) return
+
+  const script = document.createElement('script')
+  script.id = REO_SCRIPT_ID
+  script.src = `https://static.reo.dev/${clientId}/reo.js`
+  script.defer = true
+  script.onload = () => {
+    if (window.Reo && typeof window.Reo.init === 'function') {
+      window.Reo.init({ clientID: clientId })
+    }
+  }
+  document.head.appendChild(script)
+}
+
+export function ReoAnalyticsConsent({ clientId }: { clientId: string }) {
+  const [consent, setConsent] = useState<Consent>(null)
+  const [preferencesOpen, setPreferencesOpen] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    let initialConsent = storedConsent()
+    if (initialConsent === null && privacySignalEnabled()) {
+      initialConsent = CONSENT_DENIED
+      persistConsent(initialConsent)
+    }
+
+    setConsent(initialConsent)
+    setPreferencesOpen(initialConsent === null)
+    setReady(true)
+
+    if (initialConsent === CONSENT_GRANTED) {
+      loadReo(clientId)
+    }
+  }, [clientId])
+
+  const grantConsent = useCallback(() => {
+    persistConsent(CONSENT_GRANTED)
+    setConsent(CONSENT_GRANTED)
+    setPreferencesOpen(false)
+    loadReo(clientId)
+  }, [clientId])
+
+  const denyConsent = useCallback(() => {
+    const hadConsent = consent === CONSENT_GRANTED
+    persistConsent(CONSENT_DENIED)
+    clearReoCookies()
+    setConsent(CONSENT_DENIED)
+    setPreferencesOpen(false)
+
+    // Once loaded, Reo installs page-level listeners. Reloading guarantees that
+    // withdrawing consent stops collection for the remainder of the visit.
+    if (hadConsent) {
+      window.location.reload()
+    }
+  }, [consent])
+
+  if (!ready) return null
+
+  return (
+    <>
+      {preferencesOpen && (
+        <section
+          role="dialog"
+          aria-labelledby="analytics-consent-title"
+          aria-describedby="analytics-consent-description"
+          className="fixed inset-x-4 bottom-4 z-[100] mx-auto max-w-3xl rounded-xl border border-border bg-background p-5 shadow-2xl sm:p-6"
+        >
+          <h2 id="analytics-consent-title" className="text-lg font-semibold text-foreground">
+            Performance analytics preferences
+          </h2>
+          <p
+            id="analytics-consent-description"
+            className="mt-2 text-sm leading-6 text-muted-foreground"
+          >
+            With your permission, LibreChat uses Reo.dev performance analytics to understand which
+            website and documentation pages developers use. Reo.dev sets first-party cookies and
+            receives page and interaction data. Declining does not affect the site. Read our{' '}
+            <Link href="/cookie" className="underline underline-offset-2 hover:text-foreground">
+              Cookie Policy
+            </Link>{' '}
+            and{' '}
+            <Link href="/privacy" className="underline underline-offset-2 hover:text-foreground">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+          <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={denyConsent}>
+              Reject non-essential
+            </Button>
+            <Button type="button" onClick={grantConsent}>
+              Accept performance analytics
+            </Button>
+          </div>
+        </section>
+      )}
+
+      {!preferencesOpen && consent !== null && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setPreferencesOpen(true)}
+          className="fixed bottom-4 left-4 z-[90] bg-background shadow-md"
+        >
+          Cookie preferences
+        </Button>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

I replaced the Scarf pixel with a consent-gated Reo.dev integration for the LibreChat website and documentation.

- I load the Reo.dev client only after a visitor explicitly accepts performance analytics.
- I honor Global Privacy Control and Do Not Track as an initial rejection, persist the visitor's choice, and provide a site-wide preferences control.
- I stop collection on withdrawal by clearing Reo.dev's documented first-party cookies and reloading the page to remove its listeners.
- I use LibreChat's verified public Reo.dev client ID by default and retain `NEXT_PUBLIC_REO_CLIENT_ID` as an override for testing another property.
- I updated the Privacy Policy, Cookie Policy, and Terms of Service to disclose Reo.dev processing, its cookies, retention, consent basis, controls, and data-subject contact path.
- I corrected the existing policy disclosure for the `NEXT_LOCALE` language-preference cookie.

## Deployment

1. Merge this revision; the verified LibreChat Reo.dev client ID is built in, so no separate Vercel configuration is required.
2. Verify an accepted visit to `/` and a client-side navigation under `/docs` in Reo.dev.
3. Remove the now-unused `NEXT_PUBLIC_SCARF_PIXEL_ID` from Vercel after Reo.dev confirms receipt.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

I verified the consent lifecycle with the production build and real Reo.dev client ID:

- Confirmed no Reo.dev script is present before consent.
- Confirmed acceptance loads `https://static.reo.dev/38b2e79cdb32fa7/reo.js`.
- Confirmed consent persists across reloads.
- Confirmed withdrawal reloads the page and leaves no Reo.dev script active.
- Confirmed the updated Cookie Policy and consent controls render correctly in the browser.

### Test Configuration

- Next.js production build with LibreChat's Reo.dev client ID
- Node.js with an 8 GB heap for the repository's MDX-heavy production build

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

## Validation

- `pnpm lint:prettier`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 313 tests passed
- `NODE_OPTIONS='--max-old-space-size=8192' NEXT_PUBLIC_REO_CLIENT_ID=38b2e79cdb32fa7 pnpm build`
