### PR TITLE
fix(openrouter): attribute usage to the canonical LibreChat app

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { docsSource } from '@/lib/source'
 import { i18n } from '@/lib/i18n'
 import { checkRateLimit } from '@/lib/ratelimit'
+import { OPENROUTER_APP_HEADERS } from '@/lib/openrouter-attribution'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -135,13 +136,7 @@ function searchDocs(docs: SearchDoc[], query: string, limit: number): SearchDoc[
 
 const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY,
-  // OpenRouter app-attribution headers: HTTP-Referer (site URL) and X-Title
-  // (app name) attribute this traffic to LibreChat on openrouter.ai's app
-  // rankings. https://openrouter.ai/docs/api-reference/overview#headers
-  headers: {
-    'HTTP-Referer': 'https://www.librechat.ai',
-    'X-Title': 'LibreChat',
-  },
+  headers: OPENROUTER_APP_HEADERS,
 })
 
 const systemPrompt = `You are the LibreChat docs assistant. You help users find answers in the LibreChat documentation.

--- a/lib/i18n/engine.ts
+++ b/lib/i18n/engine.ts
@@ -1,5 +1,6 @@
 import { generateText } from 'ai'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
+import { OPENROUTER_APP_HEADERS } from '../openrouter-attribution'
 import { GLOSSARY, TRANSLATE_MODEL, TRANSLATE_PROVIDER, TRANSLATE_SERVICE_TIER } from './config'
 import { LOCALE_NAMES } from '../i18n'
 import { withRetry } from './retry'
@@ -60,13 +61,7 @@ export function assertNotTruncated(finishReason: string, maxOutputTokens?: numbe
 export function createOpenRouterModel(): TranslateModel {
   const openrouter = createOpenRouter({
     apiKey: process.env.OPENROUTER_API_KEY,
-    // OpenRouter app-attribution headers: HTTP-Referer (site URL) and X-Title
-    // (app name) credit this traffic to LibreChat on openrouter.ai's app
-    // rankings. https://openrouter.ai/docs/api-reference/overview#headers
-    headers: {
-      'HTTP-Referer': 'https://www.librechat.ai',
-      'X-Title': 'LibreChat',
-    },
+    headers: OPENROUTER_APP_HEADERS,
   })
   // Pin the provider via OpenRouter's routing preferences; `service_tier` is not a
   // typed setting, so pass it through `extraBody` (merged verbatim into the request

--- a/lib/openrouter-attribution.test.ts
+++ b/lib/openrouter-attribution.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { OPENROUTER_APP_HEADERS } from './openrouter-attribution'
+
+describe('OpenRouter app attribution', () => {
+  it('credits the established LibreChat app instead of creating a www alias', () => {
+    expect(OPENROUTER_APP_HEADERS).toEqual({
+      'HTTP-Referer': 'https://librechat.ai/',
+      'X-OpenRouter-Title': 'LibreChat',
+    })
+  })
+})

--- a/lib/openrouter-attribution.ts
+++ b/lib/openrouter-attribution.ts
@@ -1,0 +1,13 @@
+/**
+ * OpenRouter uses HTTP-Referer as the app's unique identifier. Keep this URL
+ * aligned with the established LibreChat listing at openrouter.ai/apps/librechat:
+ * using the www hostname creates a separate app instead of crediting LibreChat.
+ *
+ * X-OpenRouter-Title is the current header name; OpenRouter retains X-Title only
+ * for backwards compatibility.
+ * https://openrouter.ai/docs/app-attribution
+ */
+export const OPENROUTER_APP_HEADERS = {
+  'HTTP-Referer': 'https://librechat.ai/',
+  'X-OpenRouter-Title': 'LibreChat',
+} as const

--- a/scripts/generate-starters.ts
+++ b/scripts/generate-starters.ts
@@ -25,6 +25,7 @@ import { readFile, writeFile, readdir } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import { createHash } from 'node:crypto'
 import { TARGET_LOCALES } from '../lib/i18n/config'
+import { OPENROUTER_APP_HEADERS } from '../lib/openrouter-attribution'
 
 // Skip machine-generated translations (foo.<locale>.mdx); only English sources
 // are starter inputs. Derived from the i18n config so adding a locale stays a
@@ -178,6 +179,7 @@ Respond with ONLY valid JSON. No markdown fences, no explanation.
     headers: {
       Authorization: `Bearer ${API_KEY}`,
       'Content-Type': 'application/json',
+      ...OPENROUTER_APP_HEADERS,
     },
     body: JSON.stringify({
       model: MODEL,


### PR DESCRIPTION
## Summary

- Extract duplicate OpenRouter attribution headers into a shared constant (`OPENROUTER_APP_HEADERS`)
- Fix `HTTP-Referer` to use `https://librechat.ai/` instead of `https://www.librechat.ai` to credit the established LibreChat app (www subdomain creates a separate app entry)
- Update `X-Title` to `X-OpenRouter-Title` (current header name; X-Title retained for backwards compatibility only)
- Add test verifying the headers are correctly configured
- Apply headers across chat API, i18n engine, and starter generation script

## Why

OpenRouter uses HTTP-Referer as the app's unique identifier. The www subdomain variant was creating a separate app listing instead of crediting the primary LibreChat entry at openrouter.ai/apps/librechat. Centralizing the headers as a constant prevents future drift and makes the configuration explicit and tested.