### PR TITLE
🎛️ docs: Document Configurable Max Subagents

### DIFF
--- a/content/docs/configuration/librechat_yaml/example.mdx
+++ b/content/docs/configuration/librechat_yaml/example.mdx
@@ -399,6 +399,7 @@ endpoints:
   #   maxDeltaEventsPerTurn: 100000 # Optional event cap; omitted or 0 disables it
   #   maxToolCallArgBytesByTool:
   #     create_file: 131072 # Overrides the global limit for this tool; 0 disables its guard
+  #   maxSubagents: 10 # Maximum explicit subagents per agent (1-50)
   #   skills:
   #     maxCatalogSkills: 20
   custom:

--- a/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
@@ -24,12 +24,12 @@ endpoints:
     maxCitations: 30 # Maximum total citations in responses (1-50)
     maxCitationsPerFile: 7 # Maximum citations from each file (1-10)
     minRelevanceScore: 0.45 # Minimum relevance score threshold (0.0-1.0)
-    maxSubagents: 10 # Maximum explicit subagents per agent (1-50)
     titleTiming: immediate
     activityLabel: true
     activityModel: gpt-4.1-nano
     activityPhaseLabel: true
     activityPhaseMaxPerRun: 5
+    maxSubagents: 10 # Maximum explicit subagents per agent (1-50)
     skills:
       maxCatalogSkills: 20
     toolApproval:
@@ -429,9 +429,9 @@ Raise this when a deployment runs orchestration-heavy agents that need to delega
 - The Agent Builder panel, which stops accepting new subagent entries at the configured value
 
 <Callout type="warning">
-  Values outside the `1-50` range are rejected by the configuration schema, and the effective cap
-  falls back to the default of `10`. An invalid or removed key therefore never leaves a raised limit
-  in place.
+  Values outside the `1-50` range fail validation when `librechat.yaml` is loaded: the invalid file
+  is reported at startup and the effective cap falls back to the default of `10`. An invalid or
+  removed key therefore never leaves a raised limit in place.
 </Callout>
 
 <Callout type="note">

--- a/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
@@ -24,6 +24,7 @@ endpoints:
     maxCitations: 30 # Maximum total citations in responses (1-50)
     maxCitationsPerFile: 7 # Maximum citations from each file (1-10)
     minRelevanceScore: 0.45 # Minimum relevance score threshold (0.0-1.0)
+    maxSubagents: 10 # Maximum explicit subagents per agent (1-50)
     titleTiming: immediate
     activityLabel: true
     activityModel: gpt-4.1-nano
@@ -396,6 +397,52 @@ skills:
 
 This does not disable Skills. Use the `skills` capability and per-agent/model-spec skill scoping to control whether Skills are available.
 
+## maxSubagents
+
+<OptionTable
+  options={[
+    [
+      'maxSubagents',
+      'Number',
+      'Maximum number of explicit subagents a single agent may reference.',
+      'Applies to both the `agent_ids` allowlist and configured subagent `graphs`, on agents and on model specs. Must be a whole number between 1 and 50.',
+    ],
+  ]}
+/>
+
+**Default:** `10`
+
+**Range:** `1-50`
+
+**Example:**
+
+```yaml filename="endpoints / agents / maxSubagents"
+endpoints:
+  agents:
+    maxSubagents: 20
+```
+
+Raise this when a deployment runs orchestration-heavy agents that need to delegate to more than ten children. The value is read at startup and enforced in three places:
+
+- Agent create, update, and duplicate requests, for `subagents.agent_ids` and `subagents.graphs`
+- Model spec `subagents.agent_ids` allowlists, validated in the same configuration pass
+- The Agent Builder panel, which stops accepting new subagent entries at the configured value
+
+<Callout type="warning">
+  Values outside the `1-50` range are rejected by the configuration schema, and the effective cap
+  falls back to the default of `10`. An invalid or removed key therefore never leaves a raised limit
+  in place.
+</Callout>
+
+<Callout type="note">
+  The cap is process-wide and comes from `librechat.yaml`. A per-user or per-group database override
+  of `endpoints.agents.maxSubagents` is reflected in the served configuration but is not applied by
+  request validation.
+</Callout>
+
+Raising this only changes how many subagents one agent may reference. The depth, graph node, and run
+configuration limits are unaffected. See [Subagents](/docs/features/subagents#limits).
+
 ## maxCitations
 
 <OptionTable
@@ -703,7 +750,7 @@ The `subagents` field controls which isolated child agents a parent agent can sp
     [
       'agent_ids',
       'Array/List of Strings',
-      'Specific agents this agent may spawn. Maximum: 10.',
+      'Specific agents this agent may spawn. Capped by `maxSubagents`, which defaults to 10.',
       'agent_ids: ["agent_researcher"]',
     ],
   ]}
@@ -728,3 +775,4 @@ For user-facing behavior and limits, see [Subagents](/docs/features/subagents).
 - Citation limits help balance comprehensive information retrieval with response quality and performance.
 - The `context` capability works without OCR configuration using text parsing methods. OCR enhances extraction quality when configured.
 - The `ocr` capability requires an OCR service to be configured (see [OCR Configuration](/docs/configuration/librechat_yaml/object_structure/ocr)).
+- `maxSubagents` bounds how many subagents a single agent may reference. It does not change the depth or graph limits documented under [Subagents](/docs/features/subagents#limits).

--- a/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
@@ -405,7 +405,7 @@ This does not disable Skills. Use the `skills` capability and per-agent/model-sp
       'maxSubagents',
       'Number',
       'Maximum number of explicit subagents a single agent may reference.',
-      'Applies to both the `agent_ids` allowlist and configured subagent `graphs`, on agents and on model specs. Must be a whole number between 1 and 50.',
+      'Applies to the `agent_ids` allowlist on agents and on model specs, and to configured subagent `graphs`, which agents support but model specs do not. Must be a whole number between 1 and 50.',
     ],
   ]}
 />
@@ -428,10 +428,14 @@ Raise this when a deployment runs orchestration-heavy agents that need to delega
 - Model spec `subagents.agent_ids` allowlists, validated in the same configuration pass
 - The Agent Builder panel, which stops accepting new subagent entries at the configured value
 
+Model specs accept only `enabled`, `allowSelf`, and `agent_ids` under `subagents`. Subagent `graphs` are an agent-level feature: a `graphs` key on a model spec is dropped when the config is parsed, without an error.
+
 <Callout type="warning">
-  Values outside the `1-50` range fail validation when `librechat.yaml` is loaded: the invalid file
-  is reported at startup and the effective cap falls back to the default of `10`. An invalid or
-  removed key therefore never leaves a raised limit in place.
+  `maxSubagents` must be a whole number between 1 and 50. A value outside that range fails
+  `librechat.yaml` validation, and LibreChat logs the error and exits at startup instead of falling
+  back to the default. Starting with `CONFIG_BYPASS_VALIDATION=true` skips the exit, but the entire
+  custom config is discarded in that case, so the cap returns to `10`. To go back to the default
+  deliberately, remove the key: an omitted `maxSubagents` resolves to `10` with no error.
 </Callout>
 
 <Callout type="note">

--- a/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx
@@ -895,7 +895,7 @@ Controls Subagents for ephemeral agents created from this model spec. Use this w
 
 - `enabled`: adds the subagent spawn tool for this model spec.
 - `allowSelf`: lets the ephemeral agent spawn a fresh isolated copy of itself.
-- `agent_ids`: allows specific persisted agents as additional subagents. This list is capped by `MAX_SUBAGENTS` and remains server-side; startup config sent to clients only includes public `enabled` and `allowSelf` flags.
+- `agent_ids`: allows specific persisted agents as additional subagents. This list is capped by the effective subagents limit, which defaults to 10 and is configurable with [`endpoints.agents.maxSubagents`](/docs/configuration/librechat_yaml/object_structure/agents#maxsubagents). The list remains server-side; startup config sent to clients only includes public `enabled` and `allowSelf` flags.
 
 When model specs are enforced, the model spec's `subagents` settings are authoritative over request payload values.
 

--- a/content/docs/features/subagents.mdx
+++ b/content/docs/features/subagents.mdx
@@ -105,7 +105,7 @@ LibreChat enforces these limits to keep subagent graphs bounded:
     [
       'MAX_SUBAGENTS',
       'Number',
-      'Maximum explicit subagents per parent agent. Configurable via endpoints.agents.maxSubagents, up to 50.',
+      'Maximum explicit subagents per parent agent. Configurable via `endpoints.agents.maxSubagents`, up to 50.',
       '10',
     ],
     ['MAX_SUBAGENT_DEPTH', 'Number', 'Maximum explicit subagent hops from a root agent.', '5'],

--- a/content/docs/features/subagents.mdx
+++ b/content/docs/features/subagents.mdx
@@ -83,7 +83,7 @@ modelSpecs:
         model: 'gpt-4o'
 ```
 
-Only `enabled` and `allowSelf` are sent to clients in startup config. The `agent_ids` allowlist stays server-side and is validated against the shared `MAX_SUBAGENTS` limit. Client request payloads cannot supply or override model-spec Subagent configuration.
+Only `enabled` and `allowSelf` are sent to clients in startup config. The `agent_ids` allowlist stays server-side and is validated against the effective subagents limit, which defaults to 10 and is configurable with [`endpoints.agents.maxSubagents`](/docs/configuration/librechat_yaml/object_structure/agents#maxsubagents). Client request payloads cannot supply or override model-spec Subagent configuration.
 
 ## Runtime Behavior
 

--- a/content/docs/features/subagents.mdx
+++ b/content/docs/features/subagents.mdx
@@ -102,7 +102,12 @@ LibreChat enforces these limits to keep subagent graphs bounded:
 
 <OptionTable
   options={[
-    ['MAX_SUBAGENTS', 'Number', 'Maximum explicit subagents per parent agent.', '10'],
+    [
+      'MAX_SUBAGENTS',
+      'Number',
+      'Maximum explicit subagents per parent agent. Configurable via endpoints.agents.maxSubagents, up to 50.',
+      '10',
+    ],
     ['MAX_SUBAGENT_DEPTH', 'Number', 'Maximum explicit subagent hops from a root agent.', '5'],
     [
       'MAX_SUBAGENT_GRAPH_NODES',
@@ -118,6 +123,16 @@ LibreChat enforces these limits to keep subagent graphs bounded:
     ],
   ]}
 />
+
+Only the per-agent subagent count is configurable. Set `endpoints.agents.maxSubagents` in `librechat.yaml` to raise it from the default of 10, up to a hard ceiling of 50:
+
+```yaml filename="librechat.yaml"
+endpoints:
+  agents:
+    maxSubagents: 20
+```
+
+The configured value applies to agent create, update, and duplicate requests, to model spec `subagents.agent_ids` allowlists, and to the subagent picker in the Agent Builder. See [maxSubagents](/docs/configuration/librechat_yaml/object_structure/agents#maxsubagents) for the full reference. The depth, graph node, and run configuration limits above are fixed.
 
 ## Access Control
 


### PR DESCRIPTION
## Summary

Documents `endpoints.agents.maxSubagents`, added in [LibreChat#15023](https://github.com/danny-avila/LibreChat/pull/15023). The per-agent subagent cap was hardcoded at 10, and the docs described it as a fixed constant. Deployments running deeper orchestration graphs can now raise it in `librechat.yaml`, so the reference needed a real entry rather than a value readers would assume they had to patch and rebuild for.

New `maxSubagents` section on the Agents endpoint page covering the default of 10, the 1-50 range, and the three places the configured value is enforced: agent create/update/duplicate requests (`subagents.agent_ids` and `subagents.graphs`), model spec `subagents.agent_ids` allowlists, and the Agent Builder panel. It also records two behaviors that are easy to get wrong: an out-of-range or removed key resets the effective cap to 10 rather than leaving a raised limit in place, and the cap is process-wide from the yaml file, so a per-principal database override shows up in the served config without being applied by request validation.

The Subagents feature page and the model spec `subagents` reference both described the cap as the fixed `MAX_SUBAGENTS` constant. Both now point at the configurable key, and the feature page states plainly that the depth, graph node, and run configuration limits are still fixed, so raising one limit is not read as raising all four.

Files changed:

- `content/docs/configuration/librechat_yaml/object_structure/agents.mdx`: new `maxSubagents` section, key added to the page example, `agent_ids` wording, note
- `content/docs/features/subagents.mdx`: limits table row plus configuration paragraph
- `content/docs/configuration/librechat_yaml/object_structure/model_specs.mdx`: `agent_ids` cap reference
- `content/docs/configuration/librechat_yaml/example.mdx`: key added to the commented `agents` block

English sources only. Translations regenerate on merge through the Translate Docs workflow.

## Change Type

- [x] Documentation update

## Testing

Content verified line by line against the merged implementation: `packages/data-provider/src/limits.ts` (`MAX_SUBAGENTS`, `MAX_SUBAGENTS_CEILING`, `setMaxSubagents` reset behavior), `packages/data-provider/src/config.ts` (`agentsEndpointSchema`), and `packages/api/src/agents/validation.ts` (`getMaxSubagents` in the `agent_ids` and `graphs` refinement).

Commands run:

- `pnpm exec fumadocs-mdx` (compiles clean)
- `npx prettier --check` on the four touched files (all pass)

Anchors used by the new cross-links (`#maxsubagents`, `#limits`) checked against the headings they resolve to. Full `pnpm build` and Playwright E2E were not run: this is a content-only change using components already present in the same files, and link checking runs against the deployed site.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings