### PR TITLE
🌐 fix: Support Synchronous WebMCP Registration

### DIFF
--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -9,7 +9,7 @@ test('registers WebMCP tools on page load through document.modelContext', async 
   await page.addInitScript(() => {
     const state: WebMCPTestState = { tools: [], abortedTools: [] }
     const modelContext: WebMCPModelContext = {
-      async registerTool(tool, options) {
+      registerTool(tool, options) {
         state.tools.push(tool)
         options?.signal?.addEventListener('abort', () => state.abortedTools.push(tool.name), {
           once: true,

--- a/global.d.ts
+++ b/global.d.ts
@@ -15,7 +15,10 @@ interface WebMCPToolDefinition {
 }
 
 interface WebMCPModelContext {
-  registerTool: (tool: WebMCPToolDefinition, options?: { signal?: AbortSignal }) => Promise<void>
+  registerTool: (
+    tool: WebMCPToolDefinition,
+    options?: { signal?: AbortSignal },
+  ) => void | Promise<void>
 }
 
 interface Navigator {

--- a/lib/webmcp.test.ts
+++ b/lib/webmcp.test.ts
@@ -169,4 +169,48 @@ describe('WebMCP registration', () => {
     ).toBe(true)
     expect(navigatorRegister).toHaveBeenCalledTimes(tools.length)
   })
+
+  it('supports Chrome implementations whose registerTool returns void', () => {
+    const navigatorRegister = vi.fn(
+      (_tool: WebMCPToolDefinition, _options?: { signal?: AbortSignal }) => {},
+    )
+
+    expect(() =>
+      registerWebMCPTools(tools, new AbortController().signal, {
+        navigatorModelContext: { registerTool: navigatorRegister },
+      }),
+    ).not.toThrow()
+    expect(navigatorRegister).toHaveBeenCalledTimes(tools.length)
+  })
+
+  it('contains synchronous and asynchronous registration failures', async () => {
+    const syncError = new Error('sync failure')
+    const asyncError = new Error('async failure')
+    const registerTool = vi.fn((tool: WebMCPToolDefinition) => {
+      if (tool === tools[0]) throw syncError
+      if (tool === tools[1]) return Promise.reject(asyncError)
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      expect(() =>
+        registerWebMCPTools(tools, new AbortController().signal, {
+          documentModelContext: { registerTool },
+        }),
+      ).not.toThrow()
+      await Promise.resolve()
+
+      expect(registerTool).toHaveBeenCalledTimes(tools.length)
+      expect(consoleError).toHaveBeenCalledWith(
+        `[WebMCP] Failed to register ${tools[0].name}:`,
+        syncError,
+      )
+      expect(consoleError).toHaveBeenCalledWith(
+        `[WebMCP] Failed to register ${tools[1].name}:`,
+        asyncError,
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
 })

--- a/lib/webmcp.ts
+++ b/lib/webmcp.ts
@@ -288,11 +288,17 @@ export function registerWebMCPTools(
   if (!modelContext) return false
 
   for (const tool of tools) {
-    void modelContext.registerTool(tool, { signal }).catch((error: unknown) => {
+    const reportError = (error: unknown) => {
       if (!signal.aborted) {
         console.error(`[WebMCP] Failed to register ${tool.name}:`, error)
       }
-    })
+    }
+
+    try {
+      void Promise.resolve(modelContext.registerTool(tool, { signal })).catch(reportError)
+    } catch (error) {
+      reportError(error)
+    }
   }
 
   return true


### PR DESCRIPTION
## Summary

- support both synchronous and Promise-returning `WebMCPModelContext.registerTool()` implementations
- contain synchronous exceptions and asynchronous registration rejections without crashing the root layout
- cover the Chrome-compatible synchronous return in unit and browser tests

The deployed WebMCP integration assumed `registerTool()` always returned a Promise and chained `.catch()` directly. Chrome builds with the earlier synchronous API return `undefined`, which caused `Cannot read properties of undefined (reading 'catch')` during root-layout hydration. The resulting exception replaced every marketing and documentation route with Next.js's global load-error screen.

## Change Type

Bug fix and browser compatibility.

## Testing

- `pnpm exec vitest run lib/webmcp.test.ts` (9 passed)
- `pnpm test` (32 files, 366 tests passed)
- `pnpm typecheck`
- `pnpm exec eslint lib/webmcp.ts lib/webmcp.test.ts e2e/webmcp.spec.ts global.d.ts`
- `pnpm exec prettier --check lib/webmcp.ts lib/webmcp.test.ts e2e/webmcp.spec.ts global.d.ts`
- focused Playwright WebMCP flow with installed Linux Chrome and a synchronous `document.modelContext.registerTool` mock (1 passed)

## Checklist

- [x] The fix is scoped to WebMCP registration compatibility.
- [x] Unit, browser, type, lint, and formatting checks pass.
- [x] No unrelated files are included.
