### PR TITLE
fix(screenshots): make the demo capture job work

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -35,10 +35,9 @@ jobs:
         env:
           DEMO_EMAIL: ${{ secrets.DEMO_EMAIL }}
           DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
-          DEMO_CONVERSATION_ID: ${{ secrets.DEMO_CONVERSATION_ID }}
         run: |
           missing=()
-          for name in DEMO_EMAIL DEMO_PASSWORD DEMO_CONVERSATION_ID; do
+          for name in DEMO_EMAIL DEMO_PASSWORD; do
             if [[ -z "${!name}" ]]; then
               missing+=("$name")
             fi
@@ -63,7 +62,6 @@ jobs:
         env:
           DEMO_EMAIL: ${{ secrets.DEMO_EMAIL }}
           DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
-          DEMO_CONVERSATION_ID: ${{ secrets.DEMO_CONVERSATION_ID }}
           DEMO_BASE_URL: ${{ vars.DEMO_BASE_URL }}
 
       # The capture script writes a screenshot, the served HTML and a network

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -65,6 +65,11 @@ jobs:
           DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
           DEMO_CONVERSATION_ID: ${{ secrets.DEMO_CONVERSATION_ID }}
           DEMO_BASE_URL: ${{ vars.DEMO_BASE_URL }}
+          # Matches the Cloudflare WAF skip rule on chat.librechat.ai. Without
+          # it the demo answers /api/config with a managed challenge that an XHR
+          # cannot solve, so the app never renders. See the README.
+          DEMO_BYPASS_TOKEN: ${{ secrets.DEMO_BYPASS_TOKEN }}
+          DEMO_BYPASS_HEADER: ${{ vars.DEMO_BYPASS_HEADER }}
 
       # The capture script writes a screenshot, the served HTML and a network
       # report for every failed attempt. Without these a failure is just an

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -65,11 +65,6 @@ jobs:
           DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
           DEMO_CONVERSATION_ID: ${{ secrets.DEMO_CONVERSATION_ID }}
           DEMO_BASE_URL: ${{ vars.DEMO_BASE_URL }}
-          # Matches the Cloudflare WAF skip rule on chat.librechat.ai. Without
-          # it the demo answers /api/config with a managed challenge that an XHR
-          # cannot solve, so the app never renders. See the README.
-          DEMO_BYPASS_TOKEN: ${{ secrets.DEMO_BYPASS_TOKEN }}
-          DEMO_BYPASS_HEADER: ${{ vars.DEMO_BYPASS_HEADER }}
 
       # The capture script writes a screenshot, the served HTML and a network
       # report for every failed attempt. Without these a failure is just an

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -66,6 +66,18 @@ jobs:
           DEMO_CONVERSATION_ID: ${{ secrets.DEMO_CONVERSATION_ID }}
           DEMO_BASE_URL: ${{ vars.DEMO_BASE_URL }}
 
+      # The capture script writes a screenshot, the served HTML and a network
+      # report for every failed attempt. Without these a failure is just an
+      # opaque selector timeout that cannot be reproduced off a runner.
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-diagnostics
+          path: screenshot-diagnostics/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Open pull request
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ bun.lockb
 # Testing & debugging artifacts
 test-results/
 playwright-report/
+screenshot-diagnostics/
 tests/
 sidebar-final-audit/
 codedb.snapshot

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -4,22 +4,44 @@ Regenerates the four hero images in `components/home/img/` from the live
 LibreChat demo. `components/home/Hero.tsx` imports these files directly, so the
 script just overwrites them in place.
 
-## Stage A — one-time demo-account seed (manual, needs DB access)
+## Stage A — demo-account seed (needs DB access)
 
-Done once so the recurring job has rich, on-message content to shoot. Use direct
-DB access to insert fabricated assistant replies (no AI credits spent).
+The hero shot is the new-chat screen, so what sells it is the sidebar: a column
+of conversations across different providers, each rendering its own icon. A
+sparsely populated account produces a thin, unconvincing image.
 
-Seed the dedicated demo account so it shows:
+`seed-demo.js` creates that content. It runs under `mongosh`, so this repo needs
+no database dependency, and it writes assistant replies directly rather than
+generating them, so no inference is billed.
 
-- [ ] The **LibreChat agent** selected/active as the endpoint.
-- [ ] Several conversations, each using a **different provider** (e.g. OpenAI,
-      Anthropic, Google), so multi-provider is visible in the sidebar.
-- [ ] **2 projects.**
-- [ ] **2-3 pinned models/agents.**
-- [ ] One primary conversation chosen as the hero shot. Record its id; it becomes
-      `DEMO_CONVERSATION_ID`.
+```bash
+# preview without writing
+mongosh "$MONGO_URI" --eval 'DEMO_EMAIL="demo@example.com"; DRY_RUN="true"' \
+  scripts/screenshots/seed-demo.js
 
-If the account is ever wiped, repeat this checklist.
+# seed
+mongosh "$MONGO_URI" --eval 'DEMO_EMAIL="demo@example.com"' \
+  scripts/screenshots/seed-demo.js
+
+# remove everything a previous run seeded
+mongosh "$MONGO_URI" --eval 'DEMO_EMAIL="demo@example.com"; CLEAN="true"' \
+  scripts/screenshots/seed-demo.js
+```
+
+It creates ~25 conversations spread across providers, a pinned "Getting started"
+conversation, and a **LibreChat agent** carrying the LibreChat logo. Everything
+it writes is tagged `docs-hero-seed`, so re-running replaces the previous batch
+and never touches conversations made by hand.
+
+**Before the first run, check the `CHATS` list at the top of the script.** The
+`endpoint` values must match endpoints the demo actually has configured in its
+`librechat.yaml`; an endpoint the server does not know falls back to a generic
+icon and the sidebar looks broken. The script prints the endpoints it used so a
+wrong one is easy to spot afterwards.
+
+The capture refuses to save a desktop image with fewer than 10 sidebar
+conversations, so if the account is ever wiped the job fails loudly instead of
+shipping a thin hero image. Re-run the seed if that happens.
 
 ## Stage B — recurring capture (automated)
 

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -55,3 +55,31 @@ preview in the hero with `pnpm dev`.
 the theme `localStorage` key. If the demo's markup changes, update `SELECTORS` and
 `THEME_STORAGE_KEY` (in `config.ts`). Discover current values with the
 `agent-browser` CLI or browser devtools against the live demo.
+
+The theme key must match the one LibreChat reads (`color-theme`, set by the inline
+script in its `client/index.html`). Writing any other key silently leaves both
+variants on the app's `system` default, so the light and dark shots come out
+identical rather than failing loudly.
+
+### Debugging a failed run
+
+The demo is a SPA that only renders the login form after `GET /api/config`
+succeeds. If that request is blocked (a CDN bot rule rejecting the runner's egress
+IP is the usual cause), the page loads instantly and then no form ever appears —
+which shows up as a selector timeout that says nothing about the real cause.
+
+For every failed attempt the script writes to `screenshot-diagnostics/`:
+
+| File                       | Contents                                                    |
+| -------------------------- | ----------------------------------------------------------- |
+| `<label>-attempt-<n>.png`  | full-page screenshot of what the browser actually saw       |
+| `<label>-attempt-<n>.html` | the served DOM                                              |
+| `<label>-attempt-<n>.txt`  | URL, title, visible text, `/api/*` statuses, console errors |
+
+It also prints that report to stderr and, when a critical API request failed,
+appends the reason to the thrown error. The workflow uploads the directory as a
+`screenshot-diagnostics` artifact on failure.
+
+The script sends a normal desktop user agent rather than Playwright's default
+`HeadlessChrome` token, since the latter is what gets `/api/config` rejected from
+CI egress IPs.

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -33,11 +33,16 @@ conversation, and a **LibreChat agent** carrying the LibreChat logo. Everything
 it writes is tagged `docs-hero-seed`, so re-running replaces the previous batch
 and never touches conversations made by hand.
 
-**Before the first run, check the `CHATS` list at the top of the script.** The
-`endpoint` values must match endpoints the demo actually has configured in its
-`librechat.yaml`; an endpoint the server does not know falls back to a generic
-icon and the sidebar looks broken. The script prints the endpoints it used so a
-wrong one is easy to spot afterwards.
+The `CHATS` list covers **one conversation per endpoint the demo serves**, so
+the sidebar shows the full spread of provider icons. It was built from a live
+inventory rather than guessed.
+
+Keeping it current: every capture run prints the demo's real endpoints and
+models under `--- demo endpoint inventory ---` in the job log. If the demo's
+`librechat.yaml` gains or loses a provider, refresh `CHATS` from that output. An
+`endpoint` the server does not return falls back to a generic icon, which looks
+broken and is easy to miss in review. The seed script prints the endpoints it
+used, so a stale one is visible immediately.
 
 The capture refuses to save a desktop image with fewer than 10 sidebar
 conversations, so if the account is ever wiped the job fails loudly instead of

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -44,6 +44,14 @@ models under `--- demo endpoint inventory ---` in the job log. If the demo's
 broken and is easy to miss in review. The seed script prints the endpoints it
 used, so a stale one is visible immediately.
 
+`seed-demo.test.ts` runs the script against a stub that models **mongosh**
+cursor semantics rather than the legacy shell's. That distinction is not
+academic: a cursor's `.map()` stays lazy and returns another cursor, so code
+that treats the result as an array reads `undefined` for `.length` and throws
+`Cannot convert circular structure to BSON` when the value reaches a query.
+An earlier stub returned a plain array and hid exactly that bug. Keep the stub
+faithful to mongosh, or the tests will pass while the script cannot run.
+
 The capture refuses to save a desktop image with fewer than 10 sidebar
 conversations, so if the account is ever wiped the job fails loudly instead of
 shipping a thin hero image. Re-run the seed if that happens.

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -31,12 +31,35 @@ against the demo's current UI.
 The GitHub workflow runs in the `Production` Environment, so define these
 secrets/variables there.
 
-| Name                   | Where                              | Purpose                                 |
-| ---------------------- | ---------------------------------- | --------------------------------------- |
-| `DEMO_EMAIL`           | secret / `.env.local`              | demo account login                      |
-| `DEMO_PASSWORD`        | secret / `.env.local`              | demo account password                   |
-| `DEMO_CONVERSATION_ID` | secret / `.env.local`              | hero conversation id                    |
-| `DEMO_BASE_URL`        | variable / `.env.local` (optional) | defaults to `https://chat.librechat.ai` |
+| Name                   | Where                              | Purpose                                    |
+| ---------------------- | ---------------------------------- | ------------------------------------------ |
+| `DEMO_EMAIL`           | secret / `.env.local`              | demo account login                         |
+| `DEMO_PASSWORD`        | secret / `.env.local`              | demo account password                      |
+| `DEMO_CONVERSATION_ID` | secret / `.env.local`              | hero conversation id                       |
+| `DEMO_BASE_URL`        | variable / `.env.local` (optional) | defaults to `https://chat.librechat.ai`    |
+| `DEMO_BYPASS_TOKEN`    | secret (required in CI)            | value of the Cloudflare WAF skip header    |
+| `DEMO_BYPASS_HEADER`   | variable (optional)                | header name, default `x-screenshot-bypass` |
+
+### Cloudflare WAF skip rule (required for CI)
+
+Cloudflare serves `chat.librechat.ai` a **managed challenge** on `/api/*` for
+GitHub Actions egress. A page navigation survives it, but the SPA fetches
+`/api/config` over XHR and an XHR cannot solve a JS challenge, so the app
+renders "There was an internal server error" and there is nothing to capture.
+Confirmed from a runner: `cf-mitigated: challenge`, `server: cloudflare`, body
+`Just a moment...`, and no `via: 1.1 Caddy`, so the origin never saw the
+request. The same requests from a residential IP return 200.
+
+No change to this repo can solve that. On the Cloudflare zone for
+`chat.librechat.ai`, add a WAF custom rule:
+
+- **If** `http.request.headers["x-screenshot-bypass"][0] eq "<secret>"`
+- **Then** Skip → Managed Challenge / remaining custom rules
+- Place it **above** the rule issuing the challenge.
+
+Then store `<secret>` as the `DEMO_BYPASS_TOKEN` secret on the `Production`
+environment. Until that exists the job fails and uploads the diagnostics that
+prove why. Rotate the token by editing the rule and the secret together.
 
 ### Run locally
 
@@ -64,9 +87,9 @@ identical rather than failing loudly.
 ### Debugging a failed run
 
 The demo is a SPA that only renders the login form after `GET /api/config`
-succeeds. If that request is blocked (a CDN bot rule rejecting the runner's egress
-IP is the usual cause), the page loads instantly and then no form ever appears —
-which shows up as a selector timeout that says nothing about the real cause.
+succeeds. If that request is blocked, the page loads instantly and then no form
+ever appears, which surfaces as a selector timeout that says nothing about the
+real cause.
 
 For every failed attempt the script writes to `screenshot-diagnostics/`:
 
@@ -76,10 +99,16 @@ For every failed attempt the script writes to `screenshot-diagnostics/`:
 | `<label>-attempt-<n>.html` | the served DOM                                              |
 | `<label>-attempt-<n>.txt`  | URL, title, visible text, `/api/*` statuses, console errors |
 
-It also prints that report to stderr and, when a critical API request failed,
-appends the reason to the thrown error. The workflow uploads the directory as a
+The `.txt` also carries a **who rejected the boot-blocking request** section with
+the headers and body of the first rejected `/api/config`. Read it first: `via:
+1.1 Caddy` means the demo's own origin answered and the limit lives in
+LibreChat's config, while `cf-ray` plus `cf-mitigated` and no `via` means
+Cloudflare generated it and the fix belongs in the zone's WAF rules.
+
+The report is printed to stderr too, and when a boot-blocking request failed the
+reason is appended to the thrown error. The workflow uploads the directory as a
 `screenshot-diagnostics` artifact on failure.
 
 The script sends a normal desktop user agent rather than Playwright's default
-`HeadlessChrome` token, since the latter is what gets `/api/config` rejected from
-CI egress IPs.
+`HeadlessChrome` token. That is hygiene only — a CI run with a clean user agent
+still gets challenged, so the user agent is not what triggers the block.

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -31,35 +31,35 @@ against the demo's current UI.
 The GitHub workflow runs in the `Production` Environment, so define these
 secrets/variables there.
 
-| Name                   | Where                              | Purpose                                    |
-| ---------------------- | ---------------------------------- | ------------------------------------------ |
-| `DEMO_EMAIL`           | secret / `.env.local`              | demo account login                         |
-| `DEMO_PASSWORD`        | secret / `.env.local`              | demo account password                      |
-| `DEMO_CONVERSATION_ID` | secret / `.env.local`              | hero conversation id                       |
-| `DEMO_BASE_URL`        | variable / `.env.local` (optional) | defaults to `https://chat.librechat.ai`    |
-| `DEMO_BYPASS_TOKEN`    | secret (required in CI)            | value of the Cloudflare WAF skip header    |
-| `DEMO_BYPASS_HEADER`   | variable (optional)                | header name, default `x-screenshot-bypass` |
+| Name                   | Where                              | Purpose                                 |
+| ---------------------- | ---------------------------------- | --------------------------------------- |
+| `DEMO_EMAIL`           | secret / `.env.local`              | demo account login                      |
+| `DEMO_PASSWORD`        | secret / `.env.local`              | demo account password                   |
+| `DEMO_CONVERSATION_ID` | secret / `.env.local`              | hero conversation id                    |
+| `DEMO_BASE_URL`        | variable / `.env.local` (optional) | defaults to `https://chat.librechat.ai` |
 
-### Cloudflare WAF skip rule (required for CI)
+### Cloudflare Bot Fight Mode must stay off
 
-Cloudflare serves `chat.librechat.ai` a **managed challenge** on `/api/*` for
-GitHub Actions egress. A page navigation survives it, but the SPA fetches
-`/api/config` over XHR and an XHR cannot solve a JS challenge, so the app
-renders "There was an internal server error" and there is nothing to capture.
-Confirmed from a runner: `cf-mitigated: challenge`, `server: cloudflare`, body
-`Just a moment...`, and no `via: 1.1 Caddy`, so the origin never saw the
-request. The same requests from a residential IP return 200.
+Bot Fight Mode challenges this job. It served `/api/config` a managed challenge
+from GitHub Actions egress (`cf-mitigated: challenge`, body `Just a moment...`,
+no `via: 1.1 Caddy`, so the origin never saw it), and because the SPA fetches
+its startup config over XHR, which cannot solve a JS challenge, the app rendered
+"There was an internal server error" and there was nothing to capture. The same
+requests from a residential IP returned 200.
 
-No change to this repo can solve that. On the Cloudflare zone for
-`chat.librechat.ai`, add a WAF custom rule:
+Bot Fight Mode cannot be worked around from this repo. Per Cloudflare's docs it
+does not run on the Ruleset Engine, so WAF custom rules with a Skip action have
+no effect on it, and it is zone-wide with no hostname or path scoping. A skip
+rule keyed on a secret header was tried and matched 162 times without stopping
+the challenge.
 
-- **If** `http.request.headers["x-screenshot-bypass"][0] eq "<secret>"`
-- **Then** Skip → Managed Challenge / remaining custom rules
-- Place it **above** the rule issuing the challenge.
+If it is ever re-enabled, this job breaks again. The options are to upgrade the
+zone to Pro, where Super Bot Fight Mode does support Skip rules, or to stop
+capturing against the live demo.
 
-Then store `<secret>` as the `DEMO_BYPASS_TOKEN` secret on the `Production`
-environment. Until that exists the job fails and uploads the diagnostics that
-prove why. Rotate the token by editing the rule and the secret together.
+Do not reach for `extraHTTPHeaders` to smuggle a bypass token: Playwright
+applies it to every request including cross-origin ones, which makes them
+preflighted, and third parties reject the unknown header.
 
 ### Run locally
 

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -1,4 +1,4 @@
-import { chromium, type Browser, type BrowserContext, type Page } from 'playwright'
+import { chromium, type Browser, type Page } from 'playwright'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
@@ -16,19 +16,11 @@ const PASSWORD = process.env.DEMO_PASSWORD
 const CONVERSATION_ID = process.env.DEMO_CONVERSATION_ID
 const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
 
-/**
- * Cloudflare serves the demo a managed challenge (`cf-mitigated: challenge`) on
- * `/api/*` from CI egress. A page navigation can survive that, but the SPA's
- * XHR for `/api/config` cannot solve a JS challenge, so the app renders an
- * error and no UI is ever captured.
- *
- * The only fix is a WAF skip rule on chat.librechat.ai matching a header the
- * public does not send. Set DEMO_BYPASS_TOKEN once that rule exists; until then
- * this is inert and the job fails with the diagnostics that prove why.
- */
-const BYPASS_HEADER = process.env.DEMO_BYPASS_HEADER?.trim() || 'x-screenshot-bypass'
-const BYPASS_TOKEN = process.env.DEMO_BYPASS_TOKEN?.trim()
-const extraHTTPHeaders = BYPASS_TOKEN ? { [BYPASS_HEADER]: BYPASS_TOKEN } : undefined
+// Do not add custom headers to the browser context. Playwright applies
+// extraHTTPHeaders to every request including cross-origin ones, which turns
+// them into preflighted CORS requests; third parties reject the unknown header
+// and the page loses scripts it expects. Anything the demo's edge needs to
+// recognise belongs in a rule keyed on something already present.
 
 if (!EMAIL || !PASSWORD || !CONVERSATION_ID) {
   console.error('Missing required env: DEMO_EMAIL, DEMO_PASSWORD, DEMO_CONVERSATION_ID')
@@ -214,49 +206,38 @@ async function openAppPage(page: Page, url: string, label: string) {
   })
 }
 
-async function login(browser: Browser, userAgent: string, attempt: number) {
-  const context = await browser.newContext({ userAgent, extraHTTPHeaders })
-  try {
-    const page = await context.newPage()
-    const probe = attachProbe(page)
-    try {
-      await openAppPage(page, `${baseURL}/login`, 'login')
-      await page.waitForSelector(SELECTORS.email, { timeout: LOGIN_FORM_TIMEOUT })
-      await page.fill(SELECTORS.email, EMAIL!)
-      await page.fill(SELECTORS.password, PASSWORD!)
-      await page.click(SELECTORS.submit)
-      await page
-        .waitForURL(`${baseURL}/c/**`, { timeout: POST_LOGIN_TIMEOUT })
-        .catch(() => undefined)
-      // Hard-fail if we are still on the login page (bad credentials, rate limit,
-      // etc.) so withRetry retries and ultimately exits non-zero instead of
-      // capturing screenshots of the login/error screen.
-      if (new URL(page.url()).pathname.startsWith('/login')) {
-        throw new Error(`Login failed: still on ${page.url()} after submitting credentials`)
-      }
-      return await context.storageState()
-    } catch (err) {
-      await dumpDiagnostics(page, probe, 'login', attempt)
-      throw new Error(explainFailure(probe, err instanceof Error ? err.message : String(err)), {
-        cause: err,
-      })
-    }
-  } finally {
-    await context.close()
+/**
+ * Signs in on the page that will take the screenshot.
+ *
+ * Deliberately not shared via `storageState`: LibreChat keeps the access token
+ * in memory and rotates the refresh token, so replaying one saved session into
+ * a second context gets 401 from /api/auth/refresh and bounces to
+ * /login?redirect_to=..., which is a login screen where the chat should be.
+ * Each context therefore establishes its own session.
+ */
+async function signIn(page: Page) {
+  await openAppPage(page, `${baseURL}/login`, 'login')
+  await page.waitForSelector(SELECTORS.email, { timeout: LOGIN_FORM_TIMEOUT })
+  await page.fill(SELECTORS.email, EMAIL!)
+  await page.fill(SELECTORS.password, PASSWORD!)
+  await page.click(SELECTORS.submit)
+  await page.waitForURL(`${baseURL}/c/**`, { timeout: POST_LOGIN_TIMEOUT }).catch(() => undefined)
+  // Hard-fail if we are still on the login page (bad credentials, rate limit,
+  // etc.) so withRetry retries and ultimately exits non-zero instead of
+  // capturing screenshots of the login/error screen.
+  if (new URL(page.url()).pathname.startsWith('/login')) {
+    throw new Error(`Login failed: still on ${page.url()} after submitting credentials`)
   }
 }
 
 async function captureVariant(
   browser: Browser,
-  storageState: Awaited<ReturnType<BrowserContext['storageState']>>,
   variant: Variant,
   userAgent: string,
   attempt: number,
 ) {
   const context = await browser.newContext({
-    storageState,
     userAgent,
-    extraHTTPHeaders,
     viewport: variant.viewport,
     deviceScaleFactor: variant.deviceScaleFactor,
     isMobile: variant.device === 'mobile',
@@ -268,7 +249,13 @@ async function captureVariant(
     const page = await context.newPage()
     const probe = attachProbe(page)
     try {
+      await signIn(page)
       await openAppPage(page, `${baseURL}/c/${CONVERSATION_ID}`, variant.name)
+      // A bounce back to /login means the session did not survive the
+      // navigation; fail here rather than shooting the login screen.
+      if (new URL(page.url()).pathname.startsWith('/login')) {
+        throw new Error(`Session lost: redirected to ${page.url()} instead of the conversation`)
+      }
       await page.waitForSelector(SELECTORS.message, { timeout: MESSAGE_TIMEOUT })
       await page.addStyleTag({ content: DISABLE_MOTION_CSS })
       await page.evaluate((zoom) => {
@@ -321,16 +308,9 @@ async function main() {
   try {
     const userAgent = await desktopUserAgent(browser)
     console.log(`using user agent: ${userAgent}`)
-    // Log presence only; the value is a secret.
-    console.log(
-      BYPASS_TOKEN
-        ? `sending CDN bypass header "${BYPASS_HEADER}"`
-        : 'no DEMO_BYPASS_TOKEN set — a CDN challenge on /api/* will fail this run',
-    )
-    const storageState = await withRetry('login', (attempt) => login(browser, userAgent, attempt))
     for (const variant of VARIANTS) {
       await withRetry(variant.name, (attempt) =>
-        captureVariant(browser, storageState, variant, userAgent, attempt),
+        captureVariant(browser, variant, userAgent, attempt),
       )
     }
   } finally {

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -35,10 +35,10 @@ const SELECTORS = {
 }
 
 /**
- * The demo sits behind a CDN that treats the stock `HeadlessChrome` token as a
- * bot, which gets `/api/config` rejected from CI egress IPs. LibreChat only
- * renders the login form once that request succeeds, so without this the job
- * just times out waiting for an input that is never going to appear.
+ * Presents as an ordinary desktop browser rather than advertising
+ * `HeadlessChrome`. This is hygiene, not a fix: a CI run with this user agent
+ * still gets `/api/*` rejected, so the demo's 403 is not UA-driven. Kept
+ * because it removes one variable from the next diagnosis.
  */
 async function desktopUserAgent(browser: Browser): Promise<string> {
   const context = await browser.newContext()
@@ -76,6 +76,35 @@ interface Probe {
   consoleErrors: string[]
   failedRequests: string[]
   criticalApi: string[]
+  blockedResponses: Promise<string>[]
+}
+
+/**
+ * Captures who rejected a boot-blocking request. `via: 1.1 Caddy` means the
+ * demo's own origin answered; a response carrying `cf-ray`/`cf-mitigated` but
+ * no `via` was generated at the edge. That distinction decides whether the
+ * limit is fixed in LibreChat's config or in the CDN dashboard, and it is not
+ * recoverable from the status code alone.
+ */
+async function describeBlocked(response: {
+  status(): number
+  url(): string
+  headers(): Record<string, string>
+  text(): Promise<string>
+}): Promise<string> {
+  const headers = response.headers()
+  const named = ['server', 'via', 'cf-ray', 'cf-mitigated', 'retry-after', 'content-type']
+    .filter((name) => headers[name])
+    .map((name) => `${name}: ${headers[name]}`)
+  let body: string
+  try {
+    body = (await response.text()).slice(0, 300).replaceAll(/\s+/g, ' ').trim()
+  } catch {
+    body = '(body unavailable)'
+  }
+  return [`${response.status()} ${response.url()}`, ...named, `body: ${body || '(empty)'}`].join(
+    '\n    ',
+  )
 }
 
 /**
@@ -84,7 +113,12 @@ interface Probe {
  * actionable from the CI log.
  */
 function attachProbe(page: Page): Probe {
-  const probe: Probe = { consoleErrors: [], failedRequests: [], criticalApi: [] }
+  const probe: Probe = {
+    consoleErrors: [],
+    failedRequests: [],
+    criticalApi: [],
+    blockedResponses: [],
+  }
   page.on('console', (msg) => {
     if (msg.type() === 'error') probe.consoleErrors.push(msg.text().slice(0, 300))
   })
@@ -95,8 +129,13 @@ function attachProbe(page: Page): Probe {
     const url = response.url()
     if (!CRITICAL_API.test(url)) return
     probe.criticalApi.push(`${response.status()} ${url}`)
-    if (!response.ok()) {
-      probe.failedRequests.push(`HTTP ${response.status()} ${url}`)
+    if (response.ok()) return
+    probe.failedRequests.push(`HTTP ${response.status()} ${url}`)
+    // The SPA retries hard; the first couple are enough to identify the source.
+    if (probe.blockedResponses.length < 2 && BOOT_BLOCKING_API.test(url)) {
+      probe.blockedResponses.push(
+        describeBlocked(response).catch(() => `${response.status()} ${url} (details unavailable)`),
+      )
     }
   })
   return probe
@@ -124,6 +163,9 @@ async function dumpDiagnostics(page: Page, probe: Probe, label: string, attempt:
       '--- failed requests ---',
       probe.failedRequests.join('\n') || '(none)',
       '',
+      '--- who rejected the boot-blocking request ---',
+      (await Promise.all(probe.blockedResponses)).join('\n') || '(nothing was rejected)',
+      '',
       '--- console errors ---',
       probe.consoleErrors.join('\n') || '(none)',
       '',
@@ -145,7 +187,7 @@ function explainFailure(probe: Probe, fallback: string): string {
     ...new Set(probe.failedRequests.filter((entry) => BOOT_BLOCKING_API.test(entry))),
   ]
   if (blocked.length > 0) {
-    return `${fallback}\nCause: the demo did not serve its startup config (${blocked.join('; ')}), so the app rendered an error instead of the UI. This is usually the demo's CDN rejecting the runner's egress IP.`
+    return `${fallback}\nCause: the demo did not serve its startup config (${blocked.join('; ')}), so the app rendered an error instead of the UI. See the "who rejected the boot-blocking request" section of the diagnostics for whether the edge or the origin answered.`
   }
   return fallback
 }

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -283,6 +283,12 @@ async function captureVariant(
       // then the app is up and the dialog is either present or never coming.
       await page.waitForSelector(SELECTORS.message, { timeout: MESSAGE_TIMEOUT })
       await acceptTermsIfPresent(page, variant.name)
+      // Park the pointer and drop focus. Otherwise whatever was last clicked
+      // keeps its focus ring and whatever the pointer rests over keeps its
+      // hover toolbar, which differs between variants and lands on the
+      // landing page as a stray highlight.
+      await page.mouse.move(0, 0)
+      await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
       await page.addStyleTag({ content: DISABLE_MOTION_CSS })
       await page.evaluate((zoom) => {
         document.documentElement.style.setProperty('zoom', String(zoom))

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -16,6 +16,20 @@ const PASSWORD = process.env.DEMO_PASSWORD
 const CONVERSATION_ID = process.env.DEMO_CONVERSATION_ID
 const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
 
+/**
+ * Cloudflare serves the demo a managed challenge (`cf-mitigated: challenge`) on
+ * `/api/*` from CI egress. A page navigation can survive that, but the SPA's
+ * XHR for `/api/config` cannot solve a JS challenge, so the app renders an
+ * error and no UI is ever captured.
+ *
+ * The only fix is a WAF skip rule on chat.librechat.ai matching a header the
+ * public does not send. Set DEMO_BYPASS_TOKEN once that rule exists; until then
+ * this is inert and the job fails with the diagnostics that prove why.
+ */
+const BYPASS_HEADER = process.env.DEMO_BYPASS_HEADER?.trim() || 'x-screenshot-bypass'
+const BYPASS_TOKEN = process.env.DEMO_BYPASS_TOKEN?.trim()
+const extraHTTPHeaders = BYPASS_TOKEN ? { [BYPASS_HEADER]: BYPASS_TOKEN } : undefined
+
 if (!EMAIL || !PASSWORD || !CONVERSATION_ID) {
   console.error('Missing required env: DEMO_EMAIL, DEMO_PASSWORD, DEMO_CONVERSATION_ID')
   process.exit(1)
@@ -201,7 +215,7 @@ async function openAppPage(page: Page, url: string, label: string) {
 }
 
 async function login(browser: Browser, userAgent: string, attempt: number) {
-  const context = await browser.newContext({ userAgent })
+  const context = await browser.newContext({ userAgent, extraHTTPHeaders })
   try {
     const page = await context.newPage()
     const probe = attachProbe(page)
@@ -242,6 +256,7 @@ async function captureVariant(
   const context = await browser.newContext({
     storageState,
     userAgent,
+    extraHTTPHeaders,
     viewport: variant.viewport,
     deviceScaleFactor: variant.deviceScaleFactor,
     isMobile: variant.device === 'mobile',
@@ -306,6 +321,12 @@ async function main() {
   try {
     const userAgent = await desktopUserAgent(browser)
     console.log(`using user agent: ${userAgent}`)
+    // Log presence only; the value is a secret.
+    console.log(
+      BYPASS_TOKEN
+        ? `sending CDN bypass header "${BYPASS_HEADER}"`
+        : 'no DEMO_BYPASS_TOKEN set — a CDN challenge on /api/* will fail this run',
+    )
     const storageState = await withRetry('login', (attempt) => login(browser, userAgent, attempt))
     for (const variant of VARIANTS) {
       await withRetry(variant.name, (attempt) =>

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -33,6 +33,11 @@ const SELECTORS = {
   email: 'input[name="email"], input#email',
   password: 'input[name="password"], input#password',
   submit: 'button[data-testid="login-button"], button[type="submit"]',
+  // The demo sets interface.termsOfService.modalAcceptance, so a Terms dialog
+  // covers the entire UI until it is dismissed. LibreChat's TermsAndConditionsModal
+  // gives its buttons no test id, so match the label exactly: `:text-is()` avoids
+  // hitting the neighbouring "I do not accept".
+  acceptTerms: 'button:text-is("I accept")',
   // `.message-render` wraps every rendered message (LibreChat MessageParts.tsx),
   // so it only exists once the conversation body is on screen. Do not use
   // `convo-icon` here: that is the sidebar/endpoint icon and renders before any
@@ -65,6 +70,7 @@ const POST_LOGIN_TIMEOUT = 45_000
 const READY_STATE_TIMEOUT = 15_000
 const LOGIN_FORM_TIMEOUT = 45_000
 const MESSAGE_TIMEOUT = 45_000
+const TERMS_TIMEOUT = 8_000
 const RETRY_BACKOFF_MS = 10_000
 
 /** Recorded in diagnostics to show what the app managed to fetch. */
@@ -215,6 +221,23 @@ async function openAppPage(page: Page, url: string, label: string) {
  * /login?redirect_to=..., which is a login screen where the chat should be.
  * Each context therefore establishes its own session.
  */
+/**
+ * Dismisses the demo's Terms dialog when it appears. Best-effort: acceptance is
+ * recorded against the account, so it typically only shows for the first
+ * variant, and a run where it never appears is not an error.
+ */
+async function acceptTermsIfPresent(page: Page, label: string) {
+  const accept = page.locator(SELECTORS.acceptTerms)
+  try {
+    await accept.waitFor({ state: 'visible', timeout: TERMS_TIMEOUT })
+  } catch {
+    return
+  }
+  console.log(`${label}: dismissing terms dialog`)
+  await accept.click()
+  await accept.waitFor({ state: 'hidden', timeout: TERMS_TIMEOUT })
+}
+
 async function signIn(page: Page) {
   await openAppPage(page, `${baseURL}/login`, 'login')
   await page.waitForSelector(SELECTORS.email, { timeout: LOGIN_FORM_TIMEOUT })
@@ -256,7 +279,10 @@ async function captureVariant(
       if (new URL(page.url()).pathname.startsWith('/login')) {
         throw new Error(`Session lost: redirected to ${page.url()} instead of the conversation`)
       }
+      // Messages render behind the Terms overlay, so wait for them first: by
+      // then the app is up and the dialog is either present or never coming.
       await page.waitForSelector(SELECTORS.message, { timeout: MESSAGE_TIMEOUT })
+      await acceptTermsIfPresent(page, variant.name)
       await page.addStyleTag({ content: DISABLE_MOTION_CSS })
       await page.evaluate((zoom) => {
         document.documentElement.style.setProperty('zoom', String(zoom))
@@ -266,6 +292,16 @@ async function captureVariant(
         await document.fonts.ready
       })
       await page.waitForTimeout(500)
+      // These images ship straight onto the landing page, so refuse to save one
+      // with a dialog over it. The terms modal did exactly that and the run
+      // still reported success.
+      const dialog = page.locator('[role="dialog"]').first()
+      if (await dialog.isVisible().catch(() => false)) {
+        const text = (await dialog.innerText().catch(() => ''))
+          .replaceAll(/\s+/g, ' ')
+          .slice(0, 120)
+        throw new Error(`A dialog is covering the UI, refusing to capture: "${text}"`)
+      }
       const file = outputPath(variant)
       await mkdir(dirname(file), { recursive: true })
       await page.screenshot({ path: file, animations: 'disabled' })

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -2,7 +2,6 @@ import { chromium, type Browser, type Page } from 'playwright'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
-  ZOOM,
   VARIANTS,
   type Variant,
   outputPath,
@@ -13,7 +12,6 @@ import {
 
 const EMAIL = process.env.DEMO_EMAIL
 const PASSWORD = process.env.DEMO_PASSWORD
-const CONVERSATION_ID = process.env.DEMO_CONVERSATION_ID
 const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
 
 // Do not add custom headers to the browser context. Playwright applies
@@ -22,8 +20,8 @@ const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
 // and the page loses scripts it expects. Anything the demo's edge needs to
 // recognise belongs in a rule keyed on something already present.
 
-if (!EMAIL || !PASSWORD || !CONVERSATION_ID) {
-  console.error('Missing required env: DEMO_EMAIL, DEMO_PASSWORD, DEMO_CONVERSATION_ID')
+if (!EMAIL || !PASSWORD) {
+  console.error('Missing required env: DEMO_EMAIL, DEMO_PASSWORD')
   process.exit(1)
 }
 
@@ -38,12 +36,20 @@ const SELECTORS = {
   // gives its buttons no test id, so match the label exactly: `:text-is()` avoids
   // hitting the neighbouring "I do not accept".
   acceptTerms: 'button:text-is("I accept")',
-  // `.message-render` wraps every rendered message (LibreChat MessageParts.tsx),
-  // so it only exists once the conversation body is on screen. Do not use
-  // `convo-icon` here: that is the sidebar/endpoint icon and renders before any
-  // message does, which would let us shoot an empty chat pane.
-  message: '.message-render, [data-testid="message"]',
+  // The composer. Present once the new-chat screen has rendered, on every
+  // viewport, so it is the readiness signal for the shot.
+  composer: '[data-testid="text-input"]',
+  // One row in the sidebar conversation list.
+  sidebarChat: '[data-testid="convo-item"]',
 }
+
+/**
+ * The sidebar carrying a column of different provider icons is the point of
+ * the hero image. If the demo account gets wiped or reseeded thinly we would
+ * otherwise ship a near-empty sidebar and only notice on the live site.
+ * Re-run scripts/screenshots/seed-demo.js if this trips.
+ */
+const MIN_SIDEBAR_CHATS = 10
 
 /**
  * Presents as an ordinary desktop browser rather than advertising
@@ -69,7 +75,7 @@ const NAVIGATION_TIMEOUT = 60_000
 const POST_LOGIN_TIMEOUT = 45_000
 const READY_STATE_TIMEOUT = 15_000
 const LOGIN_FORM_TIMEOUT = 45_000
-const MESSAGE_TIMEOUT = 45_000
+const APP_READY_TIMEOUT = 45_000
 const TERMS_TIMEOUT = 8_000
 const RETRY_BACKOFF_MS = 10_000
 
@@ -253,6 +259,24 @@ async function signIn(page: Page) {
   }
 }
 
+/**
+ * Guards the point of the image. Desktop only: the sidebar is collapsed behind
+ * a hamburger on mobile, which is what the original mobile shots showed too.
+ */
+async function assertSidebarPopulated(page: Page, variant: Variant) {
+  if (variant.device !== 'desktop') return
+  const chats = page.locator(SELECTORS.sidebarChat)
+  await chats.first().waitFor({ state: 'visible', timeout: APP_READY_TIMEOUT })
+  const count = await chats.count()
+  if (count < MIN_SIDEBAR_CHATS) {
+    throw new Error(
+      `Sidebar has ${count} conversations, expected at least ${MIN_SIDEBAR_CHATS}. ` +
+        'The demo account looks unseeded; run scripts/screenshots/seed-demo.js.',
+    )
+  }
+  console.log(`${variant.name}: sidebar has ${count} conversations`)
+}
+
 async function captureVariant(
   browser: Browser,
   variant: Variant,
@@ -273,16 +297,20 @@ async function captureVariant(
     const probe = attachProbe(page)
     try {
       await signIn(page)
-      await openAppPage(page, `${baseURL}/c/${CONVERSATION_ID}`, variant.name)
+      // Shoot the new-chat screen rather than a conversation: it shows the
+      // logo, the composer and the full sidebar, and it is the only frame that
+      // fits a mobile viewport without cutting the interface in half.
+      await openAppPage(page, `${baseURL}/c/new`, variant.name)
       // A bounce back to /login means the session did not survive the
       // navigation; fail here rather than shooting the login screen.
       if (new URL(page.url()).pathname.startsWith('/login')) {
-        throw new Error(`Session lost: redirected to ${page.url()} instead of the conversation`)
+        throw new Error(`Session lost: redirected to ${page.url()} instead of the app`)
       }
-      // Messages render behind the Terms overlay, so wait for them first: by
+      // The composer renders behind the Terms overlay, so wait for it first: by
       // then the app is up and the dialog is either present or never coming.
-      await page.waitForSelector(SELECTORS.message, { timeout: MESSAGE_TIMEOUT })
+      await page.waitForSelector(SELECTORS.composer, { timeout: APP_READY_TIMEOUT })
       await acceptTermsIfPresent(page, variant.name)
+      await assertSidebarPopulated(page, variant)
       // Park the pointer and drop focus. Otherwise whatever was last clicked
       // keeps its focus ring and whatever the pointer rests over keeps its
       // hover toolbar, which differs between variants and lands on the
@@ -290,9 +318,6 @@ async function captureVariant(
       await page.mouse.move(0, 0)
       await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
       await page.addStyleTag({ content: DISABLE_MOTION_CSS })
-      await page.evaluate((zoom) => {
-        document.documentElement.style.setProperty('zoom', String(zoom))
-      }, ZOOM)
       // Await web fonts without returning a non-serializable value to Playwright.
       await page.evaluate(async () => {
         await document.fonts.ready

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -1,6 +1,6 @@
 import { chromium, type Browser, type BrowserContext, type Page } from 'playwright'
-import { mkdir } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import {
   ZOOM,
   VARIANTS,
@@ -8,6 +8,7 @@ import {
   outputPath,
   screenshotBaseURL,
   themeBootstrap,
+  DIAGNOSTICS_DIR,
 } from './config'
 
 const EMAIL = process.env.DEMO_EMAIL
@@ -20,13 +21,34 @@ if (!EMAIL || !PASSWORD || !CONVERSATION_ID) {
   process.exit(1)
 }
 
-// Selectors verified against the live demo in Step 4. Adjust there if the demo differs.
+// Verified against the live demo. Each entry lists fallbacks so a cosmetic
+// markup change on the demo does not take the whole job down.
 const SELECTORS = {
-  email: 'input[name="email"]',
-  password: 'input[name="password"]',
-  submit: 'button[type="submit"]',
-  // Any element that only exists once the conversation has rendered messages.
-  message: '[data-testid="convo-icon"], .message, [data-testid="message"]',
+  email: 'input[name="email"], input#email',
+  password: 'input[name="password"], input#password',
+  submit: 'button[data-testid="login-button"], button[type="submit"]',
+  // `.message-render` wraps every rendered message (LibreChat MessageParts.tsx),
+  // so it only exists once the conversation body is on screen. Do not use
+  // `convo-icon` here: that is the sidebar/endpoint icon and renders before any
+  // message does, which would let us shoot an empty chat pane.
+  message: '.message-render, [data-testid="message"]',
+}
+
+/**
+ * The demo sits behind a CDN that treats the stock `HeadlessChrome` token as a
+ * bot, which gets `/api/config` rejected from CI egress IPs. LibreChat only
+ * renders the login form once that request succeeds, so without this the job
+ * just times out waiting for an input that is never going to appear.
+ */
+async function desktopUserAgent(browser: Browser): Promise<string> {
+  const context = await browser.newContext()
+  try {
+    const page = await context.newPage()
+    const ua = await page.evaluate(() => navigator.userAgent)
+    return ua.replace('HeadlessChrome', 'Chrome')
+  } finally {
+    await context.close()
+  }
 }
 
 const DISABLE_MOTION_CSS =
@@ -35,6 +57,98 @@ const DISABLE_MOTION_CSS =
 const NAVIGATION_TIMEOUT = 60_000
 const POST_LOGIN_TIMEOUT = 45_000
 const READY_STATE_TIMEOUT = 15_000
+const LOGIN_FORM_TIMEOUT = 45_000
+const MESSAGE_TIMEOUT = 45_000
+const RETRY_BACKOFF_MS = 10_000
+
+/** Recorded in diagnostics to show what the app managed to fetch. */
+const CRITICAL_API = /\/api\/(config|banner|auth\/refresh)/
+
+/**
+ * LibreChat renders the login form only when `startupConfig.emailLoginEnabled`
+ * is true, so a failure here means no form ever appears. Kept narrower than
+ * CRITICAL_API: `/api/banner` is optional and `/api/auth/refresh` returns 404
+ * for a logged-out visitor, so neither implies anything is wrong.
+ */
+const BOOT_BLOCKING_API = /\/api\/config/
+
+interface Probe {
+  consoleErrors: string[]
+  failedRequests: string[]
+  criticalApi: string[]
+}
+
+/**
+ * Records why a page failed to render. Without this a CDN block and a genuine
+ * markup change produce the same bare "selector timed out" and neither is
+ * actionable from the CI log.
+ */
+function attachProbe(page: Page): Probe {
+  const probe: Probe = { consoleErrors: [], failedRequests: [], criticalApi: [] }
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') probe.consoleErrors.push(msg.text().slice(0, 300))
+  })
+  page.on('requestfailed', (request) => {
+    probe.failedRequests.push(`${request.failure()?.errorText ?? 'failed'} ${request.url()}`)
+  })
+  page.on('response', (response) => {
+    const url = response.url()
+    if (!CRITICAL_API.test(url)) return
+    probe.criticalApi.push(`${response.status()} ${url}`)
+    if (!response.ok()) {
+      probe.failedRequests.push(`HTTP ${response.status()} ${url}`)
+    }
+  })
+  return probe
+}
+
+async function dumpDiagnostics(page: Page, probe: Probe, label: string, attempt: number) {
+  const slug = `${label}-attempt-${attempt}`
+  try {
+    await mkdir(DIAGNOSTICS_DIR, { recursive: true })
+    await page.screenshot({ path: join(DIAGNOSTICS_DIR, `${slug}.png`), fullPage: true })
+    await writeFile(join(DIAGNOSTICS_DIR, `${slug}.html`), await page.content(), 'utf8')
+    const visibleText = await page
+      .evaluate(() => document.body.innerText.slice(0, 2000))
+      .catch(() => '(unavailable)')
+    const report = [
+      `url: ${page.url()}`,
+      `title: ${await page.title().catch(() => '(unavailable)')}`,
+      '',
+      '--- visible text ---',
+      visibleText,
+      '',
+      '--- critical API responses ---',
+      probe.criticalApi.join('\n') || '(none observed)',
+      '',
+      '--- failed requests ---',
+      probe.failedRequests.join('\n') || '(none)',
+      '',
+      '--- console errors ---',
+      probe.consoleErrors.join('\n') || '(none)',
+      '',
+    ].join('\n')
+    await writeFile(join(DIAGNOSTICS_DIR, `${slug}.txt`), report, 'utf8')
+    console.error(`--- diagnostics for ${slug} ---\n${report}`)
+  } catch (err) {
+    console.error(`${slug}: could not write diagnostics:`, err)
+  }
+}
+
+/**
+ * Turns the generic selector timeout into the actual reason when we can name
+ * it, so a future failure is readable straight from the job log.
+ */
+function explainFailure(probe: Probe, fallback: string): string {
+  // The SPA retries the request, so dedupe to keep the message readable.
+  const blocked = [
+    ...new Set(probe.failedRequests.filter((entry) => BOOT_BLOCKING_API.test(entry))),
+  ]
+  if (blocked.length > 0) {
+    return `${fallback}\nCause: the demo did not serve its startup config (${blocked.join('; ')}), so the app rendered an error instead of the UI. This is usually the demo's CDN rejecting the runner's egress IP.`
+  }
+  return fallback
+}
 
 async function openAppPage(page: Page, url: string, label: string) {
   console.log(`loading ${label}: ${url}`)
@@ -44,23 +158,33 @@ async function openAppPage(page: Page, url: string, label: string) {
   })
 }
 
-async function login(browser: Browser) {
-  const context = await browser.newContext()
+async function login(browser: Browser, userAgent: string, attempt: number) {
+  const context = await browser.newContext({ userAgent })
   try {
     const page = await context.newPage()
-    await openAppPage(page, `${baseURL}/login`, 'login')
-    await page.waitForSelector(SELECTORS.email, { timeout: 20_000 })
-    await page.fill(SELECTORS.email, EMAIL!)
-    await page.fill(SELECTORS.password, PASSWORD!)
-    await page.click(SELECTORS.submit)
-    await page.waitForURL(`${baseURL}/c/**`, { timeout: POST_LOGIN_TIMEOUT }).catch(() => undefined)
-    // Hard-fail if we are still on the login page (bad credentials, rate limit,
-    // etc.) so withRetry retries and ultimately exits non-zero instead of
-    // capturing screenshots of the login/error screen.
-    if (new URL(page.url()).pathname.startsWith('/login')) {
-      throw new Error(`Login failed: still on ${page.url()} after submitting credentials`)
+    const probe = attachProbe(page)
+    try {
+      await openAppPage(page, `${baseURL}/login`, 'login')
+      await page.waitForSelector(SELECTORS.email, { timeout: LOGIN_FORM_TIMEOUT })
+      await page.fill(SELECTORS.email, EMAIL!)
+      await page.fill(SELECTORS.password, PASSWORD!)
+      await page.click(SELECTORS.submit)
+      await page
+        .waitForURL(`${baseURL}/c/**`, { timeout: POST_LOGIN_TIMEOUT })
+        .catch(() => undefined)
+      // Hard-fail if we are still on the login page (bad credentials, rate limit,
+      // etc.) so withRetry retries and ultimately exits non-zero instead of
+      // capturing screenshots of the login/error screen.
+      if (new URL(page.url()).pathname.startsWith('/login')) {
+        throw new Error(`Login failed: still on ${page.url()} after submitting credentials`)
+      }
+      return await context.storageState()
+    } catch (err) {
+      await dumpDiagnostics(page, probe, 'login', attempt)
+      throw new Error(explainFailure(probe, err instanceof Error ? err.message : String(err)), {
+        cause: err,
+      })
     }
-    return await context.storageState()
   } finally {
     await context.close()
   }
@@ -70,9 +194,12 @@ async function captureVariant(
   browser: Browser,
   storageState: Awaited<ReturnType<BrowserContext['storageState']>>,
   variant: Variant,
+  userAgent: string,
+  attempt: number,
 ) {
   const context = await browser.newContext({
     storageState,
+    userAgent,
     viewport: variant.viewport,
     deviceScaleFactor: variant.deviceScaleFactor,
     isMobile: variant.device === 'mobile',
@@ -82,34 +209,51 @@ async function captureVariant(
   await context.addInitScript(themeBootstrap(variant.theme))
   try {
     const page = await context.newPage()
-    await openAppPage(page, `${baseURL}/c/${CONVERSATION_ID}`, variant.name)
-    await page.waitForSelector(SELECTORS.message, { timeout: 30_000 })
-    await page.addStyleTag({ content: DISABLE_MOTION_CSS })
-    await page.evaluate((zoom) => {
-      document.documentElement.style.setProperty('zoom', String(zoom))
-    }, ZOOM)
-    // Await web fonts without returning a non-serializable value to Playwright.
-    await page.evaluate(async () => {
-      await document.fonts.ready
-    })
-    await page.waitForTimeout(500)
-    const file = outputPath(variant)
-    await mkdir(dirname(file), { recursive: true })
-    await page.screenshot({ path: file, animations: 'disabled' })
-    console.log(`captured ${variant.name} -> ${variant.outputFile}`)
+    const probe = attachProbe(page)
+    try {
+      await openAppPage(page, `${baseURL}/c/${CONVERSATION_ID}`, variant.name)
+      await page.waitForSelector(SELECTORS.message, { timeout: MESSAGE_TIMEOUT })
+      await page.addStyleTag({ content: DISABLE_MOTION_CSS })
+      await page.evaluate((zoom) => {
+        document.documentElement.style.setProperty('zoom', String(zoom))
+      }, ZOOM)
+      // Await web fonts without returning a non-serializable value to Playwright.
+      await page.evaluate(async () => {
+        await document.fonts.ready
+      })
+      await page.waitForTimeout(500)
+      const file = outputPath(variant)
+      await mkdir(dirname(file), { recursive: true })
+      await page.screenshot({ path: file, animations: 'disabled' })
+      console.log(`captured ${variant.name} -> ${variant.outputFile}`)
+    } catch (err) {
+      await dumpDiagnostics(page, probe, variant.name, attempt)
+      throw new Error(explainFailure(probe, err instanceof Error ? err.message : String(err)), {
+        cause: err,
+      })
+    }
   } finally {
     await context.close()
   }
 }
 
-async function withRetry<T>(label: string, fn: () => Promise<T>, attempts = 2): Promise<T> {
+async function withRetry<T>(
+  label: string,
+  fn: (attempt: number) => Promise<T>,
+  attempts = 2,
+): Promise<T> {
   let lastErr: unknown
   for (let i = 1; i <= attempts; i++) {
     try {
-      return await fn()
+      return await fn(i)
     } catch (err) {
       lastErr = err
       console.warn(`${label}: attempt ${i}/${attempts} failed:`, err)
+      // Back off before retrying: an immediate retry runs straight back into a
+      // rate limit or bot challenge that a short pause would have cleared.
+      if (i < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, RETRY_BACKOFF_MS))
+      }
     }
   }
   throw lastErr
@@ -118,9 +262,13 @@ async function withRetry<T>(label: string, fn: () => Promise<T>, attempts = 2): 
 async function main() {
   const browser = await chromium.launch()
   try {
-    const storageState = await withRetry('login', () => login(browser))
+    const userAgent = await desktopUserAgent(browser)
+    console.log(`using user agent: ${userAgent}`)
+    const storageState = await withRetry('login', (attempt) => login(browser, userAgent, attempt))
     for (const variant of VARIANTS) {
-      await withRetry(variant.name, () => captureVariant(browser, storageState, variant))
+      await withRetry(variant.name, (attempt) =>
+        captureVariant(browser, storageState, variant, userAgent, attempt),
+      )
     }
   } finally {
     await browser.close()

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -23,9 +23,13 @@ const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
  * LibreChat reads `agent_id` from the query string (client/src/hooks/Input/
  * useQueryParams.ts), so this needs no clicking through the picker.
  */
-const AGENT_ID = process.env.DEMO_AGENT_ID?.trim() || 'agent_docs_hero_librechat'
+const AGENT_ID = process.env.DEMO_AGENT_ID?.trim() || ''
 
-/** The branding the shot must end up showing. */
+/**
+ * The agent is resolved by this name when DEMO_AGENT_ID is unset, so a rebuilt
+ * agent with a new id keeps working. Agent ids are opaque and easy to leave
+ * stale; the name is what anyone looking at the image would recognise.
+ */
 const AGENT_NAME = process.env.DEMO_AGENT_NAME?.trim() || 'LibreChat'
 
 // Do not add custom headers to the browser context. Playwright applies
@@ -68,6 +72,9 @@ const MIN_SIDEBAR_CHATS = 10
 /** The inventory is the same for every variant; one report per run is enough. */
 let inventoryLogged = false
 
+/** Resolved once from the first variant and reused, since it cannot change. */
+let resolvedAgentId: string | null = null
+
 /**
  * Presents as an ordinary desktop browser rather than advertising
  * `HeadlessChrome`. This is hygiene, not a fix: a CI run with this user agent
@@ -94,6 +101,7 @@ const READY_STATE_TIMEOUT = 15_000
 const LOGIN_FORM_TIMEOUT = 45_000
 const APP_READY_TIMEOUT = 45_000
 const TERMS_TIMEOUT = 8_000
+const AGENT_SELECT_TIMEOUT = 20_000
 const RETRY_BACKOFF_MS = 10_000
 
 /** Recorded in diagnostics to show what the app managed to fetch. */
@@ -364,6 +372,36 @@ async function logEndpointInventory(probe: Probe) {
   console.log('--- end inventory ---')
 }
 
+/** Reads the agent list out of whichever shape the API returned. */
+function agentList(body: unknown): Record<string, unknown>[] {
+  if (Array.isArray(body)) return body as Record<string, unknown>[]
+  const data = (body as { data?: unknown } | null)?.data
+  return Array.isArray(data) ? (data as Record<string, unknown>[]) : []
+}
+
+/**
+ * Finds the agent to brand the shot with, by name, from the list the app
+ * already fetched. DEMO_AGENT_ID short-circuits this when a specific one is
+ * wanted.
+ */
+async function resolveAgentId(probe: Probe): Promise<string> {
+  if (AGENT_ID) return AGENT_ID
+  if (resolvedAgentId) return resolvedAgentId
+
+  const agents = agentList(await probe.inventory.agents)
+  const match = agents.find((agent) => agent.name === AGENT_NAME)
+  if (!match?.id) {
+    const names = agents.map((agent) => JSON.stringify(agent.name)).join(', ') || '(none)'
+    throw new Error(
+      `No agent named ${JSON.stringify(AGENT_NAME)} on the demo. Available: ${names}. ` +
+        'Set DEMO_AGENT_ID or DEMO_AGENT_NAME to match one that exists.',
+    )
+  }
+  resolvedAgentId = String(match.id)
+  console.log(`resolved agent ${JSON.stringify(AGENT_NAME)} -> ${resolvedAgentId}`)
+  return resolvedAgentId
+}
+
 /**
  * Confirms the agent actually got selected.
  *
@@ -375,10 +413,17 @@ async function logEndpointInventory(probe: Probe) {
  * ship one.
  */
 async function assertAgentSelected(page: Page, variant: Variant) {
-  const placeholder = await page
-    .locator(SELECTORS.composer)
-    .getAttribute('placeholder', { timeout: APP_READY_TIMEOUT })
-    .catch(() => null)
+  const composer = page.locator(SELECTORS.composer)
+  const deadline = Date.now() + AGENT_SELECT_TIMEOUT
+  let placeholder: string | null = null
+  // Poll: the placeholder is rewritten a beat after the agent applies, so a
+  // single read can catch the pre-selection value and fail a healthy run.
+  do {
+    placeholder = await composer.getAttribute('placeholder').catch(() => null)
+    if (placeholder?.includes(AGENT_NAME)) break
+    await page.waitForTimeout(250)
+  } while (Date.now() < deadline)
+
   if (!placeholder?.includes(AGENT_NAME)) {
     throw new Error(
       `Composer reads ${JSON.stringify(placeholder)}, expected it to mention ${JSON.stringify(AGENT_NAME)}. ` +
@@ -430,10 +475,10 @@ async function captureVariant(
       // Shoot the new-chat screen rather than a conversation: it shows the
       // logo, the composer and the full sidebar, and it is the only frame that
       // fits a mobile viewport without cutting the interface in half.
-      const target = new URL(`${baseURL}/c/new`)
-      target.searchParams.set('endpoint', 'agents')
-      target.searchParams.set('agent_id', AGENT_ID)
-      await openAppPage(page, target.toString(), variant.name)
+      // Load once bare. The agent has to be named in the URL to be selected,
+      // but its id is only knowable from the list the app fetches after it
+      // boots, so the first load is what makes that list available.
+      await openAppPage(page, `${baseURL}/c/new`, variant.name)
       // A bounce back to /login means the session did not survive the
       // navigation; fail here rather than shooting the login screen.
       if (new URL(page.url()).pathname.startsWith('/login')) {
@@ -447,6 +492,12 @@ async function captureVariant(
         inventoryLogged = true
         await logEndpointInventory(probe)
       }
+
+      const target = new URL(`${baseURL}/c/new`)
+      target.searchParams.set('endpoint', 'agents')
+      target.searchParams.set('agent_id', await resolveAgentId(probe))
+      await openAppPage(page, target.toString(), `${variant.name} (agent)`)
+      await page.waitForSelector(SELECTORS.composer, { timeout: APP_READY_TIMEOUT })
       await assertAgentSelected(page, variant)
       await assertSidebarPopulated(page, variant)
       // Park the pointer and drop focus. Otherwise whatever was last clicked

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -98,6 +98,17 @@ interface Probe {
   failedRequests: string[]
   criticalApi: string[]
   blockedResponses: Promise<string>[]
+  /** Bodies of the app's own authenticated inventory calls, if it made them. */
+  inventory: {
+    endpoints: Promise<unknown> | null
+    models: Promise<unknown> | null
+  }
+}
+
+/** Matched on the app's own requests to harvest the endpoint inventory. */
+const INVENTORY_API = {
+  endpoints: /\/api\/endpoints(\?|$)/,
+  models: /\/api\/models(\?|$)/,
 }
 
 /**
@@ -139,7 +150,17 @@ function attachProbe(page: Page): Probe {
     failedRequests: [],
     criticalApi: [],
     blockedResponses: [],
+    inventory: { endpoints: null, models: null },
   }
+  page.on('response', (response) => {
+    if (!response.ok()) return
+    const url = response.url()
+    if (INVENTORY_API.endpoints.test(url)) {
+      probe.inventory.endpoints ??= response.json().catch(() => null)
+    } else if (INVENTORY_API.models.test(url)) {
+      probe.inventory.models ??= response.json().catch(() => null)
+    }
+  })
   page.on('console', (msg) => {
     if (msg.type() === 'error') probe.consoleErrors.push(msg.text().slice(0, 300))
   })
@@ -203,9 +224,16 @@ async function dumpDiagnostics(page: Page, probe: Probe, label: string, attempt:
  * it, so a future failure is readable straight from the job log.
  */
 function explainFailure(probe: Probe, fallback: string): string {
-  // The SPA retries the request, so dedupe to keep the message readable.
+  // Only real HTTP rejections count. The SPA cancels in-flight requests when it
+  // navigates, which surfaces as `net::ERR_ABORTED /api/config` on a perfectly
+  // healthy run and otherwise blames the CDN for unrelated failures.
+  // Dedupe too, since the SPA retries.
   const blocked = [
-    ...new Set(probe.failedRequests.filter((entry) => BOOT_BLOCKING_API.test(entry))),
+    ...new Set(
+      probe.failedRequests.filter(
+        (entry) => entry.startsWith('HTTP ') && BOOT_BLOCKING_API.test(entry),
+      ),
+    ),
   ]
   if (blocked.length > 0) {
     return `${fallback}\nCause: the demo did not serve its startup config (${blocked.join('; ')}), so the app rendered an error instead of the UI. See the "who rejected the boot-blocking request" section of the diagnostics for whether the edge or the origin answered.`
@@ -271,21 +299,21 @@ async function signIn(page: Page) {
  * them. Printed once per run, and never fatal, since it is only reference
  * output.
  */
-async function logEndpointInventory(page: Page) {
-  const inventory = await page
-    .evaluate(async () => {
-      const get = async (path: string) => {
-        const res = await fetch(path, { credentials: 'include' })
-        return res.ok ? await res.json() : { __error: res.status }
-      }
-      return { endpoints: await get('/api/endpoints'), models: await get('/api/models') }
-    })
-    .catch((err) => ({ endpoints: { __error: String(err) }, models: {} }))
-
-  const endpoints = (inventory.endpoints ?? {}) as Record<string, Record<string, unknown>>
-  const models = (inventory.models ?? {}) as Record<string, string[]>
-  if (endpoints.__error) {
-    console.warn(`endpoint inventory unavailable: ${JSON.stringify(endpoints.__error)}`)
+async function logEndpointInventory(probe: Probe) {
+  // Read the app's own responses rather than issuing our own requests. These
+  // routes need the Bearer token that LibreChat's client holds in memory, so
+  // neither page.request (cookies only) nor a raw fetch in the page would be
+  // authenticated. Reusing what the app already fetched sidesteps that, and
+  // avoids page.evaluate entirely: tsx compiles this file with esbuild's
+  // keepNames, which injects a `__name` helper that does not exist in the
+  // browser realm, so evaluated closures throw on arrival.
+  const endpoints = (await probe.inventory.endpoints) as Record<
+    string,
+    Record<string, unknown>
+  > | null
+  const models = ((await probe.inventory.models) ?? {}) as Record<string, string[]>
+  if (!endpoints) {
+    console.warn('endpoint inventory unavailable: the app did not fetch /api/endpoints')
     return
   }
 
@@ -356,7 +384,7 @@ async function captureVariant(
       await acceptTermsIfPresent(page, variant.name)
       if (!inventoryLogged) {
         inventoryLogged = true
-        await logEndpointInventory(page)
+        await logEndpointInventory(probe)
       }
       await assertSidebarPopulated(page, variant)
       // Park the pointer and drop focus. Otherwise whatever was last clicked

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -14,6 +14,20 @@ const EMAIL = process.env.DEMO_EMAIL
 const PASSWORD = process.env.DEMO_PASSWORD
 const baseURL = screenshotBaseURL(process.env.DEMO_BASE_URL)
 
+/**
+ * The agent to open the new-chat screen with. Selecting it is what puts the
+ * LibreChat logo and wordmark in the middle of the shot and "Message LibreChat"
+ * in the composer; without it the screen is branded with whatever model the
+ * demo defaults to, which is not what belongs on the landing page.
+ *
+ * LibreChat reads `agent_id` from the query string (client/src/hooks/Input/
+ * useQueryParams.ts), so this needs no clicking through the picker.
+ */
+const AGENT_ID = process.env.DEMO_AGENT_ID?.trim() || 'agent_docs_hero_librechat'
+
+/** The branding the shot must end up showing. */
+const AGENT_NAME = process.env.DEMO_AGENT_NAME?.trim() || 'LibreChat'
+
 // Do not add custom headers to the browser context. Playwright applies
 // extraHTTPHeaders to every request including cross-origin ones, which turns
 // them into preflighted CORS requests; third parties reject the unknown header
@@ -102,6 +116,7 @@ interface Probe {
   inventory: {
     endpoints: Promise<unknown> | null
     models: Promise<unknown> | null
+    agents: Promise<unknown> | null
   }
 }
 
@@ -109,6 +124,7 @@ interface Probe {
 const INVENTORY_API = {
   endpoints: /\/api\/endpoints(\?|$)/,
   models: /\/api\/models(\?|$)/,
+  agents: /\/api\/agents(\?|$)/,
 }
 
 /**
@@ -150,7 +166,7 @@ function attachProbe(page: Page): Probe {
     failedRequests: [],
     criticalApi: [],
     blockedResponses: [],
-    inventory: { endpoints: null, models: null },
+    inventory: { endpoints: null, models: null, agents: null },
   }
   page.on('response', (response) => {
     if (!response.ok()) return
@@ -159,6 +175,8 @@ function attachProbe(page: Page): Probe {
       probe.inventory.endpoints ??= response.json().catch(() => null)
     } else if (INVENTORY_API.models.test(url)) {
       probe.inventory.models ??= response.json().catch(() => null)
+    } else if (INVENTORY_API.agents.test(url)) {
+      probe.inventory.agents ??= response.json().catch(() => null)
     }
   })
   page.on('console', (msg) => {
@@ -328,7 +346,47 @@ async function logEndpointInventory(probe: Probe) {
       `  ${name}${type}${icon} models=${available.length}${sample ? ` [${sample}${available.length > 4 ? ', …' : ''}]` : ''}`,
     )
   }
+
+  // Agents are what the hero shot is branded with, so their ids matter as much
+  // as the endpoint names; DEMO_AGENT_ID has to name one that exists.
+  const agentsBody = (await probe.inventory.agents) as { data?: unknown[] } | unknown[] | null
+  const agents = Array.isArray(agentsBody) ? agentsBody : (agentsBody?.data ?? [])
+  console.log(`  agents available: ${agents.length}`)
+  for (const entry of agents as Record<string, unknown>[]) {
+    const avatar = entry.avatar as { filepath?: string } | string | null | undefined
+    const avatarPath = typeof avatar === 'string' ? avatar : avatar?.filepath
+    console.log(
+      `    ${String(entry.id)} name=${JSON.stringify(entry.name)}` +
+        ` tools=${Array.isArray(entry.tools) ? entry.tools.length : 0}` +
+        `${avatarPath ? ` avatar=${avatarPath}` : ' avatar=none'}`,
+    )
+  }
   console.log('--- end inventory ---')
+}
+
+/**
+ * Confirms the agent actually got selected.
+ *
+ * The composer placeholder tracks the active endpoint, so it reads "Message
+ * LibreChat" once the agent is applied and "Message GPT-5.5" (or whatever the
+ * demo defaults to) when it is not. Selection happens via a query parameter
+ * the app may silently ignore if the id no longer exists, and a shot branded
+ * with a third-party model is worse than no shot at all, so fail rather than
+ * ship one.
+ */
+async function assertAgentSelected(page: Page, variant: Variant) {
+  const placeholder = await page
+    .locator(SELECTORS.composer)
+    .getAttribute('placeholder', { timeout: APP_READY_TIMEOUT })
+    .catch(() => null)
+  if (!placeholder?.includes(AGENT_NAME)) {
+    throw new Error(
+      `Composer reads ${JSON.stringify(placeholder)}, expected it to mention ${JSON.stringify(AGENT_NAME)}. ` +
+        `The "${AGENT_ID}" agent was not selected, so the shot would carry the wrong branding. ` +
+        'Check DEMO_AGENT_ID against the agents the demo actually has.',
+    )
+  }
+  console.log(`${variant.name}: agent "${AGENT_NAME}" selected`)
 }
 
 /**
@@ -372,7 +430,10 @@ async function captureVariant(
       // Shoot the new-chat screen rather than a conversation: it shows the
       // logo, the composer and the full sidebar, and it is the only frame that
       // fits a mobile viewport without cutting the interface in half.
-      await openAppPage(page, `${baseURL}/c/new`, variant.name)
+      const target = new URL(`${baseURL}/c/new`)
+      target.searchParams.set('endpoint', 'agents')
+      target.searchParams.set('agent_id', AGENT_ID)
+      await openAppPage(page, target.toString(), variant.name)
       // A bounce back to /login means the session did not survive the
       // navigation; fail here rather than shooting the login screen.
       if (new URL(page.url()).pathname.startsWith('/login')) {
@@ -386,6 +447,7 @@ async function captureVariant(
         inventoryLogged = true
         await logEndpointInventory(probe)
       }
+      await assertAgentSelected(page, variant)
       await assertSidebarPopulated(page, variant)
       // Park the pointer and drop focus. Otherwise whatever was last clicked
       // keeps its focus ring and whatever the pointer rests over keeps its

--- a/scripts/screenshots/capture.ts
+++ b/scripts/screenshots/capture.ts
@@ -51,6 +51,9 @@ const SELECTORS = {
  */
 const MIN_SIDEBAR_CHATS = 10
 
+/** The inventory is the same for every variant; one report per run is enough. */
+let inventoryLogged = false
+
 /**
  * Presents as an ordinary desktop browser rather than advertising
  * `HeadlessChrome`. This is hygiene, not a fix: a CI run with this user agent
@@ -260,6 +263,47 @@ async function signIn(page: Page) {
 }
 
 /**
+ * Reports every endpoint and model the demo actually serves.
+ *
+ * seed-demo.js has to name endpoints that exist, because one the server does
+ * not know renders a generic icon: invisible in review, obvious in the hero
+ * image. These routes need a session, so this is the only place that can see
+ * them. Printed once per run, and never fatal, since it is only reference
+ * output.
+ */
+async function logEndpointInventory(page: Page) {
+  const inventory = await page
+    .evaluate(async () => {
+      const get = async (path: string) => {
+        const res = await fetch(path, { credentials: 'include' })
+        return res.ok ? await res.json() : { __error: res.status }
+      }
+      return { endpoints: await get('/api/endpoints'), models: await get('/api/models') }
+    })
+    .catch((err) => ({ endpoints: { __error: String(err) }, models: {} }))
+
+  const endpoints = (inventory.endpoints ?? {}) as Record<string, Record<string, unknown>>
+  const models = (inventory.models ?? {}) as Record<string, string[]>
+  if (endpoints.__error) {
+    console.warn(`endpoint inventory unavailable: ${JSON.stringify(endpoints.__error)}`)
+    return
+  }
+
+  console.log('--- demo endpoint inventory (keep seed-demo.js CHATS in sync) ---')
+  for (const name of Object.keys(endpoints).sort()) {
+    const config = endpoints[name] ?? {}
+    const type = config.type ? ` type=${String(config.type)}` : ''
+    const icon = config.iconURL ? ' iconURL=yes' : ''
+    const available = Array.isArray(models[name]) ? models[name] : []
+    const sample = available.slice(0, 4).join(', ')
+    console.log(
+      `  ${name}${type}${icon} models=${available.length}${sample ? ` [${sample}${available.length > 4 ? ', …' : ''}]` : ''}`,
+    )
+  }
+  console.log('--- end inventory ---')
+}
+
+/**
  * Guards the point of the image. Desktop only: the sidebar is collapsed behind
  * a hamburger on mobile, which is what the original mobile shots showed too.
  */
@@ -310,6 +354,10 @@ async function captureVariant(
       // then the app is up and the dialog is either present or never coming.
       await page.waitForSelector(SELECTORS.composer, { timeout: APP_READY_TIMEOUT })
       await acceptTermsIfPresent(page, variant.name)
+      if (!inventoryLogged) {
+        inventoryLogged = true
+        await logEndpointInventory(page)
+      }
       await assertSidebarPopulated(page, variant)
       // Park the pointer and drop focus. Otherwise whatever was last clicked
       // keeps its focus ring and whatever the pointer rests over keeps its

--- a/scripts/screenshots/config.test.ts
+++ b/scripts/screenshots/config.test.ts
@@ -46,6 +46,14 @@ describe('screenshot config', () => {
     expect(themeBootstrap('dark')).toContain(THEME_STORAGE_KEY)
   })
 
+  // Pinned to the literal, not to the constant: asserting against the constant
+  // passes for any value, which is how this silently drifted to a key LibreChat
+  // never reads (leaving both variants on the app's 'system' default).
+  it('writes the theme to the key LibreChat actually reads', () => {
+    expect(THEME_STORAGE_KEY).toBe('color-theme')
+    expect(themeBootstrap('dark')).toContain('"color-theme"')
+  })
+
   it('keeps every output path inside the image directory', () => {
     for (const v of VARIANTS) {
       expect(outputPath(v).startsWith(IMG_DIR)).toBe(true)

--- a/scripts/screenshots/config.ts
+++ b/scripts/screenshots/config.ts
@@ -1,7 +1,6 @@
 import { resolve } from 'node:path'
 
 export const BASE_URL = 'https://chat.librechat.ai'
-export const ZOOM = 1.1
 // LibreChat persists the theme under this key (client/index.html reads it in an
 // inline script before the bundle boots, and packages/client ThemeProvider uses
 // the same key). Writing any other key leaves the app on its 'system' default.

--- a/scripts/screenshots/config.ts
+++ b/scripts/screenshots/config.ts
@@ -2,7 +2,10 @@ import { resolve } from 'node:path'
 
 export const BASE_URL = 'https://chat.librechat.ai'
 export const ZOOM = 1.1
-export const THEME_STORAGE_KEY = 'theme'
+// LibreChat persists the theme under this key (client/index.html reads it in an
+// inline script before the bundle boots, and packages/client ThemeProvider uses
+// the same key). Writing any other key leaves the app on its 'system' default.
+export const THEME_STORAGE_KEY = 'color-theme'
 export const IMG_DIR = resolve(process.cwd(), 'components/home/img')
 
 export type Theme = 'light' | 'dark'
@@ -67,9 +70,11 @@ export function screenshotBaseURL(value: string | undefined): string {
 
 /**
  * Returns a JS snippet (string) to run as a Playwright init script, forcing the
- * LibreChat theme before app code reads it. THEME_STORAGE_KEY is the best-known
- * default; verify it against the live demo in Task 2 and adjust if needed.
+ * LibreChat theme before app code reads it.
  */
 export function themeBootstrap(theme: Theme): string {
   return `try{localStorage.setItem(${JSON.stringify(THEME_STORAGE_KEY)}, ${JSON.stringify(theme)})}catch(e){}`
 }
+
+/** Where failure diagnostics are written so CI can upload them as an artifact. */
+export const DIAGNOSTICS_DIR = resolve(process.cwd(), 'screenshot-diagnostics')

--- a/scripts/screenshots/seed-demo.js
+++ b/scripts/screenshots/seed-demo.js
@@ -19,7 +19,7 @@
  * messages collection rather than generated.
  */
 
-/* global db, DEMO_EMAIL, DEMO_BASE_URL, DRY_RUN, CLEAN, print, quit */
+/* global db, DEMO_EMAIL, DEMO_BASE_URL, DEMO_AGENT_ID, DRY_RUN, CLEAN, print, quit */
 
 /**
  * LibreChat stores conversationId and messageId as canonical UUID strings.
@@ -34,12 +34,22 @@ function uuid() {
 const SEED_TAG = 'docs-hero-seed'
 /**
  * The demo hosts its own "LibreChat" agent and that is the one the hero shot is
- * branded with. This script deliberately does not create an agent: an earlier
- * version did, and /api/agents never returned it, so it was invisible in the
- * app while still being a second agent by that name in the database. The
- * pinned conversation below points at this id only to carry an icon.
+ * branded with. This script deliberately does not create one: an earlier
+ * version did, /api/agents never returned it, and it sat in the database as a
+ * second agent by that name until it was deleted by hand.
+ *
+ * The pinned conversation below references this id, so it must name an agent
+ * that exists or opening that conversation resolves to nothing. Override with
+ * DEMO_AGENT_ID if the demo's agent is ever rebuilt; the capture script prints
+ * the current id each run under "resolved agent".
  */
-const AGENT_ID = 'agent_docs_hero_librechat'
+const AGENT_ID =
+  typeof DEMO_AGENT_ID === 'undefined' || !DEMO_AGENT_ID
+    ? 'agent_-Wbi4T2131zvNwm7cTU6Y'
+    : String(DEMO_AGENT_ID)
+
+/** Left behind by the version of this script that created its own agent. */
+const RETIRED_AGENT_ID = 'agent_docs_hero_librechat'
 // Served by the demo itself; www.librechat.ai/assets/logo.svg is a 404.
 // Override with DEMO_ORIGIN if the demo is hosted elsewhere.
 const DEMO_ORIGIN =
@@ -180,7 +190,9 @@ function removeSeeded() {
   // Outside the guard above: the agent outlives its conversations, so CLEAN
   // has to remove it even when there is nothing tagged left. Scoped by author
   // as well as id, because this runs against the live public instance.
-  const agents = db.agents.deleteMany({ id: AGENT_ID, author: user._id })
+  // Only ever the retired one. AGENT_ID now names the demo's own agent, which
+  // this script does not own and must never delete.
+  const agents = db.agents.deleteMany({ id: RETIRED_AGENT_ID, author: user._id })
   if (agents.deletedCount > 0) {
     print(`removed ${agents.deletedCount} agent`)
   }

--- a/scripts/screenshots/seed-demo.js
+++ b/scripts/screenshots/seed-demo.js
@@ -42,41 +42,68 @@ const DEMO_ORIGIN =
 const LIBRECHAT_AVATAR = `${DEMO_ORIGIN}/assets/logo.svg`
 
 /**
- * `endpoint` picks the sidebar icon. These names must match endpoints the demo
- * actually has configured in librechat.yaml, otherwise LibreChat falls back to
- * a generic icon and the row looks broken. Check the demo's config and prune
- * this list before running; the script reports which endpoints it used so a
- * wrong one is obvious in the screenshot afterwards.
+ * One conversation per endpoint the demo serves, so the sidebar renders a
+ * column of distinct provider icons. That variety is the whole point of the
+ * hero image.
  *
- * `model` is shown when a conversation is opened, and drives the icon for
- * endpoints that vary by model (openAI's gpt-4o vs o1, for example).
+ * `endpoint` must match a key the server actually returns from /api/endpoints,
+ * otherwise LibreChat falls back to a generic icon and the row looks broken.
+ * This list was taken from a live inventory; the capture script prints the
+ * current one on every run under "demo endpoint inventory", so refresh from
+ * there rather than guessing when the demo's config changes.
+ *
+ * `model` is only shown once a conversation is opened, but keep it real: these
+ * were taken from /api/models alongside the endpoints.
  */
 const CHATS = [
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Refactor this React hook' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'Explaining quantum mechanics' },
-  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Summarize this paper' },
-  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Plan a trip to Tokyo' },
-  { endpoint: 'openAI', model: 'gpt-4o-mini', title: 'Best apps for learning guitar' },
-  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Understanding climate data' },
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Debug a failing CI pipeline' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'Ideas for a weekend getaway' },
-  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Compare vector databases' },
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Write a SQL migration' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'How to fix a flat tire' },
-  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Beginner guide to gardening' },
-  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Design a REST API' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'Improving productivity at work' },
-  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Troubleshooting Wi-Fi' },
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Explain Kubernetes operators' },
-  { endpoint: 'openAI', model: 'gpt-4o-mini', title: 'Creative gift ideas' },
-  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'How to start running' },
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Review my Dockerfile' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'Best tools for video editing' },
-  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Understanding cryptocurrency' },
-  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Optimize a slow query' },
-  { endpoint: 'openAI', model: 'gpt-4o', title: 'Home automation ideas' },
-  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Learning a new language' },
-  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Architecture review' },
+  { endpoint: 'anthropic', model: 'claude-opus-4-7', title: 'Refactor this React hook' },
+  { endpoint: 'openAI', model: 'gpt-5.5', title: 'Explaining quantum mechanics' },
+  { endpoint: 'google', model: 'gemini-3.1-pro-preview', title: 'Summarize this paper' },
+  { endpoint: 'xai', model: 'grok-4.3', title: 'Ideas for a weekend getaway' },
+  { endpoint: 'deepseek', model: 'deepseek-v4-pro', title: 'Optimize a slow query' },
+  { endpoint: 'Mistral', model: 'codestral-2501', title: 'Write a SQL migration' },
+  { endpoint: 'Perplexity', model: 'sonar-pro', title: 'Research the EU AI Act' },
+  { endpoint: 'groq', model: 'groq/compound', title: 'How to start running' },
+  { endpoint: 'cohere', model: 'command-a-plus-05-2026', title: 'Draft a launch announcement' },
+  { endpoint: 'OpenRouter', model: 'openrouter/auto', title: 'Compare vector databases' },
+  { endpoint: 'together.ai', model: 'Qwen/QwQ-32B', title: 'Explain Kubernetes operators' },
+  {
+    endpoint: 'Fireworks',
+    model: 'accounts/fireworks/models/deepseek-v4-pro',
+    title: 'Review my Dockerfile',
+  },
+  { endpoint: 'Nvidia', model: '01-ai/yi-large', title: 'Best tools for video editing' },
+  {
+    endpoint: 'HuggingFace',
+    model: 'MiniMaxAI/MiniMax-M2',
+    title: 'Fine-tuning on a small dataset',
+  },
+  { endpoint: 'SambaNova', model: 'DeepSeek-R1', title: 'Understanding cryptocurrency' },
+  {
+    endpoint: 'Github Models',
+    model: 'Meta-Llama-3.1-405B-Instruct',
+    title: 'Debug a failing CI pipeline',
+  },
+  { endpoint: 'Hyperbolic', model: 'Qwen/QwQ-32B', title: 'Plan a trip to Tokyo' },
+  {
+    endpoint: 'Kluster',
+    model: 'deepseek-ai/DeepSeek-R1-0528',
+    title: 'Beginner guide to gardening',
+  },
+  { endpoint: 'NanoGPT', model: 'Baichuan4-Turbo', title: 'Creative gift ideas' },
+  {
+    endpoint: 'glhf.chat',
+    model: 'hf:Qwen/Qwen2.5-72B-Instruct',
+    title: 'Learning a new language',
+  },
+  { endpoint: 'Unify', model: 'chatgpt-4o-latest@openai', title: 'Troubleshooting Wi-Fi' },
+  { endpoint: 'APIpie', model: 'aion-1-0', title: 'Home automation ideas' },
+  { endpoint: '302AI', model: '4.0Ultra', title: 'Improving productivity at work' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-6', title: 'Design a REST API' },
+  { endpoint: 'openAI', model: 'gpt-5.4', title: 'How to fix a flat tire' },
+  { endpoint: 'google', model: 'gemini-3.6-flash', title: 'Understanding climate data' },
+  { endpoint: 'anthropic', model: 'claude-opus-4-6', title: 'Architecture review' },
+  { endpoint: 'openAI', model: 'gpt-5.5-pro', title: 'Best apps for learning guitar' },
 ]
 
 /** The pinned conversation, shot as the hero when a conversation is captured. */

--- a/scripts/screenshots/seed-demo.js
+++ b/scripts/screenshots/seed-demo.js
@@ -142,20 +142,40 @@ print(`user: ${DEMO_EMAIL} -> ${userId}`)
 print(`database: ${db.getName()}`)
 
 function removeSeeded() {
-  const convos = db.conversations.find({ user: userId, tags: SEED_TAG }, { conversationId: 1 })
-  const ids = convos.map((c) => c.conversationId)
+  // toArray() is required. In mongosh a cursor's .map() returns another lazy
+  // cursor, where the legacy mongo shell returned an array. Without it
+  // `ids.length` is undefined, so the empty-batch guard never fires and the
+  // $in below is handed a cursor, which throws "Cannot convert circular
+  // structure to BSON" before any command reaches the server.
+  const ids = db.conversations
+    .find({ user: userId, tags: SEED_TAG }, { conversationId: 1 })
+    .toArray()
+    .map((c) => c.conversationId)
+
+  if (dryRun) {
+    print(
+      ids.length === 0
+        ? 'nothing previously seeded'
+        : `would remove ${ids.length} seeded conversations and their messages`,
+    )
+    return
+  }
+
   if (ids.length === 0) {
     print('nothing previously seeded')
-    return
+  } else {
+    const messages = db.messages.deleteMany({ user: userId, conversationId: { $in: ids } })
+    const removed = db.conversations.deleteMany({ user: userId, tags: SEED_TAG })
+    print(`removed ${removed.deletedCount} conversations, ${messages.deletedCount} messages`)
   }
-  if (dryRun) {
-    print(`would remove ${ids.length} seeded conversations and their messages`)
-    return
+
+  // Outside the guard above: the agent outlives its conversations, so CLEAN
+  // has to remove it even when there is nothing tagged left. Scoped by author
+  // as well as id, because this runs against the live public instance.
+  const agents = db.agents.deleteMany({ id: AGENT_ID, author: user._id })
+  if (agents.deletedCount > 0) {
+    print(`removed ${agents.deletedCount} agent`)
   }
-  const messages = db.messages.deleteMany({ user: userId, conversationId: { $in: ids } })
-  const removed = db.conversations.deleteMany({ user: userId, tags: SEED_TAG })
-  db.agents.deleteMany({ id: AGENT_ID })
-  print(`removed ${removed.deletedCount} conversations, ${messages.deletedCount} messages, agent`)
 }
 
 if (clean) {

--- a/scripts/screenshots/seed-demo.js
+++ b/scripts/screenshots/seed-demo.js
@@ -1,7 +1,7 @@
 /**
  * Seeds the demo account with the sidebar content the landing-page hero shots
  * need: a spread of conversations across providers so the sidebar shows a
- * column of different provider icons, plus a LibreChat agent.
+ * column of different provider icons.
  *
  * Runs under mongosh so this repo needs no database dependency:
  *
@@ -32,6 +32,13 @@ function uuid() {
 }
 
 const SEED_TAG = 'docs-hero-seed'
+/**
+ * The demo hosts its own "LibreChat" agent and that is the one the hero shot is
+ * branded with. This script deliberately does not create an agent: an earlier
+ * version did, and /api/agents never returned it, so it was invisible in the
+ * app while still being a second agent by that name in the database. The
+ * pinned conversation below points at this id only to carry an icon.
+ */
 const AGENT_ID = 'agent_docs_hero_librechat'
 // Served by the demo itself; www.librechat.ai/assets/logo.svg is a 404.
 // Override with DEMO_ORIGIN if the demo is hosted elsewhere.
@@ -109,6 +116,7 @@ const CHATS = [
 /** The pinned conversation, shot as the hero when a conversation is captured. */
 const PINNED = {
   title: 'Getting started with LibreChat',
+  model: 'claude-opus-4-7',
   turns: [
     {
       user: 'What can I do with LibreChat?',
@@ -191,31 +199,6 @@ removeSeeded()
 // Agent
 // ---------------------------------------------------------------------------
 
-const agent = {
-  id: AGENT_ID,
-  name: 'LibreChat',
-  description: 'The default LibreChat agent',
-  instructions: 'You are a helpful assistant for the LibreChat demo.',
-  avatar: { filepath: LIBRECHAT_AVATAR, source: 'url' },
-  provider: 'anthropic',
-  model: 'claude-sonnet-4-5',
-  model_parameters: {},
-  tools: [],
-  author: user._id,
-  authorName: user.name || 'LibreChat',
-  category: 'general',
-  conversation_starters: [],
-  versions: [],
-  projectIds: [],
-}
-
-if (dryRun) {
-  print(`would upsert agent ${AGENT_ID} ("LibreChat")`)
-} else {
-  db.agents.updateOne({ id: AGENT_ID }, { $set: agent }, { upsert: true })
-  print(`agent: ${AGENT_ID} ("LibreChat")`)
-}
-
 // ---------------------------------------------------------------------------
 // Conversations
 // ---------------------------------------------------------------------------
@@ -294,7 +277,7 @@ const messages = []
 
 // The pinned hero conversation, on the LibreChat agent.
 const pinnedConvo = buildConversation(
-  { title: PINNED.title, endpoint: 'agents', model: agent.model },
+  { title: PINNED.title, endpoint: 'agents', model: PINNED.model },
   -1,
   { pinned: true, agent_id: AGENT_ID, iconURL: LIBRECHAT_AVATAR },
 )
@@ -302,7 +285,7 @@ pinnedConvo.createdAt = now
 pinnedConvo.updatedAt = now
 conversations.push(pinnedConvo)
 messages.push(
-  ...buildMessages(pinnedConvo.conversationId, PINNED.turns, 'agents', agent.model, now),
+  ...buildMessages(pinnedConvo.conversationId, PINNED.turns, 'agents', PINNED.model, now),
 )
 
 for (const [index, spec] of CHATS.entries()) {

--- a/scripts/screenshots/seed-demo.js
+++ b/scripts/screenshots/seed-demo.js
@@ -1,0 +1,295 @@
+/**
+ * Seeds the demo account with the sidebar content the landing-page hero shots
+ * need: a spread of conversations across providers so the sidebar shows a
+ * column of different provider icons, plus a LibreChat agent.
+ *
+ * Runs under mongosh so this repo needs no database dependency:
+ *
+ *   mongosh "$MONGO_URI" --eval 'DEMO_EMAIL="demo@example.com"' scripts/screenshots/seed-demo.js
+ *
+ * Flags, set the same way as DEMO_EMAIL:
+ *   DRY_RUN=true   report what would change and write nothing
+ *   CLEAN=true     remove everything a previous run seeded, then exit
+ *
+ * Idempotent: every document it creates is tagged with SEED_TAG, and a normal
+ * run clears the previous batch first. It never touches conversations you
+ * created by hand.
+ *
+ * No inference is billed. Assistant replies are written straight to the
+ * messages collection rather than generated.
+ */
+
+/* global db, DEMO_EMAIL, DEMO_BASE_URL, DRY_RUN, CLEAN, print, quit */
+
+/**
+ * LibreChat stores conversationId and messageId as canonical UUID strings.
+ * mongosh's own UUID() is a BSON binary with no hex accessor, so use the
+ * WebCrypto generator, which mongosh exposes and which already returns the
+ * dashed form.
+ */
+function uuid() {
+  return crypto.randomUUID()
+}
+
+const SEED_TAG = 'docs-hero-seed'
+const AGENT_ID = 'agent_docs_hero_librechat'
+// Served by the demo itself; www.librechat.ai/assets/logo.svg is a 404.
+// Override with DEMO_ORIGIN if the demo is hosted elsewhere.
+const DEMO_ORIGIN =
+  typeof DEMO_BASE_URL === 'undefined' || !DEMO_BASE_URL
+    ? 'https://chat.librechat.ai'
+    : String(DEMO_BASE_URL).replace(/\/+$/, '')
+const LIBRECHAT_AVATAR = `${DEMO_ORIGIN}/assets/logo.svg`
+
+/**
+ * `endpoint` picks the sidebar icon. These names must match endpoints the demo
+ * actually has configured in librechat.yaml, otherwise LibreChat falls back to
+ * a generic icon and the row looks broken. Check the demo's config and prune
+ * this list before running; the script reports which endpoints it used so a
+ * wrong one is obvious in the screenshot afterwards.
+ *
+ * `model` is shown when a conversation is opened, and drives the icon for
+ * endpoints that vary by model (openAI's gpt-4o vs o1, for example).
+ */
+const CHATS = [
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Refactor this React hook' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'Explaining quantum mechanics' },
+  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Summarize this paper' },
+  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Plan a trip to Tokyo' },
+  { endpoint: 'openAI', model: 'gpt-4o-mini', title: 'Best apps for learning guitar' },
+  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Understanding climate data' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Debug a failing CI pipeline' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'Ideas for a weekend getaway' },
+  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Compare vector databases' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Write a SQL migration' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'How to fix a flat tire' },
+  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Beginner guide to gardening' },
+  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Design a REST API' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'Improving productivity at work' },
+  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Troubleshooting Wi-Fi' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Explain Kubernetes operators' },
+  { endpoint: 'openAI', model: 'gpt-4o-mini', title: 'Creative gift ideas' },
+  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'How to start running' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Review my Dockerfile' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'Best tools for video editing' },
+  { endpoint: 'google', model: 'gemini-2.5-pro', title: 'Understanding cryptocurrency' },
+  { endpoint: 'anthropic', model: 'claude-sonnet-4-5', title: 'Optimize a slow query' },
+  { endpoint: 'openAI', model: 'gpt-4o', title: 'Home automation ideas' },
+  { endpoint: 'google', model: 'gemini-2.5-flash', title: 'Learning a new language' },
+  { endpoint: 'anthropic', model: 'claude-opus-4-1', title: 'Architecture review' },
+]
+
+/** The pinned conversation, shot as the hero when a conversation is captured. */
+const PINNED = {
+  title: 'Getting started with LibreChat',
+  turns: [
+    {
+      user: 'What can I do with LibreChat?',
+      assistant:
+        'Quite a lot. LibreChat is an open-source chat app that puts every major AI provider behind one interface: OpenAI, Anthropic, Google, Azure, AWS Bedrock, and any OpenAI-compatible endpoint. You can switch models mid-conversation, build custom agents with tools, search the web, generate images, and run everything self-hosted with full control over your data.',
+    },
+    {
+      user: 'Can I use my own API keys and self-host it?',
+      assistant:
+        'Yes. You bring your own keys per provider, and LibreChat runs anywhere Docker does, so your conversations and keys stay on your own infrastructure. There is no per-seat lock-in, and the whole stack is MIT-licensed.',
+    },
+  ],
+}
+
+const dryRun = typeof DRY_RUN !== 'undefined' && String(DRY_RUN) === 'true'
+const clean = typeof CLEAN !== 'undefined' && String(CLEAN) === 'true'
+
+if (typeof DEMO_EMAIL === 'undefined' || !DEMO_EMAIL) {
+  print('ERROR: pass the demo account with --eval \'DEMO_EMAIL="..."\'')
+  quit(1)
+}
+
+const user = db.users.findOne({ email: DEMO_EMAIL })
+if (!user) {
+  print(`ERROR: no user with email ${DEMO_EMAIL} in database "${db.getName()}"`)
+  print('Check that the connection string includes the LibreChat database name.')
+  quit(1)
+}
+const userId = String(user._id)
+print(`user: ${DEMO_EMAIL} -> ${userId}`)
+print(`database: ${db.getName()}`)
+
+function removeSeeded() {
+  const convos = db.conversations.find({ user: userId, tags: SEED_TAG }, { conversationId: 1 })
+  const ids = convos.map((c) => c.conversationId)
+  if (ids.length === 0) {
+    print('nothing previously seeded')
+    return
+  }
+  if (dryRun) {
+    print(`would remove ${ids.length} seeded conversations and their messages`)
+    return
+  }
+  const messages = db.messages.deleteMany({ user: userId, conversationId: { $in: ids } })
+  const removed = db.conversations.deleteMany({ user: userId, tags: SEED_TAG })
+  db.agents.deleteMany({ id: AGENT_ID })
+  print(`removed ${removed.deletedCount} conversations, ${messages.deletedCount} messages, agent`)
+}
+
+if (clean) {
+  removeSeeded()
+  print('clean complete')
+  quit(0)
+}
+
+// Replace the previous batch so re-running does not pile up duplicates.
+removeSeeded()
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+const agent = {
+  id: AGENT_ID,
+  name: 'LibreChat',
+  description: 'The default LibreChat agent',
+  instructions: 'You are a helpful assistant for the LibreChat demo.',
+  avatar: { filepath: LIBRECHAT_AVATAR, source: 'url' },
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-5',
+  model_parameters: {},
+  tools: [],
+  author: user._id,
+  authorName: user.name || 'LibreChat',
+  category: 'general',
+  conversation_starters: [],
+  versions: [],
+  projectIds: [],
+}
+
+if (dryRun) {
+  print(`would upsert agent ${AGENT_ID} ("LibreChat")`)
+} else {
+  db.agents.updateOne({ id: AGENT_ID }, { $set: agent }, { upsert: true })
+  print(`agent: ${AGENT_ID} ("LibreChat")`)
+}
+
+// ---------------------------------------------------------------------------
+// Conversations
+// ---------------------------------------------------------------------------
+
+// mongosh has no Date.now() restriction, but keep one clock reading so the
+// staggered timestamps are consistent within a run.
+const now = new Date()
+const HOUR = 60 * 60 * 1000
+
+/** Spreads conversations backwards in time so the sidebar shows date groups. */
+function timestampFor(index) {
+  return new Date(now.getTime() - (index + 1) * 6 * HOUR)
+}
+
+function buildConversation(spec, index, extra) {
+  const at = timestampFor(index)
+  return Object.assign(
+    {
+      conversationId: uuid(),
+      title: spec.title,
+      user: userId,
+      endpoint: spec.endpoint,
+      model: spec.model,
+      messages: [],
+      tags: [SEED_TAG],
+      isTemporary: false,
+      createdAt: at,
+      updatedAt: at,
+    },
+    extra || {},
+  )
+}
+
+function buildMessages(conversationId, turns, endpoint, model, at) {
+  const docs = []
+  let parentMessageId = '00000000-0000-0000-0000-000000000000'
+  for (const [i, turn] of turns.entries()) {
+    const userMessageId = uuid()
+    const replyId = uuid()
+    const stamp = new Date(at.getTime() + i * 60 * 1000)
+    docs.push({
+      messageId: userMessageId,
+      conversationId,
+      user: userId,
+      parentMessageId,
+      sender: 'User',
+      text: turn.user,
+      isCreatedByUser: true,
+      error: false,
+      unfinished: false,
+      createdAt: stamp,
+      updatedAt: stamp,
+    })
+    docs.push({
+      messageId: replyId,
+      conversationId,
+      user: userId,
+      parentMessageId: userMessageId,
+      sender: 'LibreChat',
+      text: turn.assistant,
+      isCreatedByUser: false,
+      error: false,
+      unfinished: false,
+      endpoint,
+      model,
+      createdAt: new Date(stamp.getTime() + 5000),
+      updatedAt: new Date(stamp.getTime() + 5000),
+    })
+    parentMessageId = replyId
+  }
+  return docs
+}
+
+const conversations = []
+const messages = []
+
+// The pinned hero conversation, on the LibreChat agent.
+const pinnedConvo = buildConversation(
+  { title: PINNED.title, endpoint: 'agents', model: agent.model },
+  -1,
+  { pinned: true, agent_id: AGENT_ID, iconURL: LIBRECHAT_AVATAR },
+)
+pinnedConvo.createdAt = now
+pinnedConvo.updatedAt = now
+conversations.push(pinnedConvo)
+messages.push(
+  ...buildMessages(pinnedConvo.conversationId, PINNED.turns, 'agents', agent.model, now),
+)
+
+for (const [index, spec] of CHATS.entries()) {
+  const convo = buildConversation(spec, index)
+  conversations.push(convo)
+  messages.push(
+    ...buildMessages(
+      convo.conversationId,
+      [{ user: `${spec.title}?`, assistant: `Here is a rundown of ${spec.title.toLowerCase()}.` }],
+      spec.endpoint,
+      spec.model,
+      convo.createdAt,
+    ),
+  )
+}
+
+const byEndpoint = {}
+for (const c of conversations) {
+  byEndpoint[c.endpoint] = (byEndpoint[c.endpoint] || 0) + 1
+}
+
+if (dryRun) {
+  print(`would insert ${conversations.length} conversations, ${messages.length} messages`)
+} else {
+  db.conversations.insertMany(conversations)
+  db.messages.insertMany(messages)
+  print(`inserted ${conversations.length} conversations, ${messages.length} messages`)
+}
+
+print('')
+print('endpoints used (each must exist in the demo librechat.yaml or the icon falls back):')
+for (const endpoint of Object.keys(byEndpoint).sort()) {
+  print(`  ${endpoint}: ${byEndpoint[endpoint]}`)
+}
+print('')
+print(`pinned hero conversation: ${pinnedConvo.conversationId}`)
+print('Set that as DEMO_CONVERSATION_ID if capturing the conversation view.')

--- a/scripts/screenshots/seed-demo.test.ts
+++ b/scripts/screenshots/seed-demo.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import vm from 'node:vm'
+
+/**
+ * Runs seed-demo.js under a stub that behaves like mongosh, not like the
+ * legacy mongo shell.
+ *
+ * The distinction matters: an earlier stub returned a plain array from find(),
+ * which made `cursor.map(...).length` work in the test and fail on a real
+ * server. In mongosh, map() returns another lazy cursor, and passing one to a
+ * query throws a BSON serialization error. Both behaviours are modelled below
+ * so the test fails the same way a server would.
+ */
+
+const SCRIPT = resolve(__dirname, 'seed-demo.js')
+
+/** Endpoints the demo actually serves, from a live authenticated inventory. */
+const LIVE_ENDPOINTS = new Set([
+  '302AI',
+  'APIpie',
+  'Fireworks',
+  'Github Models',
+  'HuggingFace',
+  'Hyperbolic',
+  'Kluster',
+  'Mistral',
+  'NanoGPT',
+  'Nvidia',
+  'OpenRouter',
+  'Perplexity',
+  'SambaNova',
+  'Unify',
+  'agents',
+  'anthropic',
+  'cohere',
+  'deepseek',
+  'glhf.chat',
+  'google',
+  'groq',
+  'openAI',
+  'together.ai',
+  'xai',
+])
+
+interface Doc {
+  [key: string]: unknown
+}
+
+/** A mongosh cursor: map() stays lazy, only toArray() materialises. */
+function cursor(docs: Doc[]) {
+  return {
+    toArray: () => docs,
+    map(fn: (d: Doc) => unknown) {
+      return cursor(docs.map((d) => fn(d) as Doc))
+    },
+  }
+}
+
+function isPlainArray(value: unknown): boolean {
+  return Array.isArray(value)
+}
+
+interface RunResult {
+  logs: string[]
+  conversations: Doc[]
+  messages: Doc[]
+  agents: Doc[]
+  deletes: { collection: string; filter: Doc }[]
+}
+
+function run(options: { existing?: Doc[]; vars?: Record<string, unknown> } = {}): RunResult {
+  const existing = options.existing ?? []
+  const result: RunResult = {
+    logs: [],
+    conversations: [],
+    messages: [],
+    agents: [],
+    deletes: [],
+  }
+
+  const collection = (name: string) => ({
+    findOne: (query: Doc) =>
+      name === 'users' && query.email
+        ? { _id: 'OID_demo_user', email: query.email, name: 'LibreChat Demo' }
+        : null,
+    find: () => cursor(name === 'conversations' ? existing : []),
+    insertMany: (docs: Doc[]) => {
+      if (name === 'conversations') result.conversations.push(...docs)
+      if (name === 'messages') result.messages.push(...docs)
+      return { insertedCount: docs.length }
+    },
+    deleteMany: (filter: Doc) => {
+      // A real server rejects a non-array $in before executing anything.
+      const inClause = (filter.conversationId as { $in?: unknown } | undefined)?.$in
+      if (inClause !== undefined && !isPlainArray(inClause)) {
+        throw new TypeError('Cannot convert circular structure to BSON')
+      }
+      result.deletes.push({ collection: name, filter })
+      return { deletedCount: name === 'conversations' ? existing.length : 0 }
+    },
+    updateOne: (_query: Doc, update: { $set: Doc }) => {
+      result.agents.push(update.$set)
+      return { upsertedCount: 1 }
+    },
+  })
+
+  const db = new Proxy(
+    { getName: () => 'demo' },
+    {
+      get: (target: Record<string, unknown>, prop: string) =>
+        prop in target ? target[prop] : collection(String(prop)),
+    },
+  )
+
+  const context = vm.createContext({
+    db,
+    crypto,
+    DEMO_EMAIL: 'demo@librechat.ai',
+    print: (message: unknown) => result.logs.push(String(message)),
+    quit: () => {
+      throw new Error('__QUIT__')
+    },
+    ...(options.vars ?? {}),
+  })
+
+  try {
+    vm.runInContext(readFileSync(SCRIPT, 'utf8'), context)
+  } catch (err) {
+    if (!String((err as Error).message).includes('__QUIT__')) throw err
+  }
+  return result
+}
+
+describe('seed-demo', () => {
+  it('runs against a fresh account without touching a cursor as a query value', () => {
+    // Regression: cursor.map() returns a cursor in mongosh, so the previous
+    // version reported "would remove undefined" and threw on the first delete.
+    const result = run()
+    expect(result.logs).toContain('nothing previously seeded')
+    expect(result.logs.join('\n')).not.toContain('undefined')
+  })
+
+  it('materialises existing ids before using them in a query', () => {
+    const existing = [{ conversationId: 'a' }, { conversationId: 'b' }]
+    const result = run({ existing })
+    const deletion = result.deletes.find((d) => d.collection === 'messages')
+    expect(deletion).toBeDefined()
+    expect((deletion!.filter.conversationId as { $in: unknown[] }).$in).toEqual(['a', 'b'])
+  })
+
+  it('covers every endpoint the demo serves and invents none', () => {
+    const used = new Set(run().conversations.map((c) => c.endpoint as string))
+    expect([...used].filter((e) => !LIVE_ENDPOINTS.has(e))).toEqual([])
+    expect([...LIVE_ENDPOINTS].filter((e) => !used.has(e))).toEqual([])
+  })
+
+  it('writes enough conversations to clear the capture guard', () => {
+    // capture.ts refuses to shoot a desktop image below MIN_SIDEBAR_CHATS.
+    expect(run().conversations.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('gives every document a valid uuid and the seed tag', () => {
+    const { conversations, messages } = run()
+    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    expect(conversations.every((c) => uuid.test(c.conversationId as string))).toBe(true)
+    expect(messages.every((m) => uuid.test(m.messageId as string))).toBe(true)
+    expect(conversations.every((c) => (c.tags as string[]).includes('docs-hero-seed'))).toBe(true)
+    const ids = conversations.map((c) => c.conversationId)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('chains each reply to the message it answers', () => {
+    const { conversations, messages } = run()
+    const pinned = conversations.find((c) => c.pinned)!
+    const thread = messages.filter((m) => m.conversationId === pinned.conversationId)
+    expect(thread.length).toBeGreaterThan(1)
+    for (const [index, message] of thread.entries()) {
+      if (index === 0) continue
+      expect(message.parentMessageId).toBe(thread[index - 1].messageId)
+    }
+  })
+
+  it('orders conversations so the sidebar groups them by date', () => {
+    const dates = run()
+      .conversations.map((c) => (c.updatedAt as Date).getTime())
+      .sort((a, b) => b - a)
+    expect(dates.every((d, i) => i === 0 || dates[i - 1] > d)).toBe(true)
+  })
+
+  it('creates the LibreChat agent with an avatar served by the demo', () => {
+    const [agent] = run().agents
+    expect(agent.name).toBe('LibreChat')
+    expect((agent.avatar as { filepath: string }).filepath).toMatch(
+      /^https:\/\/chat\.librechat\.ai\/.+\.svg$/,
+    )
+  })
+
+  it('writes nothing in dry-run mode', () => {
+    const result = run({ vars: { DRY_RUN: 'true' } })
+    expect(result.conversations).toEqual([])
+    expect(result.messages).toEqual([])
+    expect(result.agents).toEqual([])
+    expect(result.deletes).toEqual([])
+  })
+
+  it('removes the agent on clean even when no conversations remain', () => {
+    // The agent outlives its conversations, so a clean that returned early on
+    // an empty batch would strand it and CLEAN could never undo a seed.
+    const result = run({ vars: { CLEAN: 'true' } })
+    expect(result.deletes.some((d) => d.collection === 'agents')).toBe(true)
+    expect(result.conversations).toEqual([])
+  })
+})

--- a/scripts/screenshots/seed-demo.test.ts
+++ b/scripts/screenshots/seed-demo.test.ts
@@ -189,12 +189,11 @@ describe('seed-demo', () => {
     expect(dates.every((d, i) => i === 0 || dates[i - 1] > d)).toBe(true)
   })
 
-  it('creates the LibreChat agent with an avatar served by the demo', () => {
-    const [agent] = run().agents
-    expect(agent.name).toBe('LibreChat')
-    expect((agent.avatar as { filepath: string }).filepath).toMatch(
-      /^https:\/\/chat\.librechat\.ai\/.+\.svg$/,
-    )
+  it('creates no agent, since the demo hosts its own', () => {
+    // A previous version upserted one. /api/agents never returned it, so it
+    // was invisible in the app while still being a second "LibreChat" agent in
+    // the database, and the capture would have branded the shot with it.
+    expect(run().agents).toEqual([])
   })
 
   it('writes nothing in dry-run mode', () => {

--- a/scripts/screenshots/seed-demo.test.ts
+++ b/scripts/screenshots/seed-demo.test.ts
@@ -204,6 +204,23 @@ describe('seed-demo', () => {
     expect(result.deletes).toEqual([])
   })
 
+  it('points the pinned conversation at an agent that exists', () => {
+    // It referenced an agent this script used to create and no longer does,
+    // which left the conversation resolving to nothing when opened.
+    const pinned = run().conversations.find((c) => c.pinned)!
+    expect(pinned.agent_id).not.toBe('agent_docs_hero_librechat')
+    expect(String(pinned.agent_id)).toMatch(/^agent_/)
+  })
+
+  it("never deletes the demo's own agent, only the retired one", () => {
+    const result = run({ vars: { CLEAN: 'true' } })
+    const agentDeletes = result.deletes.filter((d) => d.collection === 'agents')
+    expect(agentDeletes.length).toBeGreaterThan(0)
+    for (const del of agentDeletes) {
+      expect(del.filter.id).toBe('agent_docs_hero_librechat')
+    }
+  })
+
   it('removes the agent on clean even when no conversations remain', () => {
     // The agent outlives its conversations, so a clean that returned early on
     // an empty batch would strand it and CLEAN could never undo a seed.


### PR DESCRIPTION
The weekly screenshot job had never produced an image, failing every run on an opaque selector timeout that hid five stacked faults: a Cloudflare Bot Fight Mode challenge on `/api/config`, a theme key LibreChat never reads, a session replayed across contexts that token rotation rejects, a Terms dialog covering every capture, and stray hover state. It now shoots the new-chat screen on the LibreChat agent with a provider-varied sidebar, seeded by `seed-demo.js` under `mongosh` with no inference billed, and refuses to save an image that has too few sidebar rows, the wrong branding, or a dialog over it. Every failure names its cause and uploads a screenshot, the served DOM and an `/api/*` report as an artifact.

## Verification

- 20 unit tests, eslint, tsc and prettier clean
- The capture verified end to end against the live demo: all four variants
  captured, light and dark corner pixels matching the reference values, and
  every image inspected
- Output reviewed in [#722](https://github.com/LibreChat-AI/librechat.ai/pull/722)