### PR TITLE
📝 docs: Document VIOLATION_SCORE_TTL

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -1616,6 +1616,12 @@ see: **[Automated Moderation](/docs/configuration/mod_system)**
       'The user will be banned every time their score reaches/crosses over the interval threshold.',
       'BAN_INTERVAL=20',
     ],
+    [
+      'VIOLATION_SCORE_TTL',
+      'integer',
+      'How long a violation score lives without new violations (in milliseconds). Each new violation restarts the countdown, so scores decay after a quiet period instead of accumulating forever. Set to 0 to never expire scores (legacy behavior).',
+      'VIOLATION_SCORE_TTL=1000 * 60 * 60',
+    ],
   ]}
 />
 

--- a/content/docs/configuration/mod_system.mdx
+++ b/content/docs/configuration/mod_system.mdx
@@ -23,6 +23,7 @@ The following are all of the related env variables to make use of and configure 
     ['BAN_VIOLATIONS', 'boolean', 'Whether or not to enable banning users for violations (they will still be logged).','BAN_VIOLATIONS=true'],
     ['BAN_DURATION', 'integer', 'How long the user and associated IP are banned for (in milliseconds).','BAN_DURATION=1000 * 60 * 60 * 2'],
     ['BAN_INTERVAL', 'integer', 'The user will be banned every time their score reaches/crosses over the interval threshold.','BAN_INTERVAL=20'],
+    ['VIOLATION_SCORE_TTL', 'integer', 'How long a violation score lives without new violations (in milliseconds). Each new violation restarts the countdown, so scores decay after a quiet period instead of accumulating forever. Set to 0 to never expire scores (legacy behavior).','VIOLATION_SCORE_TTL=1000 * 60 * 60'],
   ]}
 />
 


### PR DESCRIPTION
Documents the `VIOLATION_SCORE_TTL` environment variable introduced in [danny-avila/LibreChat#15153](https://github.com/danny-avila/LibreChat/pull/15153) (merged to dev as `b6e3cf46d2`).

Violation scores previously never expired, so a user who crossed `BAN_INTERVAL` once remained one violation away from an instant re-ban forever. Scores now decay after a configurable quiet period — 1 hour by default, refreshed by each new violation, with `0` restoring the legacy never-expire behavior.

Added to the moderation-system page and the dotenv reference, English pages only, matching the row format of the adjacent ban settings.