### PR TITLE
🙈 docs: Document Interface Option to Hide Response Feedback Buttons

### DIFF
--- a/content/docs/configuration/langfuse.mdx
+++ b/content/docs/configuration/langfuse.mdx
@@ -235,4 +235,6 @@ When Langfuse tracing is configured, LibreChat also sends message feedback to La
 
 Feedback scores include message context metadata when available, including the message ID, parent message ID, conversation/session ID, user ID, endpoint, sender, `isCreatedByUser`, token count, rating, and feedback tag. Empty metadata values are omitted before the score is sent.
 
+Feedback scores are only produced when the feedback buttons are available. Setting [`interface.feedback`](/docs/configuration/librechat_yaml/object_structure/interface#feedback) to `false` hides the buttons and rejects feedback writes, so no scores reach Langfuse.
+
 Feedback scores use the same Langfuse credentials and base URL as tracing. They also respect `LANGFUSE_TRACING_ENABLED=false`, `LANGFUSE_SAMPLE_RATE=0`, and `LANGFUSE_TRACING_ENVIRONMENT`. Score delivery is best-effort, so the feedback UI does not block if Langfuse is temporarily unavailable.

--- a/content/docs/configuration/librechat_yaml/example.mdx
+++ b/content/docs/configuration/librechat_yaml/example.mdx
@@ -73,6 +73,9 @@ interface:
   #   code: EUR
   #   rate: 0.92
 
+  # Show the thumbs up/thumbs down feedback buttons on responses (default: true)
+  # feedback: true
+
   # Default prompt-bar pinned tools for users who have not customized pins
   # defaultPinnedTools:
   #   - artifacts

--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -1035,6 +1035,12 @@ see also:
     ],
     ['fileCitations', 'Boolean', 'Globally enables or disables file citations for all users', ''],
     [
+      'feedback',
+      'Boolean',
+      'Shows or hides the thumbs up/thumbs down feedback buttons on responses',
+      '',
+    ],
+    [
       'peoplePicker',
       'Object',
       'Configures which principal types are available controls in the people picker interface',

--- a/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/interface.mdx
@@ -36,6 +36,7 @@ These are fields under `interface`:
 - `webSearch`
 - `fileSearch`
 - `fileCitations`
+- `feedback`
 - `defaultPinnedTools`
 - `peoplePicker`
 - `marketplace`
@@ -117,6 +118,7 @@ interface:
   webSearch: true
   fileSearch: true
   fileCitations: true
+  feedback: true
   defaultPinnedTools:
     - artifacts
     - execute_code
@@ -1176,6 +1178,40 @@ Controls the global availability of file citations functionality. When disabled,
 ```yaml filename="interface / fileCitations"
 interface:
   fileCitations: true
+```
+
+## feedback
+
+Controls whether the thumbs up / thumbs down buttons are shown under responses. When set to `false`, the buttons are removed from the message action row and the server rejects feedback writes, so a deployment that hides the controls also stores no ratings.
+
+**Notes:**
+
+- The other message actions (read aloud, copy, edit, fork, and regenerate) are unaffected, and the action row reflows without leaving a gap.
+- With feedback disabled, `PUT /api/messages/:conversationId/:messageId/feedback` responds with `403` and `{"error": "Feedback is disabled"}` before anything is written to the database or exported.
+- Ratings collected while the feature was enabled stay on existing messages. The flag stops new writes, it does not delete stored feedback.
+- Ratings are only consumed outside LibreChat when Langfuse tracing is configured, where each one is sent as a `user-feedback` score. See [Message Feedback Scores](/docs/configuration/langfuse#message-feedback-scores).
+- This is a plain interface flag rather than a role permission, so there is nothing to grant per role in the [Admin Panel](/docs/features/admin_panel).
+
+**Key:**
+
+<OptionTable
+  options={[
+    [
+      'feedback',
+      'Boolean',
+      'Shows or hides the thumbs up/thumbs down feedback buttons on responses.',
+      'When disabled, the buttons are removed for every user and the feedback endpoint rejects writes with a 403.',
+    ],
+  ]}
+/>
+
+**Default:** `true`
+
+**Example:**
+
+```yaml filename="interface / feedback"
+interface:
+  feedback: false
 ```
 
 ## defaultPinnedTools


### PR DESCRIPTION
## Summary

Documents `interface.feedback`, the flag added in [danny-avila/LibreChat#15085](https://github.com/danny-avila/LibreChat/pull/15085) (closes danny-avila/LibreChat#13818), which hides the thumbs up / thumbs down buttons on responses and stops the server from storing ratings.

- `librechat_yaml/object_structure/interface.mdx`: `feedback` added to the field list and the combined example, plus a `## feedback` section covering what the flag hides, the untouched message actions (read aloud, copy, edit, fork, regenerate), the `403 {"error": "Feedback is disabled"}` returned by `PUT /api/messages/:conversationId/:messageId/feedback` before any database write or Langfuse export, the fact that existing ratings are kept rather than deleted, and why this is a plain interface flag rather than a role permission.
- `librechat_yaml/object_structure/config.mdx`: `feedback` row in the `interface` option table.
- `librechat_yaml/example.mdx`: commented `feedback: true` line, mirroring `librechat.example.yaml`.
- `langfuse.mdx`: notes that `interface.feedback: false` means no `user-feedback` scores reach Langfuse, since Langfuse is the only consumer of the ratings.

English sources only. The 13 locale copies are generated by `translate_docs.yml`.

The `config_v1.3.14` changelog entry is intentionally left out: `CONFIG_VERSION` was bumped to 1.3.14 upstream by the v0.8.8-rc1 prep, and this repo writes config changelogs in one batch at release-note time, the way `config_v1.3.13` landed with v0.8.7.

## Change Type

- [x] Documentation update

## Testing

- `pnpm lint:prettier` on the four changed files: clean
- `pnpm typecheck`: clean
- `pnpm test`: 313 passed, 22 files
- `pnpm build`: exit 0, compiled successfully, 2877/2877 static pages generated

Verified against the prerendered HTML rather than the source: the `feedback` section renders with an `id="feedback"` anchor and its YAML example, the `config` option table row is present, the Langfuse paragraph is present, and both cross-links resolve to real anchors (`langfuse#message-feedback-scores` and `interface#feedback`).

ESLint ignores `content/**`, so it reports the four files as ignored and has nothing to check there.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local checks pass with my changes
