### PR TITLE
docs: add OpenAI-compatible endpoint example to speech TTS config

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/speech.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/speech.mdx
@@ -96,6 +96,20 @@ tts:
     voices: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
 ```
 
+#### OpenAI-compatible endpoints
+
+The optional `url` field points the `openai` provider at any service that implements the OpenAI speech API. Set it to the service's full speech endpoint and configure the model and voices that service documents. For example, [Gandr](https://gandr.ai) accepts `tts-1` as the model and either the OpenAI voice names, which map onto its own voices, or its native voice ids:
+
+**Example:**
+```yaml filename="speech / tts / openai (custom url)"
+tts:
+  openai:
+    url: "https://tts.gandr.ai/v1/audio/speech"
+    apiKey: "${GANDR_API_KEY}"
+    model: "tts-1"
+    voices: ["gandr-mia", "gandr-ava", "gandr-jenny", "gandr-dane", "gandr-leo", "gandr-lewis"]
+```
+
 ### azureOpenAI
 
 Azure OpenAI TTS configuration.


### PR DESCRIPTION
The `tts.openai` option table documents `url` as "Use for OpenAI-compatible endpoints", but the page has no example of what a working config looks like, so operators have to guess whether `url` takes a base URL or the full speech path.

This adds one short subsection directly after the existing `openai` example: a `#### OpenAI-compatible endpoints` note plus one yaml block using Gandr as the concrete endpoint (`https://tts.gandr.ai/v1/audio/speech`). The values are real: the endpoint implements `POST /v1/audio/speech`, accepts `tts-1` as the model, maps the OpenAI voice names onto its own voices or takes its native voice ids, and returns mp3 by default, so LibreChat works with it unchanged. Nothing else on the page is touched.

Happy to drop the vendor mention and rewrite it with a placeholder host if you prefer a neutral example.

Disclosure: I work on Gandr.