### PR TITLE
docs: add OptionsAhoy MCP server page

### DIFF
--- a/content/docs/mcp_servers/index.mdx
+++ b/content/docs/mcp_servers/index.mdx
@@ -13,6 +13,9 @@ Use these guides to configure specific MCP servers with the right transport, OAu
   <Cards.Card title="Salesforce MCP" href="/docs/mcp_servers/salesforce" arrow>
     Configure Salesforce Hosted MCP servers with an External Client App and per-user OAuth.
   </Cards.Card>
+  <Cards.Card title="OptionsAhoy MCP" href="/docs/mcp_servers/optionsahoy" arrow>
+    Connect the hosted OptionsAhoy equity-compensation MCP server over Streamable HTTP, no auth.
+  </Cards.Card>
   <Cards.Card title="MCP overview" href="/docs/features/mcp" arrow>
     Learn how MCP works in LibreChat before adding product-specific servers.
   </Cards.Card>

--- a/content/docs/mcp_servers/meta.json
+++ b/content/docs/mcp_servers/meta.json
@@ -1,5 +1,10 @@
 {
   "title": "MCP Servers",
   "icon": "Blocks",
-  "pages": ["index", "google_workspace", "salesforce"]
+  "pages": [
+    "index",
+    "google_workspace",
+    "optionsahoy",
+    "salesforce"
+  ]
 }

--- a/content/docs/mcp_servers/optionsahoy.mdx
+++ b/content/docs/mcp_servers/optionsahoy.mdx
@@ -1,0 +1,43 @@
+---
+title: OptionsAhoy MCP
+icon: Blocks
+description: Connect LibreChat to OptionsAhoy, a hosted MCP server for US equity-compensation tax planning. Streamable HTTP, no authentication.
+---
+
+OptionsAhoy hosts a remote MCP server at `https://optionsahoy.com/mcp` for US
+equity-compensation planning: incentive stock option (ISO) exercise schedules with
+alternative minimum tax (AMT) calculations, non-qualified stock option (NSO) exercise
+math, restricted stock unit (RSU) sell-vs-hold and lot ordering, qualified small
+business stock (QSBS) checks, single-stock concentration analysis, hedge pricing,
+and multi-year sale plans to fund a cash goal by a deadline. Tax math covers
+federal, all 50 states, and DC over multi-year horizons.
+
+No authentication, no API key, and no local process: LibreChat connects directly
+over Streamable HTTP.
+
+## Setup
+
+Add the server to `librechat.yaml` under `mcpServers`:
+
+```yaml
+mcpServers:
+  optionsahoy:
+    type: streamable-http
+    url: https://optionsahoy.com/mcp
+```
+
+Restart LibreChat. The eight OptionsAhoy tools appear in the tools list, and the
+server also provides MCP resources and prompts.
+
+## Try it
+
+Ask, for example:
+
+- "I have 10,000 ISOs at a $2 strike, current price $40, married filing jointly
+  in California with $350K income. How many can I exercise this year before AMT
+  kicks in?"
+- "Should I sell my RSUs at vest or hold for long-term rates?"
+
+The server asks for missing inputs rather than guessing. Documentation:
+[optionsahoy.com/for-agents](https://optionsahoy.com/for-agents). Source:
+[github.com/AlvisoOculus/optionsahoy-mcp](https://github.com/AlvisoOculus/optionsahoy-mcp) (MIT).


### PR DESCRIPTION
Adds a setup page for the hosted OptionsAhoy MCP server (streamable-http, no auth, no env vars) under MCP Servers, alongside the Google Workspace and Salesforce pages, plus the index card and meta.json entry. English only; happy to follow up with translations if that is preferred.