### PR TITLE
🔁 fix: Retry the Alias Transition Before Skipping a Cache Purge

### DIFF
--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -449,28 +449,27 @@ jobs:
         id: assets
         env:
           CACHE_PROBE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
-          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
           probe_log=$(mktemp)
+          degraded=false
           if node scripts/cache-build-assets.mjs > build-assets.txt 2> "$probe_log"; then
             cat "$probe_log" >&2
           else
-            probe_status=$?
-            if [ "$EVENT" != "workflow_dispatch" ]; then
-              cat "$probe_log" >&2
-              rm -f "$probe_log"
-              exit "$probe_status"
-            fi
-            # Manual dispatch is the escape hatch for a production/cache
-            # outage. Keep its already-computed broad prefixes and public asset
-            # targets usable even if one of the live page probes is unhealthy.
+            # Discovery retries through an alias transition on its own, so a
+            # failure here means the live site is unhealthy rather than mid-flip.
+            # Purging nothing is the worse answer: the broad prefixes and public
+            # asset targets computed above are still correct, and a degraded run
+            # records no purge marker, so the next deploy re-purges this range
+            # instead of stepping over it.
             sed 's/^::error::/::warning::/' "$probe_log" >&2
-            echo "::warning::Build-asset discovery failed; continuing with the manual recovery targets."
+            echo "::warning::Build-asset discovery failed; purging the recovery targets without the current build assets."
             : > build-assets.txt
+            degraded=true
           fi
           rm -f "$probe_log"
+          echo "degraded=$degraded" >> "$GITHUB_OUTPUT"
 
           cat build-assets.txt >> files.txt
           sort -u files.txt -o files.txt
@@ -490,6 +489,9 @@ jobs:
             echo "- prefixes: $prefix_count"
             echo "- exact URLs: $file_count"
             echo "- current build assets: $(wc -l < build-assets.txt)"
+            if [ "$degraded" = "true" ]; then
+              echo "- **degraded**: live discovery failed, no purge marker recorded"
+            fi
             echo
             echo '```'
             cat prefixes.txt files.txt
@@ -645,8 +647,11 @@ jobs:
       # next run picks its baseline from the newest deployment carrying one. A
       # run that fails leaves no marker, so the following run's diff widens to
       # include this one's range instead of stepping over it.
+      # A degraded run is the same case from the other direction: it purged the
+      # recovery targets but could not enumerate the current build assets, so it
+      # must not claim this SHA is known-good.
       - name: Record the purge against this commit
-        if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && github.event_name == 'deployment_status' }}
+        if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'deployment_status' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -459,12 +459,15 @@ jobs:
           else
             # Discovery retries through an alias transition on its own, so a
             # failure here means the live site is unhealthy rather than mid-flip.
-            # Purging nothing is the worse answer: the broad prefixes and public
-            # asset targets computed above are still correct, and a degraded run
-            # records no purge marker, so the next deploy re-purges this range
-            # instead of stepping over it.
+            # Escalate the selective plan to every page prefix and current public
+            # asset while retaining deleted URLs found by the original diff.
             sed 's/^::error::/::warning::/' "$probe_log" >&2
             echo "::warning::Build-asset discovery failed; purging the recovery targets without the current build assets."
+            node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json
+            jq -r '.prefixes[]' recovery.json >> prefixes.txt
+            jq -r '.files[]?' recovery.json >> files.txt
+            sort -u prefixes.txt -o prefixes.txt
+            sort -u files.txt -o files.txt
             : > build-assets.txt
             degraded=true
           fi

--- a/scripts/cache-build-assets.mjs
+++ b/scripts/cache-build-assets.mjs
@@ -256,8 +256,14 @@ async function fetchWithRetry(fetchImpl, url, init) {
   throw lastError
 }
 
+/**
+ * @template T, R
+ * @param {T[]} items
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @returns {Promise<R[]>}
+ */
 export async function mapConcurrent(items, worker) {
-  const results = new Array(items.length)
+  const results = /** @type {R[]} */ (new Array(items.length))
   let cursor = 0
 
   async function run() {

--- a/scripts/cache-build-assets.mjs
+++ b/scripts/cache-build-assets.mjs
@@ -46,6 +46,26 @@ const WEBPACK_RUNTIME_PATH = /\/static\/chunks\/webpack-[^/]+\.js$/u
 const REQUEST_TIMEOUT_MS = 15_000
 const MAX_CONCURRENCY = 8
 
+// A Vercel alias transition is directly observable: an asset that exists a
+// moment later answers 404 now, and shells fetched mid-flip disagree about
+// which build they came from. Both conditions are retryable. Anything else, an
+// unparseable runtime or a shell carrying no assets at all, is a real failure
+// and must not be retried into a timeout.
+const DISCOVERY_ATTEMPTS = 5
+const DISCOVERY_BACKOFF_MS = 10_000
+
+/** A retryable symptom of the production alias still moving. */
+export class DeploymentSkewError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'DeploymentSkewError'
+  }
+}
+
+function isWebpackRuntime(asset) {
+  return WEBPACK_RUNTIME_PATH.test(new URL(asset).pathname)
+}
+
 function decodeAttribute(value) {
   return value.replaceAll('&amp;', '&').replaceAll('&#38;', '&').replaceAll('&#x26;', '&')
 }
@@ -246,21 +266,36 @@ export async function discoverCurrentBuildAssets({
       { method: 'GET' },
     )
     if (!response.ok) {
-      throw new Error(`Fresh page probe failed for ${pageUrl.href}: HTTP ${response.status}`)
+      throw new DeploymentSkewError(
+        `Fresh page probe failed for ${pageUrl.href}: HTTP ${response.status}`,
+      )
     }
     return response.text()
   })
 
-  const shellAssets = [
-    ...new Set(pageResponses.flatMap((html) => extractBuildAssetUrls(html, origin))),
-  ].sort()
+  const shellAssetLists = pageResponses.map((html) => extractBuildAssetUrls(html, origin))
+  const shellAssets = [...new Set(shellAssetLists.flat())].sort()
   if (shellAssets.length === 0) {
     throw new Error('No Next.js build assets were found in the production page shells')
   }
 
-  const runtimes = shellAssets.filter((asset) => WEBPACK_RUNTIME_PATH.test(new URL(asset).pathname))
+  const runtimes = shellAssets.filter(isWebpackRuntime)
   if (runtimes.length === 0) {
     throw new Error('No Webpack runtime was found in the production page shells')
+  }
+
+  // Every shell of one build names the same runtime chunk. More than one answer
+  // across shells fetched together means the alias served two builds during
+  // this pass, so the union mixes both and its newest URLs may not be at the
+  // origin yet. Shells without a runtime are ignored rather than counted as a
+  // third answer.
+  const runtimeSignatures = new Set(
+    shellAssetLists.map((assets) => assets.filter(isWebpackRuntime).join(' ')).filter(Boolean),
+  )
+  if (runtimeSignatures.size > 1) {
+    throw new DeploymentSkewError(
+      `Production page shells disagree on the Webpack runtime (${[...runtimeSignatures].join(' vs ')}); the alias is still transitioning.`,
+    )
   }
 
   const runtimeResponses = await mapConcurrent(runtimes, async (runtime, index) => {
@@ -270,7 +305,9 @@ export async function discoverCurrentBuildAssets({
       { method: 'GET' },
     )
     if (!response.ok) {
-      throw new Error(`Fresh Webpack runtime probe failed for ${runtime}: HTTP ${response.status}`)
+      throw new DeploymentSkewError(
+        `Fresh Webpack runtime probe failed for ${runtime}: HTTP ${response.status}`,
+      )
     }
     return response.text()
   })
@@ -282,6 +319,43 @@ export async function discoverCurrentBuildAssets({
   return assets
 }
 
+/**
+ * Runs discovery, retrying only the symptoms of an in-flight alias swap.
+ *
+ * The first automatic purge after live asset discovery shipped failed exactly
+ * here: a shell fetched 15 seconds after Vercel reported ready still named the
+ * previous build's runtime, which the alias had already stopped serving, and
+ * the run aborted without purging anything. Retrying is what makes the settle
+ * window self-correcting instead of a guess.
+ *
+ * @param {NonNullable<Parameters<typeof discoverCurrentBuildAssets>[0]> & {
+ *   attempts?: number
+ *   backoffMs?: number
+ *   onRetry?: (error: Error, attempt: number) => void
+ *   sleepImpl?: (ms: number) => Promise<unknown>
+ * }} [options]
+ */
+export async function discoverCurrentBuildAssetsWithRetry({
+  attempts = DISCOVERY_ATTEMPTS,
+  backoffMs = DISCOVERY_BACKOFF_MS,
+  onRetry,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  ...options
+} = {}) {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await discoverCurrentBuildAssets({
+        ...options,
+        token: `${options.token ?? Date.now()}-attempt-${attempt}`,
+      })
+    } catch (error) {
+      if (!(error instanceof DeploymentSkewError) || attempt >= attempts) throw error
+      onRetry?.(error, attempt)
+      await sleepImpl(backoffMs * attempt)
+    }
+  }
+}
+
 async function main() {
   const token = process.env.CACHE_PROBE_TOKEN || `${Date.now()}-${process.pid}`
   const probePaths = process.env.CACHE_PROBE_PATHS
@@ -289,7 +363,15 @@ async function main() {
         .map((path) => path.trim())
         .filter(Boolean)
     : DEFAULT_PROBE_PATHS
-  const assets = await discoverCurrentBuildAssets({ probePaths, token })
+  const assets = await discoverCurrentBuildAssetsWithRetry({
+    probePaths,
+    token,
+    onRetry: (error, attempt) => {
+      process.stderr.write(
+        `::warning::Alias still transitioning on attempt ${attempt}: ${error.message} Retrying.\n`,
+      )
+    },
+  })
 
   process.stderr.write(
     `Collected ${assets.length} current build assets from ${probePaths.length} fresh page shells and their Webpack runtime.\n`,

--- a/scripts/cache-build-assets.mjs
+++ b/scripts/cache-build-assets.mjs
@@ -63,6 +63,18 @@ export class DeploymentSkewError extends Error {
   }
 }
 
+function probeFailure(message, status) {
+  const retryable =
+    status === 404 ||
+    status === 408 ||
+    status === 409 ||
+    status === 425 ||
+    status === 429 ||
+    status >= 500
+  const ErrorType = retryable ? DeploymentSkewError : Error
+  return new ErrorType(message)
+}
+
 function isWebpackRuntime(asset) {
   return WEBPACK_RUNTIME_PATH.test(new URL(asset).pathname)
 }
@@ -244,7 +256,7 @@ async function fetchWithRetry(fetchImpl, url, init) {
   throw lastError
 }
 
-async function mapConcurrent(items, worker) {
+export async function mapConcurrent(items, worker) {
   const results = new Array(items.length)
   let cursor = 0
 
@@ -257,7 +269,9 @@ async function mapConcurrent(items, worker) {
   }
 
   const workers = Array.from({ length: Math.min(MAX_CONCURRENCY, items.length) }, () => run())
-  await Promise.all(workers)
+  const settlements = await Promise.allSettled(workers)
+  const failure = settlements.find((settlement) => settlement.status === 'rejected')
+  if (failure) throw failure.reason
   return results
 }
 
@@ -275,8 +289,9 @@ export async function discoverCurrentBuildAssets({
       { method: 'GET' },
     )
     if (!response.ok) {
-      throw new DeploymentSkewError(
+      throw probeFailure(
         `Fresh page probe failed for ${pageUrl.href}: HTTP ${response.status}`,
+        response.status,
       )
     }
     return response.text()
@@ -293,14 +308,16 @@ export async function discoverCurrentBuildAssets({
   // Two answers across shells fetched together means the alias served two
   // builds during this pass, so the union mixes both and its newest URLs may
   // not be at the origin yet.
-  const buildSignatures = new Set(
-    pageResponses
-      .map(
-        (html, index) =>
-          extractDeploymentId(html) ?? shellAssetLists[index].filter(isWebpackRuntime).join(' '),
-      )
-      .filter(Boolean),
+  const shellSignatures = pageResponses.map(
+    (html, index) =>
+      extractDeploymentId(html) ?? shellAssetLists[index].filter(isWebpackRuntime).join(' '),
   )
+  if (shellSignatures.some((signature) => !signature)) {
+    throw new DeploymentSkewError(
+      'A production page shell has no deployment identity; the alias state cannot be verified.',
+    )
+  }
+  const buildSignatures = new Set(shellSignatures)
   if (buildSignatures.size > 1) {
     throw new DeploymentSkewError(
       `Production page shells came from more than one build (${[...buildSignatures].join(' vs ')}); the alias is still transitioning.`,
@@ -324,8 +341,9 @@ export async function discoverCurrentBuildAssets({
       { method: 'GET' },
     )
     if (!response.ok) {
-      throw new DeploymentSkewError(
+      throw probeFailure(
         `Fresh Webpack runtime probe failed for ${runtime}: HTTP ${response.status}`,
+        response.status,
       )
     }
     return response.text()

--- a/scripts/cache-build-assets.mjs
+++ b/scripts/cache-build-assets.mjs
@@ -1,6 +1,6 @@
 /**
- * Discovers build assets referenced by the current production page shells and
- * their Webpack runtime.
+ * Discovers build assets referenced by the current production page shells, plus
+ * the lazy-chunk map of their Webpack runtime when the build has one.
  *
  * A Vercel alias transition can briefly return a 404 for a new immutable
  * `/_next/static/**` URL. Cloudflare's cache rule may retain that 404 in one
@@ -43,6 +43,7 @@ export const DEFAULT_PROBE_PATHS = [
 const CACHE_PROBE_PARAM = '__librechat_cache_probe'
 const STATIC_PREFIX = '/_next/static/'
 const WEBPACK_RUNTIME_PATH = /\/static\/chunks\/webpack-[^/]+\.js$/u
+const DEPLOYMENT_ID_ATTRIBUTE = /<html\b[^>]*\bdata-dpl-id="([^"]+)"/iu
 const REQUEST_TIMEOUT_MS = 15_000
 const MAX_CONCURRENCY = 8
 
@@ -64,6 +65,14 @@ export class DeploymentSkewError extends Error {
 
 function isWebpackRuntime(asset) {
   return WEBPACK_RUNTIME_PATH.test(new URL(asset).pathname)
+}
+
+/**
+ * The deployment that rendered a shell, as published by Next.js when Skew
+ * Protection is on. Layout-independent, unlike the Webpack runtime name.
+ */
+export function extractDeploymentId(html) {
+  return html.match(DEPLOYMENT_ID_ATTRIBUTE)?.[1] ?? null
 }
 
 function decodeAttribute(value) {
@@ -279,23 +288,33 @@ export async function discoverCurrentBuildAssets({
     throw new Error('No Next.js build assets were found in the production page shells')
   }
 
-  const runtimes = shellAssets.filter(isWebpackRuntime)
-  if (runtimes.length === 0) {
-    throw new Error('No Webpack runtime was found in the production page shells')
+  // Every shell of one build reports the same identity: the Skew Protection
+  // deployment id when it is enabled, and otherwise the Webpack runtime chunk.
+  // Two answers across shells fetched together means the alias served two
+  // builds during this pass, so the union mixes both and its newest URLs may
+  // not be at the origin yet.
+  const buildSignatures = new Set(
+    pageResponses
+      .map(
+        (html, index) =>
+          extractDeploymentId(html) ?? shellAssetLists[index].filter(isWebpackRuntime).join(' '),
+      )
+      .filter(Boolean),
+  )
+  if (buildSignatures.size > 1) {
+    throw new DeploymentSkewError(
+      `Production page shells came from more than one build (${[...buildSignatures].join(' vs ')}); the alias is still transitioning.`,
+    )
   }
 
-  // Every shell of one build names the same runtime chunk. More than one answer
-  // across shells fetched together means the alias served two builds during
-  // this pass, so the union mixes both and its newest URLs may not be at the
-  // origin yet. Shells without a runtime are ignored rather than counted as a
-  // third answer.
-  const runtimeSignatures = new Set(
-    shellAssetLists.map((assets) => assets.filter(isWebpackRuntime).join(' ')).filter(Boolean),
-  )
-  if (runtimeSignatures.size > 1) {
-    throw new DeploymentSkewError(
-      `Production page shells disagree on the Webpack runtime (${[...runtimeSignatures].join(' vs ')}); the alias is still transitioning.`,
-    )
+  // Turbopack builds serve `/_next/static/immutable/**` and ship no Webpack
+  // runtime, so there is no lazy-chunk map to expand. The shells still name
+  // every eagerly loaded chunk, which is the set a deploy must purge; lazily
+  // loaded chunks rely on the zone's no-store rule for 4xx responses instead of
+  // on enumeration.
+  const runtimes = shellAssets.filter(isWebpackRuntime)
+  if (runtimes.length === 0) {
+    return shellAssets
   }
 
   const runtimeResponses = await mapConcurrent(runtimes, async (runtime, index) => {
@@ -373,9 +392,17 @@ async function main() {
     },
   })
 
-  process.stderr.write(
-    `Collected ${assets.length} current build assets from ${probePaths.length} fresh page shells and their Webpack runtime.\n`,
-  )
+  if (assets.some(isWebpackRuntime)) {
+    process.stderr.write(
+      `Collected ${assets.length} current build assets from ${probePaths.length} fresh page shells and their Webpack runtime.\n`,
+    )
+  } else {
+    // Loud on purpose: this build's lazily loaded chunks are not in the purge
+    // set, so they depend entirely on the zone never caching a 4xx.
+    process.stderr.write(
+      `::warning::Collected ${assets.length} eagerly referenced build assets from ${probePaths.length} fresh page shells. This build ships no Webpack runtime, so its lazy-chunk map could not be expanded.\n`,
+    )
+  }
   process.stdout.write(`${assets.join('\n')}\n`)
 }
 

--- a/scripts/cache-build-assets.test.ts
+++ b/scripts/cache-build-assets.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_PROBE_PATHS,
+  DeploymentSkewError,
   discoverCurrentBuildAssets,
+  discoverCurrentBuildAssetsWithRetry,
   extractBuildAssetUrls,
   extractWebpackRuntimeAssetUrls,
   withCacheProbe,
@@ -154,5 +156,84 @@ describe('discoverCurrentBuildAssets', () => {
     await expect(
       discoverCurrentBuildAssets({ fetchImpl, origin, probePaths: ['/'], token: 'test' }),
     ).rejects.toThrow('No Next.js build assets')
+  })
+})
+
+describe('discoverCurrentBuildAssetsWithRetry', () => {
+  const runtimeSource =
+    'r.u=e=>"static/chunks/"+e+"."+({42:"lazyhash"})[e]+".js",' +
+    'r.miniCssF=e=>"static/css/lazy.css",r.g={}'
+
+  it('retries through an alias transition instead of aborting the purge', async () => {
+    let runtimeRequests = 0
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const { pathname } = toUrl(input)
+      if (pathname.startsWith('/_next/')) {
+        runtimeRequests += 1
+        return runtimeRequests === 1
+          ? new Response(null, { status: 404 })
+          : new Response(runtimeSource)
+      }
+      return new Response('<script src="/_next/static/chunks/webpack-new.js"></script>')
+    })
+    const sleepImpl = vi.fn(async () => {})
+    const onRetry = vi.fn()
+
+    await expect(
+      discoverCurrentBuildAssetsWithRetry({
+        fetchImpl,
+        origin,
+        probePaths: ['/'],
+        token: 'test',
+        backoffMs: 1,
+        sleepImpl,
+        onRetry,
+      }),
+    ).resolves.toEqual([
+      `${origin}/_next/static/chunks/42.lazyhash.js`,
+      `${origin}/_next/static/chunks/webpack-new.js`,
+      `${origin}/_next/static/css/lazy.css`,
+    ])
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(sleepImpl).toHaveBeenCalledWith(1)
+  })
+
+  it('treats shells naming different runtimes as a transition, and gives up', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const { pathname } = toUrl(input)
+      if (pathname.startsWith('/_next/')) return new Response(runtimeSource)
+      const build = pathname === '/' ? 'old' : 'new'
+      return new Response(`<script src="/_next/static/chunks/webpack-${build}.js"></script>`)
+    })
+
+    const error = await discoverCurrentBuildAssetsWithRetry({
+      fetchImpl,
+      origin,
+      probePaths: ['/', '/docs'],
+      token: 'test',
+      attempts: 2,
+      backoffMs: 1,
+      sleepImpl: async () => {},
+    }).catch((reason: unknown) => reason)
+
+    expect(error).toBeInstanceOf(DeploymentSkewError)
+    expect((error as Error).message).toContain('disagree on the Webpack runtime')
+  })
+
+  it('does not retry a failure a later attempt cannot fix', async () => {
+    const fetchImpl = vi.fn(async () => new Response('<main>No scripts</main>'))
+    const sleepImpl = vi.fn(async () => {})
+
+    await expect(
+      discoverCurrentBuildAssetsWithRetry({
+        fetchImpl,
+        origin,
+        probePaths: ['/'],
+        token: 'test',
+        sleepImpl,
+      }),
+    ).rejects.toThrow('No Next.js build assets')
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(sleepImpl).not.toHaveBeenCalled()
   })
 })

--- a/scripts/cache-build-assets.test.ts
+++ b/scripts/cache-build-assets.test.ts
@@ -4,6 +4,7 @@ import {
   DeploymentSkewError,
   discoverCurrentBuildAssets,
   discoverCurrentBuildAssetsWithRetry,
+  mapConcurrent,
   extractBuildAssetUrls,
   extractDeploymentId,
   extractWebpackRuntimeAssetUrls,
@@ -231,6 +232,37 @@ describe('discoverCurrentBuildAssetsWithRetry', () => {
     expect(sleepImpl).toHaveBeenCalledWith(1)
   })
 
+  it('drains a failed probe batch before returning its error', async () => {
+    const slowProbe = Promise.withResolvers<void>()
+    const allWorkersStarted = Promise.withResolvers<void>()
+    let started = 0
+    let batchSettled = false
+
+    const batch = mapConcurrent(['fast failure', 'slow probe'], async (item) => {
+      started += 1
+      if (started === 2) allWorkersStarted.resolve()
+      if (item === 'fast failure') throw new Error('probe failed')
+      await slowProbe.promise
+      return item
+    })
+    void batch.then(
+      () => {
+        batchSettled = true
+      },
+      () => {
+        batchSettled = true
+      },
+    )
+
+    await allWorkersStarted.promise
+    await Promise.resolve()
+    expect(batchSettled).toBe(false)
+
+    slowProbe.resolve()
+    await expect(batch).rejects.toThrow('probe failed')
+    expect(batchSettled).toBe(true)
+  })
+
   it('treats shells from different builds as a transition, and gives up', async () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const { pathname } = toUrl(input)
@@ -278,6 +310,67 @@ describe('discoverCurrentBuildAssetsWithRetry', () => {
 
     expect(error).toBeInstanceOf(DeploymentSkewError)
     expect((error as Error).message).toContain('dpl_old vs dpl_new')
+  })
+
+  it('rejects immutable shells without a deployment identity', async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response('<script src="/_next/static/immutable/chunks/page.js"></script>'),
+    )
+
+    const error = await discoverCurrentBuildAssetsWithRetry({
+      fetchImpl,
+      origin,
+      probePaths: ['/'],
+      token: 'test',
+      attempts: 2,
+      backoffMs: 1,
+      sleepImpl: async () => {},
+    }).catch((reason: unknown) => reason)
+
+    expect(error).toBeInstanceOf(DeploymentSkewError)
+    expect((error as Error).message).toContain('no deployment identity')
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a permanent page-probe response', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 401 }))
+    const sleepImpl = vi.fn(async () => {})
+
+    await expect(
+      discoverCurrentBuildAssetsWithRetry({
+        fetchImpl,
+        origin,
+        probePaths: ['/'],
+        token: 'test',
+        sleepImpl,
+      }),
+    ).rejects.toThrow('HTTP 401')
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(sleepImpl).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a permanent runtime-probe response', async () => {
+    let runtimeRequests = 0
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      if (toUrl(input).pathname.startsWith('/_next/')) {
+        runtimeRequests += 1
+        return new Response(null, { status: 403 })
+      }
+      return new Response('<script src="/_next/static/chunks/webpack-test.js"></script>')
+    })
+    const sleepImpl = vi.fn(async () => {})
+
+    await expect(
+      discoverCurrentBuildAssetsWithRetry({
+        fetchImpl,
+        origin,
+        probePaths: ['/'],
+        token: 'test',
+        sleepImpl,
+      }),
+    ).rejects.toThrow('HTTP 403')
+    expect(runtimeRequests).toBe(1)
+    expect(sleepImpl).not.toHaveBeenCalled()
   })
 
   it('does not retry a failure a later attempt cannot fix', async () => {

--- a/scripts/cache-build-assets.test.ts
+++ b/scripts/cache-build-assets.test.ts
@@ -5,6 +5,7 @@ import {
   discoverCurrentBuildAssets,
   discoverCurrentBuildAssetsWithRetry,
   extractBuildAssetUrls,
+  extractDeploymentId,
   extractWebpackRuntimeAssetUrls,
   withCacheProbe,
 } from './cache-build-assets.mjs'
@@ -57,6 +58,13 @@ describe('extractBuildAssetUrls', () => {
       'https://www.librechat.ai/_next/static/chunks/webpack-123.js',
       'https://www.librechat.ai/_next/static/css/app.css?x=1&y=2',
     ])
+  })
+})
+
+describe('extractDeploymentId', () => {
+  it('reads the deployment id Next.js publishes on the html element', () => {
+    expect(extractDeploymentId('<html data-dpl-id="dpl_abc" lang="en">')).toBe('dpl_abc')
+    expect(extractDeploymentId('<html lang="en">')).toBeNull()
   })
 })
 
@@ -157,6 +165,31 @@ describe('discoverCurrentBuildAssets', () => {
       discoverCurrentBuildAssets({ fetchImpl, origin, probePaths: ['/'], token: 'test' }),
     ).rejects.toThrow('No Next.js build assets')
   })
+
+  /**
+   * A Turbopack build serves `/_next/static/immutable/**` and ships no Webpack
+   * runtime, so there is no lazy-chunk map. Discovery must return the eager
+   * shell assets rather than failing, and must not invent a runtime request.
+   */
+  it('accepts a Turbopack build with no Webpack runtime', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          '<html data-dpl-id="dpl_test">' +
+            '<link href="/_next/static/immutable/chunks/style.css" rel="stylesheet">' +
+            '<script src="/_next/static/immutable/chunks/page.js"></script>' +
+            '</html>',
+        ),
+    )
+
+    await expect(
+      discoverCurrentBuildAssets({ fetchImpl, origin, probePaths: ['/'], token: 'test' }),
+    ).resolves.toEqual([
+      `${origin}/_next/static/immutable/chunks/page.js`,
+      `${origin}/_next/static/immutable/chunks/style.css`,
+    ])
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('discoverCurrentBuildAssetsWithRetry', () => {
@@ -198,7 +231,7 @@ describe('discoverCurrentBuildAssetsWithRetry', () => {
     expect(sleepImpl).toHaveBeenCalledWith(1)
   })
 
-  it('treats shells naming different runtimes as a transition, and gives up', async () => {
+  it('treats shells from different builds as a transition, and gives up', async () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const { pathname } = toUrl(input)
       if (pathname.startsWith('/_next/')) return new Response(runtimeSource)
@@ -217,7 +250,34 @@ describe('discoverCurrentBuildAssetsWithRetry', () => {
     }).catch((reason: unknown) => reason)
 
     expect(error).toBeInstanceOf(DeploymentSkewError)
-    expect((error as Error).message).toContain('disagree on the Webpack runtime')
+    expect((error as Error).message).toContain('came from more than one build')
+  })
+
+  /**
+   * Turbopack builds carry no Webpack runtime, so the deployment id published
+   * by Skew Protection is the only shell identity available mid-transition.
+   */
+  it('detects a transition from disagreeing deployment ids', async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const { pathname } = toUrl(input)
+      const id = pathname === '/' ? 'dpl_old' : 'dpl_new'
+      return new Response(
+        `<html data-dpl-id="${id}"><script src="/_next/static/immutable/chunks/a.js"></script></html>`,
+      )
+    })
+
+    const error = await discoverCurrentBuildAssetsWithRetry({
+      fetchImpl,
+      origin,
+      probePaths: ['/', '/docs'],
+      token: 'test',
+      attempts: 2,
+      backoffMs: 1,
+      sleepImpl: async () => {},
+    }).catch((reason: unknown) => reason)
+
+    expect(error).toBeInstanceOf(DeploymentSkewError)
+    expect((error as Error).message).toContain('dpl_old vs dpl_new')
   })
 
   it('does not retry a failure a later attempt cannot fix', async () => {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -203,16 +203,21 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
-   * An operator uses workflow_dispatch to recover an unhealthy production
-   * site. A failed live probe must not prevent the broad page/public targets
-   * computed earlier in the job from reaching Cloudflare.
+   * Discovery retries an in-flight alias swap on its own, so a failure that
+   * survives those retries means the live site is unhealthy, not mid-flip.
+   * Every run, automatic or manual, must still send the broad page/public
+   * targets computed earlier in the job to Cloudflare, and a run that could not
+   * enumerate the current build assets must leave no purge marker behind.
    */
-  it('keeps manual recovery targets when build-asset discovery fails', () => {
-    expect(workflow).toContain('if [ "$EVENT" != "workflow_dispatch" ]; then')
+  it('degrades instead of aborting when build-asset discovery fails', () => {
     expect(workflow).toContain(': > build-assets.txt')
+    expect(workflow).toContain('degraded=true')
+    expect(workflow).toContain('echo "degraded=$degraded" >> "$GITHUB_OUTPUT"')
     expect(workflow).toContain(
-      'Build-asset discovery failed; continuing with the manual recovery targets.',
+      'Build-asset discovery failed; purging the recovery targets without the current build assets.',
     )
+    expect(workflow).not.toContain('if [ "$EVENT" != "workflow_dispatch" ]; then')
+    expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
   it('accepts a baseline only when its deployment-specific purge marker exists', () => {

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -124,7 +124,7 @@ describe('parseArgs', () => {
       },
     )
 
-    expect(invocations).toHaveLength(2)
+    expect(invocations).toHaveLength(3)
     for (const argv of invocations) {
       expect(argv.length).toBeGreaterThan(0)
       expect(() => parseArgs(argv)).not.toThrow()
@@ -216,6 +216,11 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain(
       'Build-asset discovery failed; purging the recovery targets without the current build assets.',
     )
+    expect(workflow).toContain(
+      'node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json',
+    )
+    expect(workflow).toContain("jq -r '.prefixes[]' recovery.json >> prefixes.txt")
+    expect(workflow).toContain("jq -r '.files[]?' recovery.json >> files.txt")
     expect(workflow).not.toContain('if [ "$EVENT" != "workflow_dispatch" ]; then')
     expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })


### PR DESCRIPTION
## Summary

Follow-up to #742. Its first production purge failed during Vercel's alias transition.

- Retry fresh 404s and cross-shell build disagreement up to 5 times with linear backoff.
- Drain every active probe worker before another discovery attempt starts.
- Retry only transition-compatible HTTP responses; permanent 401/403 responses fail immediately.
- Require every no-runtime shell to expose a Skew Protection deployment identity.
- Support both Webpack runtime maps and `/_next/static/immutable/**` deployments.
- On discovery failure, union broad page and public-asset recovery targets into the original diff and suppress the successful purge marker.

Stacked follow-up #745 migrates the automatic trigger to Vercel's enriched promotion event and removes build-asset probes from normal deployments.

## Root cause

Run [33258912546](https://github.com/LibreChat-AI/librechat.ai/actions/runs/33258912546), the `deployment_status` purge for #742's merge commit, failed at `Collect current build assets`:

```
::error::Fresh Webpack runtime probe failed for
  https://www.librechat.ai/_next/static/chunks/webpack-d866b33691ef39b9.js: HTTP 404
```

A shell fetched 15 seconds after Vercel reported ready still came from the old deployment, whose runtime the alias had stopped serving. The step exited 1, `Purge` was skipped, and the newly deployed assets kept the poisoned edge entries reported in [discussion 15331](https://github.com/danny-avila/LibreChat/discussions/15331). Production stayed broken in eastern North America until manual run [33525780255](https://github.com/LibreChat-AI/librechat.ai/actions/runs/33525780255) purged 27 prefixes and 120 URLs.

The Cloudflare rule that retained those 404s for a month now applies no-store to status `>= 400`. Repeated missing `/_next/static` requests return 404 with `cf-cache-status: BYPASS`, not `HIT`.

## Change Type

Bug fix (non-breaking).

## Testing

- `pnpm test`: 391 tests across 33 files on this branch.
- `pnpm typecheck`.
- `npx eslint scripts/cache-build-assets.mjs scripts/cache-build-assets.test.ts scripts/cache-purge-prefixes.test.ts`.
- `npx prettier --check .github/workflows/cache-purge.yml scripts/cache-build-assets.mjs scripts/cache-build-assets.test.ts scripts/cache-purge-prefixes.test.ts`.
- Workflow YAML parsed with PyYAML; every embedded `run` block passed `bash -n`.
- Earlier live smoke run of `node scripts/cache-build-assets.mjs` against production completed with 96 assets from 21 shells.

## Checklist

- [x] Tests cover retry boundaries, worker draining, status classification, shell identity, and degraded recovery.
- [x] Lint, format, and typecheck pass.
- [x] No user-facing content or UI changes.