### PR TITLE
docs: add OpenZoo endpoint guide

### DIFF
--- a/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/meta.json
@@ -21,6 +21,7 @@
     "neurochain",
     "ollama",
     "openrouter",
+    "openzoo",
     "perplexity",
     "portkey",
     "shuttleai",

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
@@ -3,18 +3,20 @@ title: OpenZoo
 description: Configure OpenZoo as a custom endpoint in LibreChat.
 ---
 
-[OpenZoo](https://openzoo.fun) provides an OpenAI-compatible endpoint with no
-signup — the API key can be any value, and usage is paid per request (by card,
-or automatically via the x402 protocol when using the local gateway).
+[OpenZoo](https://openzoo.fun) is an OpenAI-compatible provider with no
+account. A small local proxy (`npx openzoo`) pays for each request over the
+x402 protocol from a local burner wallet; LibreChat talks to the proxy like
+any other OpenAI-compatible endpoint.
 
 ## Configuration
 
-Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+Start the proxy with `npx openzoo` (it listens on `http://localhost:8402/v1`),
+then add the endpoint under `endpoints.custom` in your `librechat.yaml`:
 
 ```yaml filename="librechat.yaml"
     - name: "OpenZoo"
       apiKey: "sk-openzoo"
-      baseURL: "https://api.openzoo.fun/v1"
+      baseURL: "http://localhost:8402/v1"
       models:
         default:
           - "z-ai/glm-5.3-flash"
@@ -26,10 +28,13 @@ Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
 
 ## Notes
 
-- No account or signup: any API key value works; billing is per call.
+- The proxy ignores `apiKey`; any non-empty value works.
+- If LibreChat runs in Docker, use `baseURL: "http://host.docker.internal:8402/v1"`.
+- `npx openzoo address` prints the proxy's wallet — fund it with USDC on
+  Solana or Base; `npx openzoo balance` shows what is left.
 - With `fetch: true`, LibreChat loads the model list from `GET /v1/models`
   (free to fetch; ids are namespaced, like `z-ai/glm-5.3-flash`).
-- For a local gateway, run `npx openzoo` and set
-  `baseURL: "http://localhost:8402/v1"` — it pays per call from a local burner
-  wallet.
 - SSE streaming is supported.
+- The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless
+  the caller pays x402 or presents an OpenZoo subscription key
+  (`ozk_live_…`); LibreChat cannot pay x402 itself, so use the local proxy.

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
@@ -19,10 +19,10 @@ then add the endpoint under `endpoints.custom` in your `librechat.yaml`:
       baseURL: "http://localhost:8402/v1"
       models:
         default:
-          - "z-ai/glm-5.3-flash"
+          - "auto"
         fetch: true
       titleConvo: true
-      titleModel: "z-ai/glm-5.3-flash"
+      titleModel: "auto"
       modelDisplayLabel: "OpenZoo"
 ```
 
@@ -33,7 +33,8 @@ then add the endpoint under `endpoints.custom` in your `librechat.yaml`:
 - `npx openzoo address` prints the proxy's wallet — fund it with USDC on
   Solana or Base; `npx openzoo balance` shows what is left.
 - With `fetch: true`, LibreChat loads the model list from `GET /v1/models`
-  (free to fetch; ids are namespaced, like `z-ai/glm-5.3-flash`).
+  (free to fetch; ids are bare model names, like `claude-sonnet-5` or
+  `gpt-4o-mini`; `auto` lets the proxy pick a model per request).
 - SSE streaming is supported.
 - The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless
   the caller pays x402 or presents an OpenZoo subscription key

--- a/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
+++ b/content/docs/configuration/librechat_yaml/ai_endpoints/openzoo.mdx
@@ -1,0 +1,35 @@
+---
+title: OpenZoo
+description: Configure OpenZoo as a custom endpoint in LibreChat.
+---
+
+[OpenZoo](https://openzoo.fun) provides an OpenAI-compatible endpoint with no
+signup — the API key can be any value, and usage is paid per request (by card,
+or automatically via the x402 protocol when using the local gateway).
+
+## Configuration
+
+Add the endpoint under `endpoints.custom` in your `librechat.yaml`:
+
+```yaml filename="librechat.yaml"
+    - name: "OpenZoo"
+      apiKey: "sk-openzoo"
+      baseURL: "https://api.openzoo.fun/v1"
+      models:
+        default:
+          - "z-ai/glm-5.3-flash"
+        fetch: true
+      titleConvo: true
+      titleModel: "z-ai/glm-5.3-flash"
+      modelDisplayLabel: "OpenZoo"
+```
+
+## Notes
+
+- No account or signup: any API key value works; billing is per call.
+- With `fetch: true`, LibreChat loads the model list from `GET /v1/models`
+  (free to fetch; ids are namespaced, like `z-ai/glm-5.3-flash`).
+- For a local gateway, run `npx openzoo` and set
+  `baseURL: "http://localhost:8402/v1"` — it pays per call from a local burner
+  wallet.
+- SSE streaming is supported.


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

Adds a custom-endpoint guide for [OpenZoo](https://openzoo.fun) under `ai_endpoints/` plus its `meta.json` entry — the same shape as the merged NEAR AI guide (#668). English only per the automated i18n pipeline.

OpenZoo is OpenAI-compatible with no signup: a local `npx openzoo` proxy pays per call over x402 and ignores `apiKey`, so the yaml block on the page (baseURL `http://localhost:8402/v1`; `host.docker.internal` from Docker) works verbatim once the proxy is up. `fetch: true` pulls the live model list from `GET /v1/models` (free). The hosted endpoint is mentioned only as needing x402 or a subscription key.

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
