### PR TITLE
fix: vary docs cache on Accept

### DIFF
--- a/e2e/markdown-negotiation.spec.ts
+++ b/e2e/markdown-negotiation.spec.ts
@@ -25,4 +25,14 @@ test.describe('Markdown content negotiation', () => {
     expect(response.headers().vary).toContain('Accept')
     await expect(response.text()).resolves.toContain('# LibreChat')
   })
+
+  test('varies cached docs HTML on the Accept header', async ({ request }) => {
+    const response = await request.get('/docs', {
+      headers: { Accept: 'text/html' },
+    })
+
+    expect(response.ok()).toBe(true)
+    expect(response.headers()['content-type']).toContain('text/html')
+    expect(response.headers().vary).toContain('Accept')
+  })
 })

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -143,6 +143,20 @@ const cdnRulesFor = (source, cache) => [
   },
 ]
 
+const MARKDOWN_NEGOTIATED_PATHS = [
+  '/docs/:path*',
+  // Localized docs need the same cache partitioning and edge-cache policy as English.
+  '/(zh|es|fr|de|ja|pt-BR|it|nl|pl|vi|ko|id|tr)/docs/:path*',
+]
+
+// Middleware response headers are replaced when the App Router emits its RSC
+// Vary value. Configure Accept at the route layer so Next appends its own
+// variants instead of dropping the content-negotiation cache key.
+const markdownNegotiatedVaryHeaders = MARKDOWN_NEGOTIATED_PATHS.map((source) => ({
+  source,
+  headers: [{ key: 'Vary', value: 'Accept' }],
+}))
+
 // The narrower live-data rules come last so their Cache-Control overrides the
 // shared value on the paths they match.
 const cdnCacheHeaders = [
@@ -308,6 +322,7 @@ const config = {
           },
         ],
       },
+      ...markdownNegotiatedVaryHeaders,
       ...cdnCacheHeaders,
     ]
   },


### PR DESCRIPTION
## Summary

- Add `Vary: Accept` at the Next route-header layer for English and localized documentation.
- Add an end-to-end regression test for the final HTML response header.

## Root cause

The middleware set `Vary: Accept`, but the App Router replaced that header with its RSC variants. Cloudflare therefore cached HTML without `Accept` in the variant key and served that HTML to later `Accept: text/markdown` requests.

## Validation

- Production reproduction: HTML cache warm-up changed `cf-cache-status` from `MISS` to `HIT`, then a Markdown request incorrectly received cached HTML.
- Regression test failed against production before the fix.
- `pnpm build`
- `pnpm exec playwright test e2e/markdown-negotiation.spec.ts` (3 passed)
- `pnpm exec eslint next.config.mjs e2e/markdown-negotiation.spec.ts`
- `pnpm exec prettier --check next.config.mjs e2e/markdown-negotiation.spec.ts`