### PR TITLE
🔁 fix: Use Vercel Promotion Events for Cache Purges

### DIFF
--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -67,8 +67,8 @@ on:
 
 permissions:
   contents: read
-  # Writing the "this Vercel deployment was purged" marker that the next run
-  # baselines from, so a failed purge is retried rather than skipped past.
+  # Recording trusted production promotions and completed purges. Separate
+  # markers preserve rollback history even when a purge fails.
   statuses: write
 
 # Keyed per Vercel deployment, NOT a single shared group. GitHub keeps at most
@@ -103,6 +103,8 @@ env:
   # (`cache-purge/dpl_...`), while the description begins with the workflow run
   # number and promoted SHA. The sequence survives overlap, rollback, and rerun.
   PURGE_STATUS_CONTEXT: cache-purge
+  # Written as soon as a trusted event is accepted, before purge planning.
+  PROMOTION_STATUS_CONTEXT: cache-promotion
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
   # page set; its job is to surface deletions, which a range-less run cannot see.
@@ -175,6 +177,28 @@ jobs:
             echo "::error::The promoted SHA is not part of the current main history."
             exit 1
           fi
+
+      # Promotion and purge success are separate facts. Record the trusted
+      # production transition before planning so a failed or cancelled purge
+      # still leaves enough chronology for a later rollback to recover safely.
+      - name: Record promoted deployment
+        if: github.event_name == 'repository_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ steps.event.outputs.head }}
+          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
+          gh api -X POST "repos/$REPO/statuses/$ledger_sha" \
+            -f state=success \
+            -f context="$PROMOTION_STATUS_CONTEXT/$DEPLOYMENT_ID" \
+            -f target_url="$RUN_URL" \
+            -f description="$RUN_NUMBER|$SHA|Promoted" \
+            > /dev/null
       # Resolve what to map. Three cases:
       #   dispatch + broad           -> broad set, no diff
       #   dispatch + explicit range  -> that range
@@ -191,8 +215,10 @@ jobs:
           INPUT_RANGE: ${{ inputs.range }}
           HEAD_SHA: ${{ steps.event.outputs.head }}
           DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
+          CURRENT_RUN_NUMBER: ${{ github.run_number }}
           REPO: ${{ github.repository }}
           PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
+          PROMOTION_STATUS_CONTEXT: ${{ env.PROMOTION_STATUS_CONTEXT }}
         run: |
           set -euo pipefail
 
@@ -252,24 +278,42 @@ jobs:
               exit 1
             fi
 
-            # All successful promotions write to one stable commit-status
-            # ledger. Workflow run numbers are assigned at event delivery, so
-            # they preserve promotion order when concurrent purges finish out of
-            # order. Git ancestry cannot do that for a rollback from C to B.
-            # Skip markers for the same SHA so a rebuild still compares against
-            # the previous distinct deployed tree. Only the newest 100 markers
-            # are needed; otherwise broad recovery is safer than an unbounded
-            # status-history request.
+            # Promotion markers describe what served production. Purge markers
+            # describe which diff was successfully cleared. Run numbers order
+            # both facts at event delivery, even when concurrent jobs complete
+            # in the opposite order.
             ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
             status_file="purge-ledger.json"
             gh api "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"
-            base=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$head" "$PURGE_STATUS_CONTEXT")
+            ledger_state=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$head" "$CURRENT_RUN_NUMBER" "$PURGE_STATUS_CONTEXT" "$PROMOTION_STATUS_CONTEXT")
+            base=$(jq -r '.base // empty' <<< "$ledger_state")
+            previous=$(jq -r '.previous // empty' <<< "$ledger_state")
 
             if [ -n "$base" ]; then
               echo "Baseline: $base, latest successfully purged Vercel deployment."
-            else
-              # Includes the first run after introducing the chronological
-              # deployment ledger.
+            fi
+
+            # A forward deployment can widen from the last successful purge and
+            # cover failed intermediate runs. A non-forward transition cannot:
+            # its prior production tree may contain routes absent from both the
+            # successful baseline and current checkout. Diff that predecessor
+            # while broad recovery covers the current tree.
+            if [ -n "$previous" ] && [ "$previous" != "$base" ]; then
+              if ! git cat-file -e "${previous}^{commit}" 2>/dev/null; then
+                echo "::warning::Previous promotion $previous is unreachable; purging broadly."
+                emit mode broad
+                exit 0
+              fi
+              if ! git merge-base --is-ancestor "$previous" "$head"; then
+                echo "::warning::Previous promotion was not purged and is not an ancestor of this deployment; purging broad recovery targets plus $previous..$head."
+                emit mode broad
+                emit base "$previous"
+                emit head "$head"
+                exit 0
+              fi
+            fi
+
+            if [ -z "$base" ]; then
               echo "No earlier successfully purged Vercel deployment found."
               fallback_range "$head" && exit 0
               echo "::warning::No baseline and no fallback window; purging broadly."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -1,4 +1,6 @@
 name: Cloudflare Cache Purge
+run-name: >-
+  cache-purge:${{ github.event.client_payload.environment || 'manual' }}:${{ github.event.client_payload.project.id || 'manual' }}:${{ github.event.client_payload.git.ref || 'manual' }}:${{ github.event.client_payload.git.sha || github.sha }}:${{ github.event.client_payload.id || github.run_id }}
 
 # Purges the Cloudflare edge cache for the pages a production deploy actually
 # changed, so a docs edit is visible immediately instead of waiting out the 24h
@@ -66,9 +68,9 @@ on:
         required: false
 
 permissions:
+  actions: read
   contents: read
-  # Recording trusted production promotions and completed purges. Separate
-  # markers preserve rollback history even when a purge fails.
+  # Successful automatic purges are durable known-good checkpoints.
   statuses: write
 
 # Keyed per Vercel deployment, NOT a single shared group. GitHub keeps at most
@@ -103,8 +105,6 @@ env:
   # (`cache-purge/dpl_...`), while the description begins with the workflow run
   # number and promoted SHA. The sequence survives overlap, rollback, and rerun.
   PURGE_STATUS_CONTEXT: cache-purge
-  # Written as soon as a trusted event is accepted, before purge planning.
-  PROMOTION_STATUS_CONTEXT: cache-promotion
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
   # page set; its job is to surface deletions, which a range-less run cannot see.
@@ -178,34 +178,14 @@ jobs:
             exit 1
           fi
 
-      # Promotion and purge success are separate facts. Record the trusted
-      # production transition before planning so a failed or cancelled purge
-      # still leaves enough chronology for a later rollback to recover safely.
-      - name: Record promoted deployment
-        if: github.event_name == 'repository_dispatch'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ steps.event.outputs.head }}
-          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
-          RUN_NUMBER: ${{ github.run_number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
-          gh api -X POST "repos/$REPO/statuses/$ledger_sha" \
-            -f state=success \
-            -f context="$PROMOTION_STATUS_CONTEXT/$DEPLOYMENT_ID" \
-            -f target_url="$RUN_URL" \
-            -f description="$RUN_NUMBER|$SHA|Promoted" \
-            > /dev/null
       # Resolve what to map. Three cases:
       #   dispatch + broad           -> broad set, no diff
       #   dispatch + explicit range  -> that range
-      #   Vercel promotion           -> last successfully purged commit .. this one
+      #   Vercel promotion           -> last known-good purge .. this commit
       #
-      # Diffing promotion-to-promotion covers every commit that actually shipped,
-      # including commits whose intermediate Vercel builds were superseded.
+      # Automatic runs reconcile every intervening workflow run before using a
+      # selective range. Run names capture Vercel routing data when GitHub
+      # creates the run, so queued and cancelled predecessors stay visible.
       - name: Resolve diff range
         id: range
         env:
@@ -218,7 +198,6 @@ jobs:
           CURRENT_RUN_NUMBER: ${{ github.run_number }}
           REPO: ${{ github.repository }}
           PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
-          PROMOTION_STATUS_CONTEXT: ${{ env.PROMOTION_STATUS_CONTEXT }}
         run: |
           set -euo pipefail
 
@@ -278,58 +257,57 @@ jobs:
               exit 1
             fi
 
-            # Promotion markers describe what served production. Purge markers
-            # describe which diff was successfully cleared. Run numbers order
-            # both facts at event delivery, even when concurrent jobs complete
-            # in the opposite order.
+            # A successful purge is the only known-good cache checkpoint.
+            # `run-name` records each dispatch before a runner starts, and the
+            # Actions API exposes it as `display_title`. Any intervening
+            # production run, missing run number, or malformed title means an
+            # earlier production tree may still be cached. Fail closed to one
+            # exceptional full purge rather than guess a selective range.
             ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
             status_file="purge-ledger.json"
-            gh api "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"
-            ledger_state=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$head" "$CURRENT_RUN_NUMBER" "$PURGE_STATUS_CONTEXT" "$PROMOTION_STATUS_CONTEXT")
-            base=$(jq -r '.base // empty' <<< "$ledger_state")
-            previous=$(jq -r '.previous // empty' <<< "$ledger_state")
-
-            if [ -n "$base" ]; then
-              echo "Baseline: $base, latest successfully purged Vercel deployment."
-            fi
-
-            # A forward deployment can widen from the last successful purge and
-            # cover failed intermediate runs. A non-forward transition cannot:
-            # its prior production tree may contain routes absent from both the
-            # successful baseline and current checkout. Diff that predecessor
-            # while broad recovery covers the current tree.
-            if [ -n "$previous" ] && [ "$previous" != "$base" ]; then
-              if ! git cat-file -e "${previous}^{commit}" 2>/dev/null; then
-                echo "::warning::Previous promotion $previous is unreachable; purging broadly."
-                emit mode broad
-                exit 0
-              fi
-              if ! git merge-base --is-ancestor "$previous" "$head"; then
-                echo "::warning::Previous promotion was not purged and is not an ancestor of this deployment; purging broad recovery targets plus $previous..$head."
-                emit mode broad
-                emit base "$previous"
-                emit head "$head"
-                exit 0
-              fi
-            fi
-
-            if [ -z "$base" ]; then
-              echo "No earlier successfully purged Vercel deployment found."
-              fallback_range "$head" && exit 0
-              echo "::warning::No baseline and no fallback window; purging broadly."
-              emit mode broad
+            workflow_runs_file="purge-workflow-runs.json"
+            if ! gh api --paginate --slurp "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"; then
+              echo "::warning::Could not read the purge checkpoint ledger; purging the full zone."
+              emit mode full
               exit 0
             fi
+            if ! gh api --paginate --slurp "repos/$REPO/actions/workflows/cache-purge.yml/runs?per_page=100" > "$workflow_runs_file"; then
+              echo "::warning::Could not reconcile earlier cache-purge runs; purging the full zone."
+              emit mode full
+              exit 0
+            fi
+
+            ledger_state=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$workflow_runs_file" "$head" "$CURRENT_RUN_NUMBER" "$PURGE_STATUS_CONTEXT")
+            base=$(jq -r '.base // empty' <<< "$ledger_state")
+            unsafe=$(jq -r '.unsafe | length' <<< "$ledger_state")
+
+            if [ "$unsafe" -ne 0 ]; then
+              unsafe_runs=$(jq -r '.unsafe | join(", ")' <<< "$ledger_state")
+              echo "::warning::Earlier workflow run(s) $unsafe_runs may represent an unpurged production transition; purging the full zone."
+              emit mode full
+              exit 0
+            fi
+            if [ -z "$base" ]; then
+              echo "::warning::No known-good automatic purge checkpoint exists; purging the full zone."
+              emit mode full
+              exit 0
+            fi
+            echo "Baseline: $base, latest known-good automatic purge."
           fi
 
           # A force-push or rollback can leave the baseline outside the promoted
           # commit's ancestry. Fetch main once so a newer prior deployment is
-          # available for a reverse diff, then degrade safely if it is still
-          # unreachable.
+          # available for a reverse diff. An automatic run with no reachable
+          # checkpoint cannot prove which assets were previously live.
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             git fetch --no-tags origin main || true
           fi
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            if [ "$EVENT" = "repository_dispatch" ]; then
+              echo "::warning::Known-good checkpoint $base is unreachable; purging the full zone."
+              emit mode full
+              exit 0
+            fi
             echo "Base commit $base is not reachable in this checkout."
             fallback_range "$head" && exit 0
             echo "::warning::No fallback window either; purging broadly."
@@ -337,8 +315,13 @@ jobs:
             exit 0
           fi
           if ! git cat-file -e "${head}^{commit}" 2>/dev/null; then
-            echo "::warning::Head commit $head is not reachable in this checkout; purging broadly."
-            emit mode broad
+            if [ "$EVENT" = "repository_dispatch" ]; then
+              echo "::warning::Promoted commit $head is unreachable; purging the full zone."
+              emit mode full
+            else
+              echo "::warning::Head commit $head is not reachable; purging broadly."
+              emit mode broad
+            fi
             exit 0
           fi
 
@@ -360,14 +343,19 @@ jobs:
           MODE: ${{ steps.range.outputs.mode }}
           BASE: ${{ steps.range.outputs.base }}
           HEAD: ${{ steps.range.outputs.head }}
+          FALLBACK_I18N_FILE: ../workflow-source/lib/i18n.ts
         run: |
           set -euo pipefail
 
-          # No range to work from: a manual run without one, an unreachable base,
-          # or no previously purged deployment. --assets covers public/ wholesale
-          # because nothing here can tell which asset changed, and these are the
-          # runs that exist precisely because something already went wrong.
-          if [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
+          # A chronology hole has no recoverable promoted SHA. Use Cloudflare's
+          # explicit full-zone operation rather than pretending the current tree
+          # can enumerate assets that existed only in that missing deployment.
+          if [ "$MODE" = "full" ]; then
+            jq -n '{prefixes: [], files: [], broad: true, collapsed: false}' > purge.json
+          # No range to work from: a manual run without one or an unreachable
+          # input. --assets covers public/ wholesale because a range-less mapper
+          # cannot tell which asset changed.
+          elif [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
             node ../workflow-source/scripts/cache-purge-prefixes.mjs --broad --assets --json > purge.json
           else
             # Broad *with* a range still walks the diff, so the broad page set
@@ -432,7 +420,13 @@ jobs:
           broad=$(jq -r '.broad' purge.json)
           collapsed=$(jq -r '.collapsed' purge.json)
 
-          echo "mode=$([ "$broad" = "true" ] && echo broad || echo selective)" >> "$GITHUB_OUTPUT"
+          if [ "$MODE" = "full" ]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=$([ "$broad" = "true" ] && echo broad || echo selective)" >> "$GITHUB_OUTPUT"
+            echo "full=false" >> "$GITHUB_OUTPUT"
+          fi
           echo "collapsed=$collapsed" >> "$GITHUB_OUTPUT"
 
       # Automatic promotions purge only the changed HTML/RSC prefixes and
@@ -447,6 +441,7 @@ jobs:
         env:
           CACHE_PROBE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
           EVENT: ${{ github.event_name }}
+          FULL: ${{ steps.compute.outputs.full }}
         run: |
           set -euo pipefail
 
@@ -479,6 +474,7 @@ jobs:
           prefix_count=$(wc -l < prefixes.txt)
           file_count=$(wc -l < files.txt)
           total=$((prefix_count + file_count))
+          [ "$FULL" = "true" ] && total=1
           echo "count=$total" >> "$GITHUB_OUTPUT"
 
           {
@@ -510,11 +506,15 @@ jobs:
         if: inputs.dry_run && steps.assets.outputs.count != '0'
         run: |
           set -euo pipefail
-          echo "DRY RUN — the Cloudflare API is not called. Prefixes:"
-          cat prefixes.txt
-          if [ -s files.txt ]; then
-            echo "Exact URLs:"
-            cat files.txt
+          if [ "${{ steps.compute.outputs.full }}" = "true" ]; then
+            echo "DRY RUN: the Cloudflare API would purge the full zone."
+          else
+            echo "DRY RUN: the Cloudflare API is not called. Prefixes:"
+            cat prefixes.txt
+            if [ -s files.txt ]; then
+              echo "Exact URLs:"
+              cat files.txt
+            fi
           fi
 
       # Fail loudly on missing configuration. A purge that quietly skips is the
@@ -540,24 +540,28 @@ jobs:
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          PURGE_MODE: ${{ steps.compute.outputs.mode }}
         run: |
           set -euo pipefail
 
           endpoint="https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache"
 
-          # One purge call. Fails the job on a non-200 *or* on `success: false`
-          # in the body — Cloudflare returns 200 with success:false for things
-          # like an unauthorised prefix, and treating that as a win is how a
-          # cache silently stays stale. Never `|| true`.
+          # One purge call. Fails the job on a non-200 or on `success: false`
+          # in the body. Cloudflare returns 200 with success:false for failures
+          # such as an unauthorised prefix, and treating that as a win silently
+          # leaves stale cache entries. Never `|| true`.
           purge_call() {
             local field="$1" payload_file="$2" attempt=1 max_attempts=5 delay=5
             local body http
 
-            # `files` and `prefixes` are mutually exclusive in the API, so each
-            # kind goes in its own call.
+            # `files`, `prefixes`, and `purge_everything` are mutually exclusive.
             local payload
-            payload=$(jq -Rs --arg field "$field" \
-              'split("\n") | map(select(length > 0)) | {($field): .}' < "$payload_file")
+            if [ "$field" = "purge_everything" ]; then
+              payload='{"purge_everything":true}'
+            else
+              payload=$(jq -Rs --arg field "$field" \
+                'split("\n") | map(select(length > 0)) | {($field): .}' < "$payload_file")
+            fi
 
             local headers
             while :; do
@@ -570,7 +574,11 @@ jobs:
                 --data "$payload") || http=000
 
               if [ "$http" = "200" ] && [ "$(jq -r '.success' "$body")" = "true" ]; then
-                echo "  purged $(jq -r --arg f "$field" '.[$f] | length' <<< "$payload") $field (id $(jq -r '.result.id // "n/a"' "$body"))"
+                if [ "$field" = "purge_everything" ]; then
+                  echo "  purged the full zone (id $(jq -r '.result.id // "n/a"' "$body"))"
+                else
+                  echo "  purged $(jq -r --arg f "$field" '.[$f] | length' <<< "$payload") $field (id $(jq -r '.result.id // "n/a"' "$body"))"
+                fi
                 rm -f "$body" "$headers"
                 return 0
               fi
@@ -635,20 +643,23 @@ jobs:
             rm -rf "$chunkdir"
           }
 
-          purge_all prefixes prefixes.txt
-          # The homepage has no usable prefix — `www.librechat.ai/` prefixes the
-          # whole zone, static assets included — so it is purged by exact URL.
-          purge_all files files.txt
+          if [ "$PURGE_MODE" = "full" ]; then
+            purge_call purge_everything /dev/null
+          else
+            purge_all prefixes prefixes.txt
+            # The homepage has no usable prefix. `www.librechat.ai/` prefixes the
+            # whole zone, static assets included, so purge it by exact URL.
+            purge_all files files.txt
+          fi
 
           echo "::notice::Cloudflare purge complete."
 
-      # Only reached when every call above succeeded. The marker is appended to
-      # a stable commit-status ledger with the workflow run number and promoted
-      # SHA. A failed run leaves no marker, so the following promotion widens its
-      # diff. Manual recovery never writes deployment history, and a degraded
-      # recovery cannot claim the cache is known-good.
+      # A successful full, selective, or no-op automatic run becomes the next
+      # known-good checkpoint. Recording no-ops matters: otherwise their run
+      # numbers look like chronology holes to a later promotion. A failed or
+      # degraded run leaves no marker and forces the next run to recover fully.
       - name: Record the purge in deployment order
-        if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
+        if: ${{ !inputs.dry_run && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -659,10 +670,17 @@ jobs:
         run: |
           set -euo pipefail
           ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
+          if [ "${{ steps.compute.outputs.full }}" = "true" ]; then
+            detail="Purged full zone"
+          elif [ "${{ steps.assets.outputs.count }}" = "0" ]; then
+            detail="No cache changes"
+          else
+            detail="Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs"
+          fi
           gh api -X POST "repos/$REPO/statuses/$ledger_sha" \
             -f state=success \
             -f context="$PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID" \
             -f target_url="$RUN_URL" \
-            -f description="$RUN_NUMBER|$SHA|Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
+            -f description="$RUN_NUMBER|$SHA|$detail" \
             > /dev/null
           echo "Marked $SHA as purged by $DEPLOYMENT_ID."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -156,6 +156,25 @@ jobs:
           CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
         working-directory: workflow-source
         run: node scripts/cache-purge-event.mjs
+
+      # repository_dispatch fields are caller-controlled. The event can select a
+      # deployed tree only after proving that the SHA belongs to protected main.
+      # Older ancestors remain valid, which preserves production rollbacks.
+      - name: Validate promoted source
+        if: github.event_name == 'repository_dispatch'
+        env:
+          HEAD_SHA: ${{ steps.event.outputs.head }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
+            echo "::error::The deployed checkout does not match the promoted SHA."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$HEAD_SHA" origin/main; then
+            echo "::error::The promoted SHA is not part of the current main history."
+            exit 1
+          fi
       # Resolve what to map. Three cases:
       #   dispatch + broad           -> broad set, no diff
       #   dispatch + explicit range  -> that range

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -98,10 +98,10 @@ env:
   # second between calls keeps us under every per-second bucket, and 429s are
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
-  # Successful purges are written as chronological statuses on one stable
-  # repository-root commit. Each context carries the Vercel deployment id
-  # (`cache-purge/dpl_...`), while the description begins with the promoted SHA.
-  # A single ledger preserves deployment order across rollbacks and rebuilds.
+  # Successful purges are written as statuses on one stable repository-root
+  # commit. Each context carries the Vercel deployment id
+  # (`cache-purge/dpl_...`), while the description begins with the workflow run
+  # number and promoted SHA. The sequence survives overlap, rollback, and rerun.
   PURGE_STATUS_CONTEXT: cache-purge
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
@@ -253,12 +253,13 @@ jobs:
             fi
 
             # All successful promotions write to one stable commit-status
-            # ledger. Marker timestamps preserve deployment chronology, unlike
-            # Git ancestry: a rollback from C to ancestor B must diff C..B.
+            # ledger. Workflow run numbers are assigned at event delivery, so
+            # they preserve promotion order when concurrent purges finish out of
+            # order. Git ancestry cannot do that for a rollback from C to B.
             # Skip markers for the same SHA so a rebuild still compares against
             # the previous distinct deployed tree. Only the newest 100 markers
-            # are needed; if they are all rebuilds of one SHA, broad recovery is
-            # safer than an unbounded status-history request.
+            # are needed; otherwise broad recovery is safer than an unbounded
+            # status-history request.
             ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
             status_file="purge-ledger.json"
             gh api "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"
@@ -598,11 +599,10 @@ jobs:
           echo "::notice::Cloudflare purge complete."
 
       # Only reached when every call above succeeded. The marker is appended to
-      # a stable commit-status ledger, with the promoted SHA in its description.
-      # That preserves deployment chronology across rollbacks. A failed run
-      # leaves no marker, so the following promotion widens its diff.
-      # Manual recovery never writes deployment history, and a degraded recovery
-      # cannot claim the cache is known-good.
+      # a stable commit-status ledger with the workflow run number and promoted
+      # SHA. A failed run leaves no marker, so the following promotion widens its
+      # diff. Manual recovery never writes deployment history, and a degraded
+      # recovery cannot claim the cache is known-good.
       - name: Record the purge in deployment order
         if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
         env:
@@ -610,6 +610,7 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ steps.event.outputs.head }}
           DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
+          RUN_NUMBER: ${{ github.run_number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -618,6 +619,6 @@ jobs:
             -f state=success \
             -f context="$PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID" \
             -f target_url="$RUN_URL" \
-            -f description="$SHA|Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
+            -f description="$RUN_NUMBER|$SHA|Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
             > /dev/null
           echo "Marked $SHA as purged by $DEPLOYMENT_ID."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -98,10 +98,10 @@ env:
   # second between calls keeps us under every per-second bucket, and 429s are
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
-  # Commit-status context marking "the cache was successfully purged". The real
-  # context carries the Vercel deployment id (`cache-purge/dpl_...`) because a
-  # SHA is not unique: a rollback or rebuild can promote another deployment from
-  # the same commit. Only a completed Cloudflare purge writes this marker.
+  # Successful purges are written as chronological statuses on one stable
+  # repository-root commit. Each context carries the Vercel deployment id
+  # (`cache-purge/dpl_...`), while the description begins with the promoted SHA.
+  # A single ledger preserves deployment order across rollbacks and rebuilds.
   PURGE_STATUS_CONTEXT: cache-purge
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
@@ -127,13 +127,26 @@ jobs:
        github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj' &&
        github.event.client_payload.git.ref == 'main')
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: deployed-source
     steps:
-      # Repository-dispatch workflows start from the default-branch SHA. Check
-      # out the commit Vercel actually promoted so the diff and mapper see the
-      # deployed tree.
-      - uses: actions/checkout@v4
+      # Keep the default-branch workflow revision separate from the commit being
+      # deployed. During a rollback, that deployed commit can predate these
+      # scripts and must not replace the validator or mapper implementation.
+      - name: Check out workflow source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: workflow-source
+          ref: ${{ github.sha }}
+
+      - name: Check out deployed source
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: deployed-source
           ref: ${{ github.event.client_payload.git.sha || github.sha }}
 
       - name: Validate promoted deployment
@@ -141,6 +154,7 @@ jobs:
         id: event
         env:
           CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+        working-directory: workflow-source
         run: node scripts/cache-purge-event.mjs
       # Resolve what to map. Three cases:
       #   dispatch + broad           -> broad set, no diff
@@ -219,34 +233,23 @@ jobs:
               exit 1
             fi
 
-            # The baseline is the newest ancestor carrying a successful marker
-            # from this Vercel-deployment-aware workflow. If B's purge fails and
-            # C deploys, B has no marker, so the diff widens from the last known
-            # good deployment A through C.
-            base=""
-            mkdir -p commit-statuses
-            prefix="$PURGE_STATUS_CONTEXT/dpl_"
-            commits=$(git rev-list --since="$FALLBACK_WINDOW" "${head}^" 2>/dev/null || true)
-            while read -r sha; do
-              [ -n "$sha" ] || continue
-              status_file="commit-statuses/$sha.json"
-              gh api --paginate --slurp \
-                "repos/$REPO/commits/$sha/statuses?per_page=100" > "$status_file"
-              purged=$(jq --arg prefix "$prefix" '
-                [.[][] |
-                  select(.state == "success") |
-                  select(.context | startswith($prefix))
-                ] | length' "$status_file")
-              if [ "${purged:-0}" -gt 0 ]; then
-                base="$sha"
-                echo "Baseline: $sha, newest ancestor with a successful Vercel purge marker."
-                break
-              fi
-            done <<< "$commits"
+            # All successful promotions write to one stable commit-status
+            # ledger. Marker timestamps preserve deployment chronology, unlike
+            # Git ancestry: a rollback from C to ancestor B must diff C..B.
+            # Skip markers for the same SHA so a rebuild still compares against
+            # the previous distinct deployed tree. Only the newest 100 markers
+            # are needed; if they are all rebuilds of one SHA, broad recovery is
+            # safer than an unbounded status-history request.
+            ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
+            status_file="purge-ledger.json"
+            gh api "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"
+            base=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$head" "$PURGE_STATUS_CONTEXT")
 
-            if [ -z "$base" ]; then
-              # Includes the first run after migrating from numeric GitHub
-              # Deployment markers to Vercel `dpl_...` markers.
+            if [ -n "$base" ]; then
+              echo "Baseline: $base, latest successfully purged Vercel deployment."
+            else
+              # Includes the first run after introducing the chronological
+              # deployment ledger.
               echo "No earlier successfully purged Vercel deployment found."
               fallback_range "$head" && exit 0
               echo "::warning::No baseline and no fallback window; purging broadly."
@@ -255,8 +258,13 @@ jobs:
             fi
           fi
 
-          # A force-push or a dropped branch can orphan the base commit. Mapping
-          # nothing would leave the cache stale, so fall back to the broad set.
+          # A force-push or rollback can leave the baseline outside the promoted
+          # commit's ancestry. Fetch main once so a newer prior deployment is
+          # available for a reverse diff, then degrade safely if it is still
+          # unreachable.
+          if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin main || true
+          fi
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             echo "Base commit $base is not reachable in this checkout."
             fallback_range "$head" && exit 0
@@ -296,7 +304,7 @@ jobs:
           # because nothing here can tell which asset changed, and these are the
           # runs that exist precisely because something already went wrong.
           if [ "$MODE" = "broad" ] && [ -z "${BASE:-}" ]; then
-            node scripts/cache-purge-prefixes.mjs --broad --assets --json > purge.json
+            node ../workflow-source/scripts/cache-purge-prefixes.mjs --broad --assets --json > purge.json
           else
             # Broad *with* a range still walks the diff, so the broad page set
             # is topped up with changed asset URLs and locales removed in the
@@ -352,7 +360,7 @@ jobs:
 
             # shellcheck disable=SC2086 # broad_flag is intentionally unquoted: empty means no flag.
             TREE_EDITS_FILE=tree-edits.z \
-              node scripts/cache-purge-prefixes.mjs - --json --explain $broad_flag < changed.z > purge.json
+              node ../workflow-source/scripts/cache-purge-prefixes.mjs - --json --explain $broad_flag < changed.z > purge.json
           fi
 
           jq -r '.prefixes[]' purge.json > prefixes.txt
@@ -382,14 +390,14 @@ jobs:
           : > build-assets.txt
           if [ "$EVENT" = "workflow_dispatch" ]; then
             probe_log=$(mktemp)
-            if node scripts/cache-build-assets.mjs > build-assets.txt 2> "$probe_log"; then
+            if node ../workflow-source/scripts/cache-build-assets.mjs > build-assets.txt 2> "$probe_log"; then
               cat "$probe_log" >&2
             else
               # Escalate the selective plan to every page prefix and current public
               # asset while retaining deleted URLs found by the original diff.
               sed 's/^::error::/::warning::/' "$probe_log" >&2
               echo "::warning::Build-asset discovery failed; purging the recovery targets without the current build assets."
-              node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json
+              node ../workflow-source/scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json
               jq -r '.prefixes[]' recovery.json >> prefixes.txt
               jq -r '.files[]?' recovery.json >> files.txt
               sort -u prefixes.txt -o prefixes.txt
@@ -570,12 +578,13 @@ jobs:
 
           echo "::notice::Cloudflare purge complete."
 
-      # Only reached when every call above succeeded. The marker means this
-      # Vercel deployment's computed targets were purged. A failed run leaves no
-      # marker, so the following promotion's diff widens to include its range.
+      # Only reached when every call above succeeded. The marker is appended to
+      # a stable commit-status ledger, with the promoted SHA in its description.
+      # That preserves deployment chronology across rollbacks. A failed run
+      # leaves no marker, so the following promotion widens its diff.
       # Manual recovery never writes deployment history, and a degraded recovery
       # cannot claim the cache is known-good.
-      - name: Record the purge against this commit
+      - name: Record the purge in deployment order
         if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -585,10 +594,11 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          gh api -X POST "repos/$REPO/statuses/$SHA" \
+          ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
+          gh api -X POST "repos/$REPO/statuses/$ledger_sha" \
             -f state=success \
             -f context="$PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID" \
             -f target_url="$RUN_URL" \
-            -f description="Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
+            -f description="$SHA|Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs" \
             > /dev/null
-          echo "Marked $SHA as purged."
+          echo "Marked $SHA as purged by $DEPLOYMENT_ID."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -2,8 +2,7 @@ name: Cloudflare Cache Purge
 
 # Purges the Cloudflare edge cache for the pages a production deploy actually
 # changed, so a docs edit is visible immediately instead of waiting out the 24h
-# edge TTL (`SHARED_CDN_CACHE` in next.config.mjs). It also clears any cached
-# error responses for current Next.js build assets. Nothing here changes a TTL.
+# edge TTL (`SHARED_CDN_CACHE` in next.config.mjs). Nothing here changes a TTL.
 #
 # WHY PREFIXES, NOT URLS
 # The App Router serves the HTML document and the RSC flight payload at the same
@@ -19,9 +18,9 @@ name: Cloudflare Cache Purge
 #
 # WHY NOT `purge_everything`
 # It also evicts /_next/static/**, which would put every asset on the site into
-# a MISS wave on every deploy. This workflow instead purges the exact build
-# assets referenced by current page shells and their runtime (roughly 100 URLs),
-# leaving historical and unrelated static assets warm.
+# a MISS wave on every deploy. Generated assets are content-addressed, and the
+# zone bypasses every 4xx response, so they cannot retain a poisoned negative
+# entry. Historical and unrelated static assets stay warm.
 #
 # KNOWN, ACCEPTED BEHAVIOURS
 # 1. Prefix matching is a plain string match, so `/docs/features/agents` also
@@ -34,30 +33,19 @@ name: Cloudflare Cache Purge
 on:
   # The purge MUST happen after Vercel has finished deploying. Running it when
   # the commit lands (`on: push`) is worse than not purging at all: Cloudflare
-  # would immediately refill every purged entry from the *old* origin build and
+  # would immediately refill every purged entry from the old origin build and
   # re-pin it for another 24h.
   #
-  # Vercel's GitHub integration publishes a GitHub Deployment for every
-  # production build and marks it `success` when the build is ready and the
-  # production alias points at it. That is a real completion signal, it needs no
-  # new credentials, and it arrives when the work is done rather than after a
-  # guessed wait. Verified present on this repo: `Production` deployments whose
-  # successful deployment status is posted by `vercel[bot]`. The deployment
-  # itself is attributed to the human who initiated it, so that creator is not
-  # a reliable integration identifier.
+  # Vercel's enriched `deployment.promoted` event fires after the deployment
+  # starts serving production traffic and carries the exact project, branch,
+  # commit, and Vercel deployment id. Vercel recommends this event over the
+  # older GitHub `deployment_status` inference.
   #
-  # Limitations, written down rather than papered over:
-  #   - It depends on Vercel's GitHub integration staying enabled. If a deploy
-  #     ever reaches production without producing a GitHub Deployment, no purge
-  #     runs and those pages fall back to the 24h TTL. Use the manual
-  #     `workflow_dispatch` broad purge to recover.
-  #   - `success` is posted when Vercel considers the deployment ready. The
-  #     alias swap is effectively simultaneous, but a purge issued in the same
-  #     second could still race an edge that has not seen the new origin.
-  #     SETTLE_SECONDS below covers that window.
-  #   - `deployment_status` workflows only run from the file on the default
-  #     branch, so this cannot be exercised until it is merged to main.
-  deployment_status:
+  # Repository-dispatch workflows only run from the file on the default branch,
+  # so this trigger cannot be exercised until it is merged to main. The manual
+  # dry run below is the pre-merge verification path.
+  repository_dispatch:
+    types: ['vercel.deployment.promoted']
 
   # Manual escape hatch: purge the four top-level prefixes (and the rest of the
   # broad set) without needing a deploy. Use it after a Cloudflare rule change,
@@ -79,34 +67,25 @@ on:
 
 permissions:
   contents: read
-  # Reading the previous successful production deployment, to know where the
-  # diff starts.
-  deployments: read
-  # Writing the "this commit was purged" marker that the next run baselines
-  # from, so a failed purge is retried rather than skipped past.
+  # Writing the "this Vercel deployment was purged" marker that the next run
+  # baselines from, so a failed purge is retried rather than skipped past.
   statuses: write
 
-# Keyed per deployment, NOT a single shared group. GitHub keeps at most one
-# pending run per concurrency group: "any existing pending job or workflow in the
-# same concurrency group will be canceled and the new queued job or workflow will
-# take its place" — and that happens even with `cancel-in-progress: false`.
+# Keyed per Vercel deployment, NOT a single shared group. GitHub keeps at most
+# one pending run per concurrency group: "any existing pending job or workflow
+# in the same concurrency group will be canceled and the new queued job or
+# workflow will take its place", even with `cancel-in-progress: false`.
 # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
 #
 # With one shared group and three deploys in quick succession (B running, C
-# pending, D arriving), C is dropped. D's baseline is then deployment C, which
-# did go live, so everything changed between B and C is never purged by anyone
-# and stays stale for the full TTL. Purges are idempotent and each call handles
+# pending, D arriving), C is dropped. Purges are idempotent and each call handles
 # its own rate limiting, so letting runs overlap is strictly safer than
 # serialising them and losing one.
 concurrency:
-  group: cache-purge-${{ github.event.deployment.id || github.run_id }}
+  group: cache-purge-${{ github.event.client_payload.id || github.run_id }}
   cancel-in-progress: false
 
 env:
-  # Grace period between "Vercel says ready" and the first purge call. Cheap
-  # insurance against purging an edge a moment before it can see the new origin;
-  # raise it if a purged page is ever observed refilling with old content.
-  SETTLE_SECONDS: 15
   # Cloudflare documents "Maximum 30 prefixes per API call" for purge by prefix.
   # The general limits table allows 100 operations per request (500 on
   # Enterprise), so 30 is the tighter of the two documented numbers and is what
@@ -120,16 +99,10 @@ env:
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
   # Commit-status context marking "the cache was successfully purged". The real
-  # context carries the deployment id — `cache-purge/12345` — because a SHA is
-  # not a unique key: a rollback redeploys one that was already purged. Ordering
-  # by timestamp is not enough either, since an earlier deployment's overlapping
-  # purge can post its marker after a later deployment was created. The id is
-  # the only thing that identifies which deployment a marker belongs to.
+  # context carries the Vercel deployment id (`cache-purge/dpl_...`) because a
+  # SHA is not unique: a rollback or rebuild can promote another deployment from
+  # the same commit. Only a completed Cloudflare purge writes this marker.
   PURGE_STATUS_CONTEXT: cache-purge
-  # How far back to look for the last purged Vercel release. One page is 100
-  # deployments, which on this repo is ~3.3 days because translate_docs.yml
-  # creates a Production record every 30 minutes; 5 pages is a fortnight.
-  MAX_DEPLOYMENT_PAGES: 5
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
   # page set; its job is to surface deletions, which a range-less run cannot see.
@@ -145,36 +118,37 @@ env:
 jobs:
   purge:
     name: Purge changed prefixes
-    # Only successful *production* deployments from Vercel. `deployment_status`
-    # also fires for pending/failure states and for every preview deployment.
-    #
-    # Check the status creator, not the deployment creator. Vercel attributes
-    # the deployment to the human who initiated it and posts the ready status as
-    # `vercel[bot]`. A job-level `environment: Production` also creates records,
-    # but their statuses are posted by the Actions actor and must stay excluded.
+    # Vercel emits this event for previews too. Reject those before a runner is
+    # allocated, then validate the same fields again before Cloudflare secrets
+    # become reachable.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.deployment_status.state == 'success' &&
-       github.event.deployment.environment == 'Production' &&
-       github.event.deployment_status.creator.login == 'vercel[bot]')
+      (github.event.client_payload.environment == 'production' &&
+       github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj' &&
+       github.event.client_payload.git.ref == 'main')
     runs-on: ubuntu-latest
     steps:
-      # Full history: the diff base is the previous deployed commit, which can be
-      # many commits back when deploys are batched or a build was superseded.
+      # Repository-dispatch workflows start from the default-branch SHA. Check
+      # out the commit Vercel actually promoted so the diff and mapper see the
+      # deployed tree.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.client_payload.git.sha || github.sha }}
 
+      - name: Validate promoted deployment
+        if: github.event_name == 'repository_dispatch'
+        id: event
+        env:
+          CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+        run: node scripts/cache-purge-event.mjs
       # Resolve what to map. Three cases:
-      #   dispatch + broad          -> broad set, no diff
-      #   dispatch + explicit range -> that range
-      #   deployment_status         -> previous successful production deploy .. this one
+      #   dispatch + broad           -> broad set, no diff
+      #   dispatch + explicit range  -> that range
+      #   Vercel promotion           -> last successfully purged commit .. this one
       #
-      # Using the previous *deployed* commit rather than `push.before` matters:
-      # when several commits land quickly Vercel may supersede a build, so some
-      # commits never deploy on their own. Diffing deploy-to-deploy covers every
-      # commit that actually shipped between two live builds; diffing push-to-push
-      # would silently skip the superseded ones.
+      # Diffing promotion-to-promotion covers every commit that actually shipped,
+      # including commits whose intermediate Vercel builds were superseded.
       - name: Resolve diff range
         id: range
         env:
@@ -182,8 +156,8 @@ jobs:
           EVENT: ${{ github.event_name }}
           INPUT_BROAD: ${{ inputs.broad_pages }}
           INPUT_RANGE: ${{ inputs.range }}
-          HEAD_SHA: ${{ github.event.deployment.sha }}
-          DEPLOYMENT_ID: ${{ github.event.deployment.id }}
+          HEAD_SHA: ${{ steps.event.outputs.head }}
+          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
           REPO: ${{ github.repository }}
           PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
         run: |
@@ -240,84 +214,40 @@ jobs:
             head="${INPUT_RANGE##*..}"
           else
             head="$HEAD_SHA"
-            if ! printf '%s' "${DEPLOYMENT_ID:-}" | grep -Eq '^[0-9]+$'; then
-              echo "::error::deployment_status payload carried no numeric deployment id."
+            if ! printf '%s' "${DEPLOYMENT_ID:-}" | grep -Eq '^dpl_[A-Za-z0-9]+$'; then
+              echo "::error::Promoted event carried no valid Vercel deployment id."
               exit 1
             fi
-            # Walk production deployments newest-first and take the first
-            # deployment-specific successful purge marker on a *different*
-            # commit. Skipping same-sha entries means a redeploy of the current
-            # commit re-purges that commit's prefixes instead of computing an
-            # empty diff.
-            #
-            # The purge marker proves both that the candidate was a Vercel
-            # success event and that its entire purge completed. This avoids
-            # trusting `deployment.creator`: Vercel records carry the initiating
-            # human there, just like unrelated Actions Production deployments.
-            #
-            # `id < this deployment` is still required. Deployment ids increase
-            # monotonically, so
-            #   this is an "older than the event we are processing" test. Without
-            #   it, a deploy that finishes while this runner is queued is newer
-            #   yet still differs from head, so it would be accepted as the
-            #   "previous" build and the real B..C delta would go unpurged.
+
+            # The baseline is the newest ancestor carrying a successful marker
+            # from this Vercel-deployment-aware workflow. If B's purge fails and
+            # C deploys, B has no marker, so the diff widens from the last known
+            # good deployment A through C.
             base=""
-            # Pagination is not optional here. `environment=Production` is
-            # dominated by the half-hourly translate_docs.yml jobs, which declare
-            # that environment and so create a deployment record each run.
-            # Measured on this repo: one page of 100 covers about 3.3 days and
-            # holds 5 Vercel releases against 95 Actions records. Any release gap
-            # longer than that would push the real baseline off page one, and the
-            # run would silently degrade to a broad purge every time.
-            page=1
-            while [ "$page" -le "$MAX_DEPLOYMENT_PAGES" ] && [ -z "$base" ]; do
-              deployments=$(gh api \
-                "repos/$REPO/deployments?environment=Production&per_page=100&page=$page")
-              [ "$(jq 'length' <<< "$deployments")" -gt 0 ] || break
-              ids=$(jq -r --argjson current "$DEPLOYMENT_ID" '
-                      [ .[]
-                        | select(.id < $current)
-                      ][]
-                      | "\(.id) \(.sha)"' <<< "$deployments")
-            # The baseline is the last commit we actually PURGED, not merely the
-            # last one deployed. If B's purge fails or is cancelled and C then
-            # deploys, taking B as the baseline would compute B..C and leave
-            # everything unique to A..B stale forever, with no run left that
-            # would ever revisit it. Walking back to the newest deployment
-            # carrying the `PURGE_STATUS_CONTEXT` commit status makes the next
-            # run absorb the failed one's range: the diff widens to A..C.
-              while read -r id sha; do
-                [ -n "$id" ] || continue
-                [ -z "$base" ] || break
-                [ "$sha" = "$head" ] && continue
-                # Cache commit statuses by SHA. Production deployment history is
-                # dominated by scheduled Actions records, often dozens on one
-                # commit; querying once per deployment would burn the API budget
-                # without learning anything new.
-                status_file="commit-statuses/$sha.json"
-                if [ ! -f "$status_file" ]; then
-                  mkdir -p commit-statuses
-                  gh api --paginate --slurp \
-                    "repos/$REPO/commits/$sha/statuses?per_page=100" > "$status_file"
-                fi
-                # Keyed to this deployment, not merely this commit. Only this
-                # workflow writes the marker, after every Cloudflare call wins.
-                purged=$(jq --arg context "$PURGE_STATUS_CONTEXT/$id" \
-                  '[.[][] | select(.context == $context and .state == "success")] | length' \
-                  "$status_file")
-                if [ "${purged:-0}" -gt 0 ]; then
-                  base="$sha"
-                  echo "Baseline: $sha (deployment $id) — last commit with a successful purge."
-                  break
-                fi
-                echo "Skipping $sha (deployment $id): deployed, but never purged successfully."
-              done <<< "$ids"
-              page=$((page + 1))
-            done
+            mkdir -p commit-statuses
+            prefix="$PURGE_STATUS_CONTEXT/dpl_"
+            commits=$(git rev-list --since="$FALLBACK_WINDOW" "${head}^" 2>/dev/null || true)
+            while read -r sha; do
+              [ -n "$sha" ] || continue
+              status_file="commit-statuses/$sha.json"
+              gh api --paginate --slurp \
+                "repos/$REPO/commits/$sha/statuses?per_page=100" > "$status_file"
+              purged=$(jq --arg prefix "$prefix" '
+                [.[][] |
+                  select(.state == "success") |
+                  select(.context | startswith($prefix))
+                ] | length' "$status_file")
+              if [ "${purged:-0}" -gt 0 ]; then
+                base="$sha"
+                echo "Baseline: $sha, newest ancestor with a successful Vercel purge marker."
+                break
+              fi
+            done <<< "$commits"
 
             if [ -z "$base" ]; then
-              # Also the first-ever run, when no commit carries the marker yet.
-              echo "No earlier successfully purged deployment found."
+              # Includes the first run after migrating from numeric GitHub
+              # Deployment markers to Vercel `dpl_...` markers.
+              echo "No earlier successfully purged Vercel deployment found."
               fallback_range "$head" && exit 0
               echo "::warning::No baseline and no fallback window; purging broadly."
               emit mode broad
@@ -433,45 +363,42 @@ jobs:
           echo "mode=$([ "$broad" = "true" ] && echo broad || echo selective)" >> "$GITHUB_OUTPUT"
           echo "collapsed=$collapsed" >> "$GITHUB_OUTPUT"
 
-      # Vercel posts success as its production alias changes. Let that alias
-      # propagate before reading fresh page shells or purging anything.
-      - name: Wait for the deploy to settle
-        if: ${{ github.event_name == 'deployment_status' }}
-        run: sleep "$SETTLE_SECONDS"
-
-      # A new immutable asset can be requested during the alias transition and
-      # receive a short-lived origin 404. The zone's Cache Rule may retain that
-      # response much longer, independently in each Cloudflare location. Read a
-      # bounded set of fresh page shells plus their runtime's complete lazy-chunk
-      # map, then globally purge those exact current build-asset URLs; a health
-      # check from one runner cannot see poisoned keys in another edge location.
-      - name: Collect current build assets
+      # Automatic promotions purge only the changed HTML/RSC prefixes and
+      # changed public files. Generated assets are content-addressed, and the
+      # zone's 4xx no-store rule prevents negative entries, so probing 21 fresh
+      # page shells on every deploy would add Vercel cost without adding safety.
+      #
+      # Manual recovery keeps live discovery: an operator may be clearing
+      # poisoned entries created before the no-store rule existed.
+      - name: Finalize purge plan
         id: assets
         env:
           CACHE_PROBE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
+          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          probe_log=$(mktemp)
           degraded=false
-          if node scripts/cache-build-assets.mjs > build-assets.txt 2> "$probe_log"; then
-            cat "$probe_log" >&2
-          else
-            # Discovery retries through an alias transition on its own, so a
-            # failure here means the live site is unhealthy rather than mid-flip.
-            # Escalate the selective plan to every page prefix and current public
-            # asset while retaining deleted URLs found by the original diff.
-            sed 's/^::error::/::warning::/' "$probe_log" >&2
-            echo "::warning::Build-asset discovery failed; purging the recovery targets without the current build assets."
-            node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json
-            jq -r '.prefixes[]' recovery.json >> prefixes.txt
-            jq -r '.files[]?' recovery.json >> files.txt
-            sort -u prefixes.txt -o prefixes.txt
-            sort -u files.txt -o files.txt
-            : > build-assets.txt
-            degraded=true
+          : > build-assets.txt
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            probe_log=$(mktemp)
+            if node scripts/cache-build-assets.mjs > build-assets.txt 2> "$probe_log"; then
+              cat "$probe_log" >&2
+            else
+              # Escalate the selective plan to every page prefix and current public
+              # asset while retaining deleted URLs found by the original diff.
+              sed 's/^::error::/::warning::/' "$probe_log" >&2
+              echo "::warning::Build-asset discovery failed; purging the recovery targets without the current build assets."
+              node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json
+              jq -r '.prefixes[]' recovery.json >> prefixes.txt
+              jq -r '.files[]?' recovery.json >> files.txt
+              sort -u prefixes.txt -o prefixes.txt
+              sort -u files.txt -o files.txt
+              : > build-assets.txt
+              degraded=true
+            fi
+            rm -f "$probe_log"
           fi
-          rm -f "$probe_log"
           echo "degraded=$degraded" >> "$GITHUB_OUTPUT"
 
           cat build-assets.txt >> files.txt
@@ -491,7 +418,7 @@ jobs:
             fi
             echo "- prefixes: $prefix_count"
             echo "- exact URLs: $file_count"
-            echo "- current build assets: $(wc -l < build-assets.txt)"
+            echo "- recovery build assets: $(wc -l < build-assets.txt)"
             if [ "$degraded" = "true" ]; then
               echo "- **degraded**: live discovery failed, no purge marker recorded"
             fi
@@ -501,9 +428,8 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Defensive only: build-assets.txt normally makes every production deploy
-      # non-empty. Keep a clear no-op result for an explicitly narrowed future
-      # configuration.
+      # A promoted commit that changes no cache-relevant path is a real no-op.
+      # Keep it explicit rather than touching Vercel or Cloudflare.
       - name: Nothing to purge
         if: steps.assets.outputs.count == '0'
         run: echo "::notice::No cached route or build asset needs purging."
@@ -644,22 +570,18 @@ jobs:
 
           echo "::notice::Cloudflare purge complete."
 
-      # Only reached when every call above succeeded, because `set -e` plus
-      # purge_call's non-zero return aborts the step otherwise. That is the
-      # point: the marker means "the cache is known-good at this SHA", and the
-      # next run picks its baseline from the newest deployment carrying one. A
-      # run that fails leaves no marker, so the following run's diff widens to
-      # include this one's range instead of stepping over it.
-      # A degraded run is the same case from the other direction: it purged the
-      # recovery targets but could not enumerate the current build assets, so it
-      # must not claim this SHA is known-good.
+      # Only reached when every call above succeeded. The marker means this
+      # Vercel deployment's computed targets were purged. A failed run leaves no
+      # marker, so the following promotion's diff widens to include its range.
+      # Manual recovery never writes deployment history, and a degraded recovery
+      # cannot claim the cache is known-good.
       - name: Record the purge against this commit
-        if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'deployment_status' }}
+        if: ${{ !inputs.dry_run && steps.assets.outputs.count != '0' && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.event.deployment.sha }}
-          DEPLOYMENT_ID: ${{ github.event.deployment.id }}
+          SHA: ${{ steps.event.outputs.head }}
+          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -1,6 +1,4 @@
 name: Cloudflare Cache Purge
-run-name: >-
-  cache-purge:${{ github.event.client_payload.environment || 'manual' }}:${{ github.event.client_payload.project.id || 'manual' }}:${{ github.event.client_payload.git.ref || 'manual' }}:${{ github.event.client_payload.git.sha || github.sha }}:${{ github.event.client_payload.id || github.run_id }}
 
 # Purges the Cloudflare edge cache for the pages a production deploy actually
 # changed, so a docs edit is visible immediately instead of waiting out the 24h
@@ -18,11 +16,11 @@ run-name: >-
 # Prefix is therefore the only usable unit. Note the format: `hostname/path`,
 # no scheme, no query string.
 #
-# WHY NOT `purge_everything`
-# It also evicts /_next/static/**, which would put every asset on the site into
-# a MISS wave on every deploy. Generated assets are content-addressed, and the
-# zone bypasses every 4xx response, so they cannot retain a poisoned negative
-# entry. Historical and unrelated static assets stay warm.
+# WHY AUTOMATIC PROMOTIONS PURGE THE FULL ZONE
+# Vercel can promote deployments without repository Git metadata, and dispatch
+# delivery order is not guaranteed to match production alias order. No Git diff
+# or workflow ledger can then prove which URLs were previously live. Automatic
+# promotions use full-zone invalidation; manual recovery remains prefix-based.
 #
 # KNOWN, ACCEPTED BEHAVIOURS
 # 1. Prefix matching is a plain string match, so `/docs/features/agents` also
@@ -38,10 +36,10 @@ on:
   # would immediately refill every purged entry from the old origin build and
   # re-pin it for another 24h.
   #
-  # Vercel's enriched `deployment.promoted` event fires after the deployment
-  # starts serving production traffic and carries the exact project, branch,
-  # commit, and Vercel deployment id. Vercel recommends this event over the
-  # older GitHub `deployment_status` inference.
+  # Vercel's enriched `deployment.promoted` event fires after a deployment
+  # starts serving production traffic and carries the exact project and Vercel
+  # deployment id. Git metadata is present for normal connected deployments but
+  # is not required for CLI, fork, or deleted-branch promotions.
   #
   # Repository-dispatch workflows only run from the file on the default branch,
   # so this trigger cannot be exercised until it is merged to main. The manual
@@ -68,10 +66,7 @@ on:
         required: false
 
 permissions:
-  actions: read
   contents: read
-  # Successful automatic purges are durable known-good checkpoints.
-  statuses: write
 
 # Keyed per Vercel deployment, NOT a single shared group. GitHub keeps at most
 # one pending run per concurrency group: "any existing pending job or workflow
@@ -100,11 +95,6 @@ env:
   # second between calls keeps us under every per-second bucket, and 429s are
   # retried with backoff below, which is what makes the floor safe too.
   SLEEP_BETWEEN_CALLS: 1
-  # Successful purges are written as statuses on one stable repository-root
-  # commit. Each context carries the Vercel deployment id
-  # (`cache-purge/dpl_...`), while the description begins with the workflow run
-  # number and promoted SHA. The sequence survives overlap, rollback, and rerun.
-  PURGE_STATUS_CONTEXT: cache-purge
   # How far back a blind recovery reaches when it has no baseline to work from.
   # Only ever an approximation of where to start, so it is paired with the broad
   # page set; its job is to surface deletions, which a range-less run cannot see.
@@ -133,22 +123,15 @@ jobs:
         shell: bash
         working-directory: deployed-source
     steps:
-      # Keep the default-branch workflow revision separate from the commit being
-      # deployed. During a rollback, that deployed commit can predate these
-      # scripts and must not replace the validator or mapper implementation.
+      # Trusted workflow code always comes from the default-branch revision.
+      # Automatic purges need no deployed checkout; the full-zone operation is
+      # deliberately independent of Git metadata and repository reachability.
       - name: Check out workflow source
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           path: workflow-source
           ref: ${{ github.sha }}
-
-      - name: Check out deployed source
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          path: deployed-source
-          ref: ${{ github.event.client_payload.git.sha || github.sha }}
 
       - name: Validate promoted deployment
         if: github.event_name == 'repository_dispatch'
@@ -158,66 +141,47 @@ jobs:
         working-directory: workflow-source
         run: node scripts/cache-purge-event.mjs
 
-      # repository_dispatch fields are caller-controlled. The checkout must
-      # match the promoted SHA. Main deployments additionally prove ancestry
-      # before their tree can feed the mapper; non-main promotions never feed
-      # it and route directly to a full-zone purge.
-      - name: Validate promoted source
+      - name: Prepare automatic purge workspace
         if: github.event_name == 'repository_dispatch'
-        env:
-          HEAD_SHA: ${{ steps.event.outputs.head }}
-          PROMOTED_REF: ${{ steps.event.outputs.ref }}
-        run: |
-          set -euo pipefail
-          if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
-            echo "::error::The deployed checkout does not match the promoted SHA."
-            exit 1
-          fi
-          if [ "$PROMOTED_REF" != "main" ]; then
-            echo "::notice::Non-main production deployment will use full-zone recovery."
-            exit 0
-          fi
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$HEAD_SHA" origin/main; then
-            echo "::error::The promoted SHA is not part of the current main history."
-            exit 1
-          fi
+        working-directory: .
+        run: mkdir -p deployed-source
 
-      # Resolve what to map. Three cases:
-      #   dispatch + broad           -> broad set, no diff
-      #   dispatch + explicit range  -> that range
-      #   Vercel promotion           -> last known-good purge .. this commit
-      #
-      # Automatic runs reconcile every intervening workflow run before using a
-      # selective range. Run names capture Vercel routing data when GitHub
-      # creates the run, so queued and cancelled predecessors stay visible.
+      # Manual recovery still uses diffs, current public assets, and trusted
+      # workflow scripts. It needs the full default-branch history.
+      - name: Check out manual source
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: deployed-source
+          ref: ${{ github.sha }}
+
+      # Automatic promotions are stateless full-zone invalidations. Manual
+      # dispatch keeps the precise broad/range mapper for operator recovery.
       - name: Resolve diff range
         id: range
         env:
-          GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
           INPUT_BROAD: ${{ inputs.broad_pages }}
           INPUT_RANGE: ${{ inputs.range }}
-          HEAD_SHA: ${{ steps.event.outputs.head }}
-          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
-          PROMOTED_REF: ${{ steps.event.outputs.ref }}
-          CURRENT_RUN_NUMBER: ${{ github.run_number }}
-          REPO: ${{ github.repository }}
-          PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
         run: |
           set -euo pipefail
 
           emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
 
-          # Last resort before giving up on a range entirely.
+          if [ "$EVENT" = "repository_dispatch" ]; then
+            echo "::notice::Automatic production promotion; purging the full zone."
+            emit mode full
+            exit 0
+          fi
+
+          # Last resort before giving up on a manual range entirely.
           #
           # A range-less purge is blind to deletions: every target is enumerated
-          # from the deployed checkout, so a file removed in the meantime has no
-          # entry anywhere and its old URL survives at the edge. A time-boxed
-          # range is approximate about *where* to start, but it is a real diff,
-          # so removals inside it come through as `D` and get purged like any
-          # other change. Strictly better than nothing; still paired with the
-          # broad page set, because the window may not reach far enough back.
+          # from the checkout, so a file removed in the meantime has no entry
+          # anywhere and its old URL survives at the edge. A time-boxed range is
+          # approximate about where to start, but it is a real diff, so removals
+          # inside it come through as `D` and get purged like any other change.
           fallback_range() {
             local since ref
             ref="${1:-}"
@@ -233,92 +197,33 @@ jobs:
             return 1
           }
 
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            if [ "$INPUT_BROAD" = "true" ] && [ -z "${INPUT_RANGE:-}" ]; then
-              # Pages only. Cannot reach changed asset URLs or a locale that was
-              # removed, because both are discovered from a diff — supply a range
-              # as well to recover those.
-              echo "Manual dispatch: broad page purge, no range given."
-              fallback_range && exit 0
-              echo "::warning::No range and no fallback window; deletions in the meantime cannot be discovered."
-              emit mode broad
-              exit 0
-            fi
-            if [ -z "${INPUT_RANGE:-}" ]; then
-              echo "::error::broad_pages=false requires a 'range' input (e.g. abc1234..def5678)."
-              exit 1
-            fi
-            # Constrain the shape before it reaches git, so a value like
-            # `--upload-pack=...` can't be read as an option.
-            if ! printf '%s' "$INPUT_RANGE" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*\.\.[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
-              echo "::error::Invalid range '$INPUT_RANGE'. Expected <base>..<head>."
-              exit 1
-            fi
-            base="${INPUT_RANGE%%..*}"
-            head="${INPUT_RANGE##*..}"
-          else
-            head="$HEAD_SHA"
-            if ! printf '%s' "${DEPLOYMENT_ID:-}" | grep -Eq '^dpl_[A-Za-z0-9]+$'; then
-              echo "::error::Promoted event carried no valid Vercel deployment id."
-              exit 1
-            fi
-            if [ "$PROMOTED_REF" != "main" ]; then
-              echo "::warning::Non-main production deployment; purging the full zone."
-              emit mode full
-              exit 0
-            fi
-
-            # A successful purge is the only known-good cache checkpoint.
-            # `run-name` records each dispatch before a runner starts, and the
-            # Actions API exposes it as `display_title`. Any intervening
-            # production run, missing run number, or malformed title means an
-            # earlier production tree may still be cached. Fail closed to one
-            # exceptional full purge rather than guess a selective range.
-            ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
-            status_file="purge-ledger.json"
-            workflow_runs_file="purge-workflow-runs.json"
-            if ! gh api --paginate --slurp "repos/$REPO/commits/$ledger_sha/statuses?per_page=100" > "$status_file"; then
-              echo "::warning::Could not read the purge checkpoint ledger; purging the full zone."
-              emit mode full
-              exit 0
-            fi
-            if ! gh api --paginate --slurp "repos/$REPO/actions/workflows/cache-purge.yml/runs?per_page=100" > "$workflow_runs_file"; then
-              echo "::warning::Could not reconcile earlier cache-purge runs; purging the full zone."
-              emit mode full
-              exit 0
-            fi
-
-            ledger_state=$(node ../workflow-source/scripts/cache-purge-event.mjs baseline "$status_file" "$workflow_runs_file" "$head" "$CURRENT_RUN_NUMBER" "$PURGE_STATUS_CONTEXT")
-            base=$(jq -r '.base // empty' <<< "$ledger_state")
-            unsafe=$(jq -r '.unsafe | length' <<< "$ledger_state")
-
-            if [ "$unsafe" -ne 0 ]; then
-              unsafe_runs=$(jq -r '.unsafe | join(", ")' <<< "$ledger_state")
-              echo "::warning::Earlier workflow run(s) $unsafe_runs may represent an unpurged production transition; purging the full zone."
-              emit mode full
-              exit 0
-            fi
-            if [ -z "$base" ]; then
-              echo "::warning::No known-good automatic purge checkpoint exists; purging the full zone."
-              emit mode full
-              exit 0
-            fi
-            echo "Baseline: $base, latest known-good automatic purge."
+          if [ "$INPUT_BROAD" = "true" ] && [ -z "${INPUT_RANGE:-}" ]; then
+            # Pages only. Cannot reach changed asset URLs or a locale that was
+            # removed, because both are discovered from a diff. Supply a range
+            # as well to recover those.
+            echo "Manual dispatch: broad page purge, no range given."
+            fallback_range && exit 0
+            echo "::warning::No range and no fallback window; deletions in the meantime cannot be discovered."
+            emit mode broad
+            exit 0
           fi
+          if [ -z "${INPUT_RANGE:-}" ]; then
+            echo "::error::broad_pages=false requires a 'range' input (e.g. abc1234..def5678)."
+            exit 1
+          fi
+          # Constrain the shape before it reaches git, so a value like
+          # `--upload-pack=...` cannot be read as an option.
+          if ! printf '%s' "$INPUT_RANGE" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*\.\.[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+            echo "::error::Invalid range '$INPUT_RANGE'. Expected <base>..<head>."
+            exit 1
+          fi
+          base="${INPUT_RANGE%%..*}"
+          head="${INPUT_RANGE##*..}"
 
-          # A force-push or rollback can leave the baseline outside the promoted
-          # commit's ancestry. Fetch main once so a newer prior deployment is
-          # available for a reverse diff. An automatic run with no reachable
-          # checkpoint cannot prove which assets were previously live.
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             git fetch --no-tags origin main || true
           fi
           if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
-            if [ "$EVENT" = "repository_dispatch" ]; then
-              echo "::warning::Known-good checkpoint $base is unreachable; purging the full zone."
-              emit mode full
-              exit 0
-            fi
             echo "Base commit $base is not reachable in this checkout."
             fallback_range "$head" && exit 0
             echo "::warning::No fallback window either; purging broadly."
@@ -326,24 +231,13 @@ jobs:
             exit 0
           fi
           if ! git cat-file -e "${head}^{commit}" 2>/dev/null; then
-            if [ "$EVENT" = "repository_dispatch" ]; then
-              echo "::warning::Promoted commit $head is unreachable; purging the full zone."
-              emit mode full
-            else
-              echo "::warning::Head commit $head is not reachable; purging broadly."
-              emit mode broad
-            fi
+            echo "::warning::Head commit $head is not reachable; purging broadly."
+            emit mode broad
             exit 0
           fi
 
-          if [ "$EVENT" = "workflow_dispatch" ] && [ "$INPUT_BROAD" = "true" ]; then
-            # Broad page coverage, topped up from the range.
+          if [ "$INPUT_BROAD" = "true" ]; then
             emit mode broad
-          elif [ "$EVENT" = "repository_dispatch" ] && [ "$base" = "$head" ]; then
-            # The Git tree is unchanged, but Vercel environment or build inputs
-            # can still change rendered output. Purge pages without evicting
-            # unchanged public assets or content-addressed generated assets.
-            emit mode pages
           else
             emit mode diff
           fi
@@ -363,9 +257,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A chronology hole has no recoverable promoted SHA. Use Cloudflare's
-          # explicit full-zone operation rather than pretending the current tree
-          # can enumerate assets that existed only in that missing deployment.
+          # Automatic promotions use Cloudflare's explicit full-zone operation
+          # and never need a deployed tree. Manual runs continue through the
+          # prefix mapper below.
           if [ "$MODE" = "full" ]; then
             jq -n '{prefixes: [], files: [], broad: true, collapsed: false}' > purge.json
           # No range to work from: a manual run without one or an unreachable
@@ -378,13 +272,12 @@ jobs:
             # is topped up with changed asset URLs and locales removed in the
             # range. --assets rides along for the same reason it applies to a
             # range-less run: broad means the diff is not trusted to be
-            # complete, and the window may not reach back far enough. A run that
-            # escalates to broad from a *trusted* diff does not get it — there we
-            # know exactly which assets changed, and evicting every image on any
-            # shared-file change is what avoiding purge_everything is for.
+            # complete, and the window may not reach back far enough. A manual
+            # run escalated from a trusted diff does not get it. There we know
+            # exactly which assets changed, and evicting every image on any
+            # shared-file change would defeat precise manual recovery.
             broad_flag=""
             [ "$MODE" = "broad" ] && broad_flag="--broad --assets"
-            [ "$MODE" = "pages" ] && broad_flag="--broad"
             # --no-renames is load-bearing. Git's rename detection is on by
             # default, and it reports a moved file as its destination alone, so
             # a page moved without edits would never have its old URL purged and
@@ -396,9 +289,9 @@ jobs:
             # renders, so the mapper widens the purge for them.
             # -z, not the default text format. Git prints pathnames verbatim
             # under it, so there is no C-quoting to decode and no whitespace to
-            # tell apart from a delimiter — the two things that silently
-            # mismapped `café.png` and `logo.png ` before. NUL cannot occur in a
-            # filename, so the framing is unambiguous by construction.
+            # tell apart from a delimiter. Those two issues silently mismapped
+            # `café.png` and `logo.png ` before. NUL cannot occur in a filename,
+            # so the framing is unambiguous by construction.
             #
             # --no-renames keeps a move reported as delete + add: git's rename
             # detection would otherwise name only the destination and the old URL
@@ -446,13 +339,10 @@ jobs:
           fi
           echo "collapsed=$collapsed" >> "$GITHUB_OUTPUT"
 
-      # Automatic promotions purge only the changed HTML/RSC prefixes and
-      # changed public files. Generated assets are content-addressed, and the
-      # zone's 4xx no-store rule prevents negative entries, so probing 21 fresh
-      # page shells on every deploy would add Vercel cost without adding safety.
-      #
-      # Manual recovery keeps live discovery: an operator may be clearing
-      # poisoned entries created before the no-store rule existed.
+      # Automatic promotions already have a complete full-zone plan and make no
+      # cache-busted Vercel page requests. Manual recovery keeps live discovery:
+      # an operator may be clearing poisoned entries created before the no-store
+      # rule existed.
       - name: Finalize purge plan
         id: assets
         env:
@@ -670,34 +560,3 @@ jobs:
           fi
 
           echo "::notice::Cloudflare purge complete."
-
-      # A successful full, selective, or no-op automatic run becomes the next
-      # known-good checkpoint. Recording no-ops matters: otherwise their run
-      # numbers look like chronology holes to a later promotion. A failed or
-      # degraded run leaves no marker and forces the next run to recover fully.
-      - name: Record the purge in deployment order
-        if: ${{ !inputs.dry_run && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ steps.event.outputs.head }}
-          DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
-          RUN_NUMBER: ${{ github.run_number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          ledger_sha=$(git rev-list --max-parents=0 HEAD | sort | sed -n '1p')
-          if [ "${{ steps.compute.outputs.full }}" = "true" ]; then
-            detail="Purged full zone"
-          elif [ "${{ steps.assets.outputs.count }}" = "0" ]; then
-            detail="No cache changes"
-          else
-            detail="Purged $(wc -l < prefixes.txt) prefixes, $(wc -l < files.txt) URLs"
-          fi
-          gh api -X POST "repos/$REPO/statuses/$ledger_sha" \
-            -f state=success \
-            -f context="$PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID" \
-            -f target_url="$RUN_URL" \
-            -f description="$RUN_NUMBER|$SHA|$detail" \
-            > /dev/null
-          echo "Marked $SHA as purged by $DEPLOYMENT_ID."

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -1,10 +1,12 @@
 name: Cloudflare Cache Purge
 
-# Purges the Cloudflare edge cache for the pages a production deploy actually
-# changed, so a docs edit is visible immediately instead of waiting out the 24h
-# edge TTL (`SHARED_CDN_CACHE` in next.config.mjs). Nothing here changes a TTL.
+# Invalidates Cloudflare after each production promotion so docs changes are
+# visible immediately instead of waiting out the 24h edge TTL
+# (`SHARED_CDN_CACHE` in next.config.mjs). Automatic promotions purge the full
+# zone; manual recovery can target prefixes and assets. Nothing here changes a
+# TTL.
 #
-# WHY PREFIXES, NOT URLS
+# WHY MANUAL RECOVERY USES PREFIXES, NOT URLS
 # The App Router serves the HTML document and the RSC flight payload at the same
 # path; the flight request carries a `?_rsc=<hash>` query that Next generates
 # client-side from router headers. Cloudflare keeps the query string in the
@@ -109,7 +111,7 @@ env:
 
 jobs:
   purge:
-    name: Purge changed prefixes
+    name: Purge production cache
     # Vercel emits this event for previews too. Reject non-production events
     # before a runner is allocated, then validate all routing fields before
     # Cloudflare secrets become reachable.

--- a/.github/workflows/cache-purge.yml
+++ b/.github/workflows/cache-purge.yml
@@ -120,14 +120,13 @@ env:
 jobs:
   purge:
     name: Purge changed prefixes
-    # Vercel emits this event for previews too. Reject those before a runner is
-    # allocated, then validate the same fields again before Cloudflare secrets
-    # become reachable.
+    # Vercel emits this event for previews too. Reject non-production events
+    # before a runner is allocated, then validate all routing fields before
+    # Cloudflare secrets become reachable.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.client_payload.environment == 'production' &&
-       github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj' &&
-       github.event.client_payload.git.ref == 'main')
+       github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -159,20 +158,26 @@ jobs:
         working-directory: workflow-source
         run: node scripts/cache-purge-event.mjs
 
-      # repository_dispatch fields are caller-controlled. The event can select a
-      # deployed tree only after proving that the SHA belongs to protected main.
-      # Older ancestors remain valid, which preserves production rollbacks.
+      # repository_dispatch fields are caller-controlled. The checkout must
+      # match the promoted SHA. Main deployments additionally prove ancestry
+      # before their tree can feed the mapper; non-main promotions never feed
+      # it and route directly to a full-zone purge.
       - name: Validate promoted source
         if: github.event_name == 'repository_dispatch'
         env:
           HEAD_SHA: ${{ steps.event.outputs.head }}
+          PROMOTED_REF: ${{ steps.event.outputs.ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
             echo "::error::The deployed checkout does not match the promoted SHA."
             exit 1
           fi
+          if [ "$PROMOTED_REF" != "main" ]; then
+            echo "::notice::Non-main production deployment will use full-zone recovery."
+            exit 0
+          fi
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$HEAD_SHA" origin/main; then
             echo "::error::The promoted SHA is not part of the current main history."
             exit 1
@@ -195,6 +200,7 @@ jobs:
           INPUT_RANGE: ${{ inputs.range }}
           HEAD_SHA: ${{ steps.event.outputs.head }}
           DEPLOYMENT_ID: ${{ steps.event.outputs.deployment_id }}
+          PROMOTED_REF: ${{ steps.event.outputs.ref }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}
           REPO: ${{ github.repository }}
           PURGE_STATUS_CONTEXT: ${{ env.PURGE_STATUS_CONTEXT }}
@@ -255,6 +261,11 @@ jobs:
             if ! printf '%s' "${DEPLOYMENT_ID:-}" | grep -Eq '^dpl_[A-Za-z0-9]+$'; then
               echo "::error::Promoted event carried no valid Vercel deployment id."
               exit 1
+            fi
+            if [ "$PROMOTED_REF" != "main" ]; then
+              echo "::warning::Non-main production deployment; purging the full zone."
+              emit mode full
+              exit 0
             fi
 
             # A successful purge is the only known-good cache checkpoint.
@@ -328,6 +339,11 @@ jobs:
           if [ "$EVENT" = "workflow_dispatch" ] && [ "$INPUT_BROAD" = "true" ]; then
             # Broad page coverage, topped up from the range.
             emit mode broad
+          elif [ "$EVENT" = "repository_dispatch" ] && [ "$base" = "$head" ]; then
+            # The Git tree is unchanged, but Vercel environment or build inputs
+            # can still change rendered output. Purge pages without evicting
+            # unchanged public assets or content-addressed generated assets.
+            emit mode pages
           else
             emit mode diff
           fi
@@ -368,6 +384,7 @@ jobs:
             # shared-file change is what avoiding purge_everything is for.
             broad_flag=""
             [ "$MODE" = "broad" ] && broad_flag="--broad --assets"
+            [ "$MODE" = "pages" ] && broad_flag="--broad"
             # --no-renames is load-bearing. Git's rename detection is on by
             # default, and it reports a moved file as its destination alone, so
             # a page moved without edits would never have its old URL purged and

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -1,13 +1,9 @@
-import { appendFileSync, readFileSync } from 'node:fs'
+import { appendFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
 
-const COMMIT_SHA = /^[0-9a-f]{40}$/u
 const DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]+$/u
-const GIT_REF = /^(?!.*(?:^|\/)\.)(?!.*\.\.)(?!.*\/$)[A-Za-z0-9][A-Za-z0-9._/-]*$/u
-const PURGE_LEDGER_DESCRIPTION = /^([1-9]\d*)\|([0-9a-f]{40})\|/u
-const RUN_TITLE = /^cache-purge:([^:]+):([^:]+):([^:]+):([0-9a-f]{40}):(dpl_[A-Za-z0-9]+)$/u
 
 /**
  * Validates the enriched payload Vercel sends with
@@ -27,173 +23,16 @@ export function validatePromotedDeployment(payload) {
       `Vercel event has an unexpected Vercel project: ${payload.project?.id ?? 'missing'}`,
     )
   }
-  if (!GIT_REF.test(payload.git?.ref ?? '')) {
-    throw new Error(`Vercel event has an invalid Git ref: ${payload.git?.ref ?? 'missing'}`)
-  }
-  if (!COMMIT_SHA.test(payload.git?.sha ?? '')) {
-    throw new Error(`Vercel event has an invalid Git commit SHA: ${payload.git?.sha ?? 'missing'}`)
-  }
   if (!DEPLOYMENT_ID.test(payload.id ?? '')) {
     throw new Error(`Vercel event has an invalid Vercel deployment ID: ${payload.id ?? 'missing'}`)
   }
 
   return {
     deploymentId: payload.id,
-    head: payload.git.sha,
-    ref: payload.git.ref,
-  }
-}
-
-function parseCachePurgeRunTitle(value) {
-  if (typeof value !== 'string') return null
-  const match = value.match(RUN_TITLE)
-  if (!match) return null
-  return {
-    environment: match[1],
-    projectId: match[2],
-    ref: match[3],
-    sha: match[4],
-    deploymentId: match[5],
-  }
-}
-
-/**
- * Finds the latest known-good purge checkpoint and proves that no workflow run
- * between it and the current event can hide an unpurged production transition.
- *
- * `run-name` is evaluated when GitHub creates a run, before a runner starts,
- * and the REST API exposes it as `display_title`. It carries the immutable
- * Vercel routing fields even for queued, failed, or cancelled runs. A current
- * project production run after the checkpoint is therefore unsafe to skip;
- * previews and manual recovery runs do not change this production history.
- */
-export function selectPurgeState(
-  statusPages,
-  workflowRunPages,
-  currentHead,
-  currentRunNumber,
-  purgeContextPrefix = 'cache-purge',
-) {
-  if (!COMMIT_SHA.test(currentHead)) {
-    throw new Error(`Current head is not a valid Git commit SHA: ${currentHead}`)
-  }
-  if (!/^[1-9]\d*$/u.test(currentRunNumber)) {
-    throw new Error(`Current run number is invalid: ${currentRunNumber}`)
-  }
-
-  const currentRun = BigInt(currentRunNumber)
-  const runsByNumber = new Map()
-  for (const page of Array.isArray(workflowRunPages) ? workflowRunPages : []) {
-    for (const run of Array.isArray(page?.workflow_runs) ? page.workflow_runs : []) {
-      if (!/^[1-9]\d*$/u.test(String(run?.run_number ?? ''))) continue
-      const runNumber = BigInt(run.run_number)
-      if (runNumber >= currentRun) continue
-      runsByNumber.set(String(runNumber), run)
-    }
-  }
-
-  const purgeContext = `${purgeContextPrefix}/`
-  let checkpoint
-  for (const status of Array.isArray(statusPages) ? statusPages.flat() : []) {
-    if (
-      !status ||
-      typeof status !== 'object' ||
-      status.state !== 'success' ||
-      typeof status.context !== 'string' ||
-      !status.context.startsWith(purgeContext) ||
-      typeof status.description !== 'string'
-    ) {
-      continue
-    }
-
-    const deploymentId = status.context.slice(purgeContext.length)
-    const marker = status.description.match(PURGE_LEDGER_DESCRIPTION)
-    if (!DEPLOYMENT_ID.test(deploymentId) || !marker) continue
-
-    const entry = {
-      deploymentId,
-      runNumber: BigInt(marker[1]),
-      sha: marker[2],
-    }
-    if (entry.runNumber >= currentRun) continue
-
-    const run = runsByNumber.get(String(entry.runNumber))
-    const metadata = parseCachePurgeRunTitle(run?.display_title)
-    if (
-      run?.event !== 'repository_dispatch' ||
-      metadata?.environment !== 'production' ||
-      metadata.projectId !== VERCEL_PROJECT_ID ||
-      metadata.sha !== entry.sha ||
-      metadata.deploymentId !== entry.deploymentId
-    ) {
-      continue
-    }
-    if (!checkpoint || entry.runNumber > checkpoint.runNumber) {
-      checkpoint = entry
-    }
-  }
-
-  if (!checkpoint) {
-    return { base: null, unsafe: [] }
-  }
-
-  const unsafe = []
-  for (let runNumber = checkpoint.runNumber + 1n; runNumber < currentRun; runNumber += 1n) {
-    const key = String(runNumber)
-    const run = runsByNumber.get(key)
-    if (!run) {
-      unsafe.push(key)
-      continue
-    }
-    if (run.event === 'workflow_dispatch') continue
-    if (run.event !== 'repository_dispatch') {
-      unsafe.push(key)
-      continue
-    }
-
-    const metadata = parseCachePurgeRunTitle(run.display_title)
-    if (!metadata) {
-      unsafe.push(key)
-      continue
-    }
-    if (metadata.environment !== 'production' || metadata.projectId !== VERCEL_PROJECT_ID) {
-      continue
-    }
-
-    // The normal production branch and a manually promoted non-main deployment
-    // both changed what the zone served. The current job validates main events;
-    // either kind is a chronology hole until a successful purge checkpoints it.
-    unsafe.push(key)
-  }
-
-  return {
-    base: checkpoint.sha,
-    unsafe,
   }
 }
 
 function main() {
-  if (process.argv[2] === 'baseline') {
-    const [, , , statusFile, workflowRunsFile, currentHead, currentRunNumber, purgeContextPrefix] =
-      process.argv
-    if (!statusFile || !workflowRunsFile || !currentHead || !currentRunNumber) {
-      throw new Error(
-        'baseline requires <status-file> <workflow-runs-file> <current-head> <current-run-number> [purge-context]',
-      )
-    }
-    const statusPages = JSON.parse(readFileSync(statusFile, 'utf8'))
-    const workflowRunPages = JSON.parse(readFileSync(workflowRunsFile, 'utf8'))
-    const state = selectPurgeState(
-      statusPages,
-      workflowRunPages,
-      currentHead,
-      currentRunNumber,
-      purgeContextPrefix,
-    )
-    process.stdout.write(`${JSON.stringify(state)}\n`)
-    return
-  }
-
   const output = process.env.GITHUB_OUTPUT
   if (!output) throw new Error('GITHUB_OUTPUT is required')
 
@@ -205,10 +44,7 @@ function main() {
   }
 
   const event = validatePromotedDeployment(payload)
-  appendFileSync(
-    output,
-    `deployment_id=${event.deploymentId}\nhead=${event.head}\nref=${event.ref}\n`,
-  )
+  appendFileSync(output, `deployment_id=${event.deploymentId}\n`)
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -1,4 +1,4 @@
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
@@ -40,7 +40,55 @@ export function validatePromotedDeployment(payload) {
   }
 }
 
+/**
+ * Selects the most recently recorded successful deployment that differs from
+ * the commit currently being promoted. Statuses live on one stable ledger
+ * commit, so created_at represents promotion order even when production rolls
+ * back from a descendant to an ancestor.
+ */
+export function selectPreviousPurgedCommit(
+  statusPages,
+  currentHead,
+  contextPrefix = 'cache-purge',
+) {
+  if (!COMMIT_SHA.test(currentHead)) {
+    throw new Error(`Current head is not a valid Git commit SHA: ${currentHead}`)
+  }
+
+  const deploymentContext = `${contextPrefix}/dpl_`
+  return (
+    (Array.isArray(statusPages) ? statusPages.flat() : [])
+      .filter(
+        (status) =>
+          status &&
+          typeof status === 'object' &&
+          status.state === 'success' &&
+          typeof status.context === 'string' &&
+          status.context.startsWith(deploymentContext) &&
+          typeof status.created_at === 'string' &&
+          typeof status.description === 'string',
+      )
+      .map((status) => ({
+        createdAt: status.created_at,
+        sha: status.description.slice(0, 40),
+      }))
+      .filter(({ sha }) => COMMIT_SHA.test(sha) && sha !== currentHead)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0]?.sha ?? null
+  )
+}
+
 function main() {
+  if (process.argv[2] === 'baseline') {
+    const [, , , statusFile, currentHead, contextPrefix] = process.argv
+    if (!statusFile || !currentHead) {
+      throw new Error('baseline requires <status-file> <current-head> [context-prefix]')
+    }
+    const statusPages = JSON.parse(readFileSync(statusFile, 'utf8'))
+    const base = selectPreviousPurgedCommit(statusPages, currentHead, contextPrefix)
+    if (base) process.stdout.write(`${base}\n`)
+    return
+  }
+
   const output = process.env.GITHUB_OUTPUT
   if (!output) throw new Error('GITHUB_OUTPUT is required')
 

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -42,58 +42,100 @@ export function validatePromotedDeployment(payload) {
 }
 
 /**
- * Selects the latest successful promotion that differs from the commit
- * currently being promoted. GitHub assigns `run_number` when each workflow run
- * is created and keeps it stable on reruns, so it preserves event order even
- * when overlapping purges finish in the opposite order.
+ * Returns two independent facts from the deployment ledger:
+ * - `base`: latest successful purge from a different commit
+ * - `previous`: commit from the immediately preceding trusted promotion
+ *
+ * `run_number` is assigned when each workflow run is created and stays stable
+ * on reruns, so it preserves event order when overlapping purges finish in the
+ * opposite order.
  */
-export function selectPreviousPurgedCommit(
+export function selectPurgeState(
   statusPages,
   currentHead,
-  contextPrefix = 'cache-purge',
+  currentRunNumber,
+  purgeContextPrefix = 'cache-purge',
+  promotionContextPrefix = 'cache-promotion',
 ) {
   if (!COMMIT_SHA.test(currentHead)) {
     throw new Error(`Current head is not a valid Git commit SHA: ${currentHead}`)
   }
+  if (!/^[1-9]\d*$/u.test(currentRunNumber)) {
+    throw new Error(`Current run number is invalid: ${currentRunNumber}`)
+  }
 
-  const deploymentContext = `${contextPrefix}/dpl_`
-  const deployments = []
+  const currentRun = BigInt(currentRunNumber)
+  const purgeContext = `${purgeContextPrefix}/dpl_`
+  const promotionContext = `${promotionContextPrefix}/dpl_`
+  let base
+  let previous
+
   for (const status of Array.isArray(statusPages) ? statusPages.flat() : []) {
     if (
       !status ||
       typeof status !== 'object' ||
       status.state !== 'success' ||
       typeof status.context !== 'string' ||
-      !status.context.startsWith(deploymentContext) ||
       typeof status.description !== 'string'
     ) {
       continue
     }
 
     const marker = status.description.match(PURGE_LEDGER_DESCRIPTION)
-    if (!marker || marker[2] === currentHead) continue
-    deployments.push({
+    if (!marker) continue
+    const entry = {
       runNumber: BigInt(marker[1]),
       sha: marker[2],
-    })
+    }
+    if (entry.runNumber >= currentRun) continue
+
+    if (
+      status.context.startsWith(promotionContext) &&
+      (!previous || entry.runNumber > previous.runNumber)
+    ) {
+      previous = entry
+    }
+    if (
+      status.context.startsWith(purgeContext) &&
+      entry.sha !== currentHead &&
+      (!base || entry.runNumber > base.runNumber)
+    ) {
+      base = entry
+    }
   }
 
-  deployments.sort((left, right) => {
-    if (left.runNumber === right.runNumber) return 0
-    return left.runNumber > right.runNumber ? -1 : 1
-  })
-  return deployments[0]?.sha ?? null
+  return {
+    base: base?.sha ?? null,
+    previous: previous?.sha ?? null,
+  }
 }
 
 function main() {
   if (process.argv[2] === 'baseline') {
-    const [, , , statusFile, currentHead, contextPrefix] = process.argv
-    if (!statusFile || !currentHead) {
-      throw new Error('baseline requires <status-file> <current-head> [context-prefix]')
+    const [
+      ,
+      ,
+      ,
+      statusFile,
+      currentHead,
+      currentRunNumber,
+      purgeContextPrefix,
+      promotionContextPrefix,
+    ] = process.argv
+    if (!statusFile || !currentHead || !currentRunNumber) {
+      throw new Error(
+        'baseline requires <status-file> <current-head> <current-run-number> [purge-context] [promotion-context]',
+      )
     }
     const statusPages = JSON.parse(readFileSync(statusFile, 'utf8'))
-    const base = selectPreviousPurgedCommit(statusPages, currentHead, contextPrefix)
-    if (base) process.stdout.write(`${base}\n`)
+    const state = selectPurgeState(
+      statusPages,
+      currentHead,
+      currentRunNumber,
+      purgeContextPrefix,
+      promotionContextPrefix,
+    )
+    process.stdout.write(`${JSON.stringify(state)}\n`)
     return
   }
 

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -1,0 +1,65 @@
+import { appendFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/u
+const DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]+$/u
+
+/**
+ * Validates the enriched payload Vercel sends with
+ * `vercel.deployment.promoted`. The workflow filters the same fields before
+ * allocating a runner; this is the credential-boundary check before it reaches
+ * Cloudflare secrets.
+ */
+export function validatePromotedDeployment(payload) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Vercel promoted payload is missing')
+  }
+  if (payload.environment !== 'production') {
+    throw new Error('Vercel event is not a production deployment')
+  }
+  if (payload.project?.id !== VERCEL_PROJECT_ID) {
+    throw new Error(
+      `Vercel event has an unexpected Vercel project: ${payload.project?.id ?? 'missing'}`,
+    )
+  }
+  if (payload.git?.ref !== 'main') {
+    throw new Error(`Vercel event is not the production branch: ${payload.git?.ref ?? 'missing'}`)
+  }
+  if (!COMMIT_SHA.test(payload.git?.sha ?? '')) {
+    throw new Error(`Vercel event has an invalid Git commit SHA: ${payload.git?.sha ?? 'missing'}`)
+  }
+  if (!DEPLOYMENT_ID.test(payload.id ?? '')) {
+    throw new Error(`Vercel event has an invalid Vercel deployment ID: ${payload.id ?? 'missing'}`)
+  }
+
+  return {
+    deploymentId: payload.id,
+    head: payload.git.sha,
+  }
+}
+
+function main() {
+  const output = process.env.GITHUB_OUTPUT
+  if (!output) throw new Error('GITHUB_OUTPUT is required')
+
+  let payload
+  try {
+    payload = JSON.parse(process.env.CLIENT_PAYLOAD ?? '')
+  } catch {
+    throw new Error('CLIENT_PAYLOAD is not valid JSON')
+  }
+
+  const event = validatePromotedDeployment(payload)
+  appendFileSync(output, `deployment_id=${event.deploymentId}\nhead=${event.head}\n`)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main()
+  } catch (error) {
+    process.stderr.write(`::error::${error.message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -6,6 +6,7 @@ export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
 const COMMIT_SHA = /^[0-9a-f]{40}$/u
 const DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]+$/u
 const PURGE_LEDGER_DESCRIPTION = /^([1-9]\d*)\|([0-9a-f]{40})\|/u
+const RUN_TITLE = /^cache-purge:([^:]+):([^:]+):([^:]+):([0-9a-f]{40}):(dpl_[A-Za-z0-9]+)$/u
 
 /**
  * Validates the enriched payload Vercel sends with
@@ -41,21 +42,35 @@ export function validatePromotedDeployment(payload) {
   }
 }
 
+function parseCachePurgeRunTitle(value) {
+  if (typeof value !== 'string') return null
+  const match = value.match(RUN_TITLE)
+  if (!match) return null
+  return {
+    environment: match[1],
+    projectId: match[2],
+    ref: match[3],
+    sha: match[4],
+    deploymentId: match[5],
+  }
+}
+
 /**
- * Returns two independent facts from the deployment ledger:
- * - `base`: latest successful purge from a different commit
- * - `previous`: commit from the immediately preceding trusted promotion
+ * Finds the latest known-good purge checkpoint and proves that no workflow run
+ * between it and the current event can hide an unpurged production transition.
  *
- * `run_number` is assigned when each workflow run is created and stays stable
- * on reruns, so it preserves event order when overlapping purges finish in the
- * opposite order.
+ * `run-name` is evaluated when GitHub creates a run, before a runner starts,
+ * and the REST API exposes it as `display_title`. It carries the immutable
+ * Vercel routing fields even for queued, failed, or cancelled runs. A current
+ * project production run after the checkpoint is therefore unsafe to skip;
+ * previews and manual recovery runs do not change this production history.
  */
 export function selectPurgeState(
   statusPages,
+  workflowRunPages,
   currentHead,
   currentRunNumber,
   purgeContextPrefix = 'cache-purge',
-  promotionContextPrefix = 'cache-promotion',
 ) {
   if (!COMMIT_SHA.test(currentHead)) {
     throw new Error(`Current head is not a valid Git commit SHA: ${currentHead}`)
@@ -65,75 +80,114 @@ export function selectPurgeState(
   }
 
   const currentRun = BigInt(currentRunNumber)
-  const purgeContext = `${purgeContextPrefix}/dpl_`
-  const promotionContext = `${promotionContextPrefix}/dpl_`
-  let base
-  let previous
+  const runsByNumber = new Map()
+  for (const page of Array.isArray(workflowRunPages) ? workflowRunPages : []) {
+    for (const run of Array.isArray(page?.workflow_runs) ? page.workflow_runs : []) {
+      if (!/^[1-9]\d*$/u.test(String(run?.run_number ?? ''))) continue
+      const runNumber = BigInt(run.run_number)
+      if (runNumber >= currentRun) continue
+      runsByNumber.set(String(runNumber), run)
+    }
+  }
 
+  const purgeContext = `${purgeContextPrefix}/`
+  let checkpoint
   for (const status of Array.isArray(statusPages) ? statusPages.flat() : []) {
     if (
       !status ||
       typeof status !== 'object' ||
       status.state !== 'success' ||
       typeof status.context !== 'string' ||
+      !status.context.startsWith(purgeContext) ||
       typeof status.description !== 'string'
     ) {
       continue
     }
 
+    const deploymentId = status.context.slice(purgeContext.length)
     const marker = status.description.match(PURGE_LEDGER_DESCRIPTION)
-    if (!marker) continue
+    if (!DEPLOYMENT_ID.test(deploymentId) || !marker) continue
+
     const entry = {
+      deploymentId,
       runNumber: BigInt(marker[1]),
       sha: marker[2],
     }
     if (entry.runNumber >= currentRun) continue
 
+    const run = runsByNumber.get(String(entry.runNumber))
+    const metadata = parseCachePurgeRunTitle(run?.display_title)
     if (
-      status.context.startsWith(promotionContext) &&
-      (!previous || entry.runNumber > previous.runNumber)
+      run?.event !== 'repository_dispatch' ||
+      metadata?.environment !== 'production' ||
+      metadata.projectId !== VERCEL_PROJECT_ID ||
+      metadata.ref !== 'main' ||
+      metadata.sha !== entry.sha ||
+      metadata.deploymentId !== entry.deploymentId
     ) {
-      previous = entry
+      continue
     }
-    if (
-      status.context.startsWith(purgeContext) &&
-      entry.sha !== currentHead &&
-      (!base || entry.runNumber > base.runNumber)
-    ) {
-      base = entry
+    if (!checkpoint || entry.runNumber > checkpoint.runNumber) {
+      checkpoint = entry
     }
   }
 
+  if (!checkpoint) {
+    return { base: null, unsafe: [] }
+  }
+
+  const unsafe = []
+  for (let runNumber = checkpoint.runNumber + 1n; runNumber < currentRun; runNumber += 1n) {
+    const key = String(runNumber)
+    const run = runsByNumber.get(key)
+    if (!run) {
+      unsafe.push(key)
+      continue
+    }
+    if (run.event === 'workflow_dispatch') continue
+    if (run.event !== 'repository_dispatch') {
+      unsafe.push(key)
+      continue
+    }
+
+    const metadata = parseCachePurgeRunTitle(run.display_title)
+    if (!metadata) {
+      unsafe.push(key)
+      continue
+    }
+    if (metadata.environment !== 'production' || metadata.projectId !== VERCEL_PROJECT_ID) {
+      continue
+    }
+
+    // The normal production branch and a manually promoted non-main deployment
+    // both changed what the zone served. The current job validates main events;
+    // either kind is a chronology hole until a successful purge checkpoints it.
+    unsafe.push(key)
+  }
+
   return {
-    base: base?.sha ?? null,
-    previous: previous?.sha ?? null,
+    base: checkpoint.sha,
+    unsafe,
   }
 }
 
 function main() {
   if (process.argv[2] === 'baseline') {
-    const [
-      ,
-      ,
-      ,
-      statusFile,
-      currentHead,
-      currentRunNumber,
-      purgeContextPrefix,
-      promotionContextPrefix,
-    ] = process.argv
-    if (!statusFile || !currentHead || !currentRunNumber) {
+    const [, , , statusFile, workflowRunsFile, currentHead, currentRunNumber, purgeContextPrefix] =
+      process.argv
+    if (!statusFile || !workflowRunsFile || !currentHead || !currentRunNumber) {
       throw new Error(
-        'baseline requires <status-file> <current-head> <current-run-number> [purge-context] [promotion-context]',
+        'baseline requires <status-file> <workflow-runs-file> <current-head> <current-run-number> [purge-context]',
       )
     }
     const statusPages = JSON.parse(readFileSync(statusFile, 'utf8'))
+    const workflowRunPages = JSON.parse(readFileSync(workflowRunsFile, 'utf8'))
     const state = selectPurgeState(
       statusPages,
+      workflowRunPages,
       currentHead,
       currentRunNumber,
       purgeContextPrefix,
-      promotionContextPrefix,
     )
     process.stdout.write(`${JSON.stringify(state)}\n`)
     return

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -5,6 +5,7 @@ export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/u
 const DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]+$/u
+const PURGE_LEDGER_DESCRIPTION = /^([1-9]\d*)\|([0-9a-f]{40})\|/u
 
 /**
  * Validates the enriched payload Vercel sends with
@@ -41,10 +42,10 @@ export function validatePromotedDeployment(payload) {
 }
 
 /**
- * Selects the most recently recorded successful deployment that differs from
- * the commit currently being promoted. Statuses live on one stable ledger
- * commit, so created_at represents promotion order even when production rolls
- * back from a descendant to an ancestor.
+ * Selects the latest successful promotion that differs from the commit
+ * currently being promoted. GitHub assigns `run_number` when each workflow run
+ * is created and keeps it stable on reruns, so it preserves event order even
+ * when overlapping purges finish in the opposite order.
  */
 export function selectPreviousPurgedCommit(
   statusPages,
@@ -56,25 +57,32 @@ export function selectPreviousPurgedCommit(
   }
 
   const deploymentContext = `${contextPrefix}/dpl_`
-  return (
-    (Array.isArray(statusPages) ? statusPages.flat() : [])
-      .filter(
-        (status) =>
-          status &&
-          typeof status === 'object' &&
-          status.state === 'success' &&
-          typeof status.context === 'string' &&
-          status.context.startsWith(deploymentContext) &&
-          typeof status.created_at === 'string' &&
-          typeof status.description === 'string',
-      )
-      .map((status) => ({
-        createdAt: status.created_at,
-        sha: status.description.slice(0, 40),
-      }))
-      .filter(({ sha }) => COMMIT_SHA.test(sha) && sha !== currentHead)
-      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0]?.sha ?? null
-  )
+  const deployments = []
+  for (const status of Array.isArray(statusPages) ? statusPages.flat() : []) {
+    if (
+      !status ||
+      typeof status !== 'object' ||
+      status.state !== 'success' ||
+      typeof status.context !== 'string' ||
+      !status.context.startsWith(deploymentContext) ||
+      typeof status.description !== 'string'
+    ) {
+      continue
+    }
+
+    const marker = status.description.match(PURGE_LEDGER_DESCRIPTION)
+    if (!marker || marker[2] === currentHead) continue
+    deployments.push({
+      runNumber: BigInt(marker[1]),
+      sha: marker[2],
+    })
+  }
+
+  deployments.sort((left, right) => {
+    if (left.runNumber === right.runNumber) return 0
+    return left.runNumber > right.runNumber ? -1 : 1
+  })
+  return deployments[0]?.sha ?? null
 }
 
 function main() {

--- a/scripts/cache-purge-event.mjs
+++ b/scripts/cache-purge-event.mjs
@@ -5,6 +5,7 @@ export const VERCEL_PROJECT_ID = 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'
 
 const COMMIT_SHA = /^[0-9a-f]{40}$/u
 const DEPLOYMENT_ID = /^dpl_[A-Za-z0-9]+$/u
+const GIT_REF = /^(?!.*(?:^|\/)\.)(?!.*\.\.)(?!.*\/$)[A-Za-z0-9][A-Za-z0-9._/-]*$/u
 const PURGE_LEDGER_DESCRIPTION = /^([1-9]\d*)\|([0-9a-f]{40})\|/u
 const RUN_TITLE = /^cache-purge:([^:]+):([^:]+):([^:]+):([0-9a-f]{40}):(dpl_[A-Za-z0-9]+)$/u
 
@@ -26,8 +27,8 @@ export function validatePromotedDeployment(payload) {
       `Vercel event has an unexpected Vercel project: ${payload.project?.id ?? 'missing'}`,
     )
   }
-  if (payload.git?.ref !== 'main') {
-    throw new Error(`Vercel event is not the production branch: ${payload.git?.ref ?? 'missing'}`)
+  if (!GIT_REF.test(payload.git?.ref ?? '')) {
+    throw new Error(`Vercel event has an invalid Git ref: ${payload.git?.ref ?? 'missing'}`)
   }
   if (!COMMIT_SHA.test(payload.git?.sha ?? '')) {
     throw new Error(`Vercel event has an invalid Git commit SHA: ${payload.git?.sha ?? 'missing'}`)
@@ -39,6 +40,7 @@ export function validatePromotedDeployment(payload) {
   return {
     deploymentId: payload.id,
     head: payload.git.sha,
+    ref: payload.git.ref,
   }
 }
 
@@ -121,7 +123,6 @@ export function selectPurgeState(
       run?.event !== 'repository_dispatch' ||
       metadata?.environment !== 'production' ||
       metadata.projectId !== VERCEL_PROJECT_ID ||
-      metadata.ref !== 'main' ||
       metadata.sha !== entry.sha ||
       metadata.deploymentId !== entry.deploymentId
     ) {
@@ -204,7 +205,10 @@ function main() {
   }
 
   const event = validatePromotedDeployment(payload)
-  appendFileSync(output, `deployment_id=${event.deploymentId}\nhead=${event.head}\n`)
+  appendFileSync(
+    output,
+    `deployment_id=${event.deploymentId}\nhead=${event.head}\nref=${event.ref}\n`,
+  )
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   VERCEL_PROJECT_ID,
-  selectPreviousPurgedCommit,
+  selectPurgeState,
   validatePromotedDeployment,
 } from './cache-purge-event.mjs'
 
@@ -42,12 +42,18 @@ describe('validatePromotedDeployment', () => {
   })
 })
 
-describe('selectPreviousPurgedCommit', () => {
-  const status = (sha: string, runNumber: string, createdAt: string) => ({
-    context: 'cache-purge/dpl_test',
+describe('selectPurgeState', () => {
+  const status = (
+    kind: 'cache-promotion' | 'cache-purge',
+    sha: string,
+    runNumber: string,
+    createdAt: string,
+    state = 'success',
+  ) => ({
+    context: `${kind}/dpl_test`,
     created_at: createdAt,
-    description: `${runNumber}|${sha}|Purged 3 prefixes, 1 URLs`,
-    state: 'success',
+    description: `${runNumber}|${sha}|${kind}`,
+    state,
   })
 
   it('uses promotion chronology when the current deployment rolls back', () => {
@@ -56,57 +62,96 @@ describe('selectPreviousPurgedCommit', () => {
     const olderDeployed = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     expect(
-      selectPreviousPurgedCommit(
+      selectPurgeState(
         [
           // The older promotion finishes last. Completion timestamps must not
           // override the workflow run numbers assigned at event delivery.
-          [status(olderDeployed, '10', '2026-09-01T13:00:00Z')],
-          [status(latestDeployed, '11', '2026-09-01T12:00:00Z')],
+          [
+            status('cache-promotion', olderDeployed, '10', '2026-09-01T13:00:00Z'),
+            status('cache-purge', olderDeployed, '10', '2026-09-01T13:00:00Z'),
+          ],
+          [
+            status('cache-promotion', latestDeployed, '11', '2026-09-01T12:00:00Z'),
+            status('cache-purge', latestDeployed, '11', '2026-09-01T12:00:00Z'),
+          ],
         ],
         rollbackHead,
+        '12',
       ),
-    ).toBe(latestDeployed)
+    ).toEqual({ base: latestDeployed, previous: latestDeployed })
   })
 
-  it('skips a prior deployment of the same commit', () => {
+  it('keeps the same-commit predecessor but skips it as a diff baseline', () => {
     const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
     const previousHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     expect(
-      selectPreviousPurgedCommit(
+      selectPurgeState(
         [
           [
-            status(currentHead, '12', '2026-09-01T13:00:00Z'),
-            status(previousHead, '11', '2026-09-01T12:00:00Z'),
+            status('cache-promotion', currentHead, '12', '2026-09-01T13:00:00Z'),
+            status('cache-purge', currentHead, '12', '2026-09-01T13:00:00Z'),
+            status('cache-promotion', previousHead, '11', '2026-09-01T12:00:00Z'),
+            status('cache-purge', previousHead, '11', '2026-09-01T12:00:00Z'),
           ],
         ],
         currentHead,
+        '13',
       ),
-    ).toBe(previousHead)
+    ).toEqual({ base: previousHead, previous: currentHead })
   })
 
-  it('ignores failed and malformed ledger entries', () => {
+  it('retains an unpurged predecessor separately from the last success', () => {
     const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const unpurgedHead = 'cccccccccccccccccccccccccccccccccccccccc'
+    const successfulHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
     expect(
-      selectPreviousPurgedCommit(
+      selectPurgeState(
         [
           [
-            {
-              ...status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '10', '2026-09-01T12:00:00Z'),
-              state: 'failure',
-            },
-            { ...status('not-a-sha', '11', '2026-09-01T13:00:00Z') },
-            {
-              ...status(
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-                'not-a-run',
-                '2026-09-01T14:00:00Z',
-              ),
-            },
+            status('cache-promotion', unpurgedHead, '11', '2026-09-01T13:00:00Z'),
+            status('cache-promotion', successfulHead, '10', '2026-09-01T12:00:00Z'),
+            status('cache-purge', successfulHead, '10', '2026-09-01T12:05:00Z'),
           ],
         ],
         currentHead,
+        '12',
       ),
-    ).toBeNull()
+    ).toEqual({ base: successfulHead, previous: unpurgedHead })
+  })
+
+  it('ignores future, failed, and malformed ledger entries', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    expect(
+      selectPurgeState(
+        [
+          [
+            status(
+              'cache-purge',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              '10',
+              '2026-09-01T12:00:00Z',
+              'failure',
+            ),
+            status('cache-promotion', 'not-a-sha', '11', '2026-09-01T13:00:00Z'),
+            status(
+              'cache-promotion',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              'not-a-run',
+              '2026-09-01T14:00:00Z',
+            ),
+            status(
+              'cache-promotion',
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              '13',
+              '2026-09-01T15:00:00Z',
+            ),
+          ],
+        ],
+        currentHead,
+        '12',
+      ),
+    ).toEqual({ base: null, previous: null })
   })
 })

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  VERCEL_PROJECT_ID,
-  selectPurgeState,
-  validatePromotedDeployment,
-} from './cache-purge-event.mjs'
+import { VERCEL_PROJECT_ID, validatePromotedDeployment } from './cache-purge-event.mjs'
 
 const promoted = {
   environment: 'production',
@@ -20,11 +16,15 @@ const promoted = {
 }
 
 describe('validatePromotedDeployment', () => {
-  it('returns the trusted routing fields for this project production deployment', () => {
+  it('returns the trusted deployment id for this project production event', () => {
     expect(validatePromotedDeployment(promoted)).toEqual({
       deploymentId: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa',
-      head: 'e161206fa9fd03294430019666687e8f8e232201',
-      ref: 'main',
+    })
+  })
+
+  it('accepts production promotions without Git metadata', () => {
+    expect(validatePromotedDeployment({ ...promoted, git: undefined })).toEqual({
+      deploymentId: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa',
     })
   })
 
@@ -34,7 +34,7 @@ describe('validatePromotedDeployment', () => {
         ...promoted,
         git: { ...promoted.git, ref: 'feature/manual-promotion' },
       }),
-    ).toMatchObject({ ref: 'feature/manual-promotion' })
+    ).toEqual({ deploymentId: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa' })
   })
 
   it.each([
@@ -44,160 +44,8 @@ describe('validatePromotedDeployment', () => {
       { project: { id: 'prj_other', name: 'other' } },
       'unexpected Vercel project',
     ],
-    ['malformed SHA', { git: { ref: 'main', sha: 'main' } }, 'invalid Git commit SHA'],
     ['malformed deployment id', { id: '6204988438' }, 'invalid Vercel deployment ID'],
-    ['malformed branch', { git: { ...promoted.git, ref: '../main' } }, 'invalid Git ref'],
   ])('rejects a %s', (_name, patch, message) => {
     expect(() => validatePromotedDeployment({ ...promoted, ...patch })).toThrow(message)
-  })
-})
-
-describe('selectPurgeState', () => {
-  const status = (sha: string, runNumber: string, state = 'success') => ({
-    context: 'cache-purge/dpl_test',
-    description: `${runNumber}|${sha}|Purged`,
-    state,
-  })
-
-  const runTitle = ({
-    environment = 'production',
-    projectId = VERCEL_PROJECT_ID,
-    ref = 'main',
-    sha = 'cccccccccccccccccccccccccccccccccccccccc',
-  } = {}) => `cache-purge:${environment}:${projectId}:${ref}:${sha}:dpl_test`
-
-  const run = (
-    runNumber: number,
-    {
-      displayTitle = runTitle(),
-      event = 'repository_dispatch',
-    }: { displayTitle?: string; event?: string } = {},
-  ) => ({
-    display_title: displayTitle,
-    event,
-    run_number: runNumber,
-  })
-
-  it('selects the latest successful purge checkpoint across status pages', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const latestPurged = 'cccccccccccccccccccccccccccccccccccccccc'
-    const olderPurged = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [[status(olderPurged, '10')], [status(latestPurged, '11'), status(currentHead, '13')]],
-        [
-          {
-            workflow_runs: [
-              run(10, { displayTitle: runTitle({ sha: olderPurged }) }),
-              run(11, { displayTitle: runTitle({ sha: latestPurged }) }),
-            ],
-          },
-        ],
-        currentHead,
-        '12',
-      ),
-    ).toEqual({ base: latestPurged, unsafe: [] })
-  })
-
-  it('uses a same-commit purge as the known-good checkpoint', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-
-    expect(
-      selectPurgeState(
-        [[status(currentHead, '11')]],
-        [{ workflow_runs: [run(11, { displayTitle: runTitle({ sha: currentHead }) })] }],
-        currentHead,
-        '12',
-      ),
-    ).toEqual({ base: currentHead, unsafe: [] })
-  })
-
-  it('rejects a lower production promotion before its runner starts', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [[status(checkpoint, '10')]],
-        [
-          {
-            workflow_runs: [run(10, { displayTitle: runTitle({ sha: checkpoint }) }), run(11)],
-          },
-        ],
-        currentHead,
-        '12',
-      ),
-    ).toEqual({ base: checkpoint, unsafe: ['11'] })
-  })
-  it('rejects an uncheckpointed production run but ignores previews and manual runs', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [[status(checkpoint, '10')]],
-        [
-          {
-            workflow_runs: [
-              run(10, { displayTitle: runTitle({ sha: checkpoint }) }),
-              run(11),
-              run(12, { displayTitle: runTitle({ environment: 'preview' }) }),
-              run(13, { event: 'workflow_dispatch' }),
-            ],
-          },
-        ],
-        currentHead,
-        '14',
-      ),
-    ).toEqual({ base: checkpoint, unsafe: ['11'] })
-  })
-
-  it('treats a lower run missing from the API snapshot as unsafe', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [[status(checkpoint, '10')]],
-        [{ workflow_runs: [run(10, { displayTitle: runTitle({ sha: checkpoint }) })] }],
-        currentHead,
-        '12',
-      ),
-    ).toEqual({ base: checkpoint, unsafe: ['11'] })
-  })
-
-  it('rejects a purge marker that does not match its run title', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [[status(checkpoint, '10')]],
-        [{ workflow_runs: [run(10)] }],
-        currentHead,
-        '11',
-      ),
-    ).toEqual({ base: null, unsafe: [] })
-  })
-
-  it('ignores failed, malformed, and future purge markers', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-
-    expect(
-      selectPurgeState(
-        [
-          [
-            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '10', 'failure'),
-            status('not-a-sha', '11'),
-            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'not-a-run'),
-            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '13'),
-          ],
-        ],
-        [{ workflow_runs: [] }],
-        currentHead,
-        '12',
-      ),
-    ).toEqual({ base: null, unsafe: [] })
   })
 })

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -20,11 +20,21 @@ const promoted = {
 }
 
 describe('validatePromotedDeployment', () => {
-  it('returns the trusted routing fields for this project production branch', () => {
+  it('returns the trusted routing fields for this project production deployment', () => {
     expect(validatePromotedDeployment(promoted)).toEqual({
       deploymentId: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa',
       head: 'e161206fa9fd03294430019666687e8f8e232201',
+      ref: 'main',
     })
+  })
+
+  it('accepts a non-main production promotion for full-zone recovery', () => {
+    expect(
+      validatePromotedDeployment({
+        ...promoted,
+        git: { ...promoted.git, ref: 'feature/manual-promotion' },
+      }),
+    ).toMatchObject({ ref: 'feature/manual-promotion' })
   })
 
   it.each([
@@ -34,9 +44,9 @@ describe('validatePromotedDeployment', () => {
       { project: { id: 'prj_other', name: 'other' } },
       'unexpected Vercel project',
     ],
-    ['different branch', { git: { ...promoted.git, ref: 'docs' } }, 'not the production branch'],
     ['malformed SHA', { git: { ref: 'main', sha: 'main' } }, 'invalid Git commit SHA'],
     ['malformed deployment id', { id: '6204988438' }, 'invalid Vercel deployment ID'],
+    ['malformed branch', { git: { ...promoted.git, ref: '../main' } }, 'invalid Git ref'],
   ])('rejects a %s', (_name, patch, message) => {
     expect(() => validatePromotedDeployment({ ...promoted, ...patch })).toThrow(message)
   })

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { VERCEL_PROJECT_ID, validatePromotedDeployment } from './cache-purge-event.mjs'
+import {
+  VERCEL_PROJECT_ID,
+  selectPreviousPurgedCommit,
+  validatePromotedDeployment,
+} from './cache-purge-event.mjs'
 
 const promoted = {
   environment: 'production',
@@ -35,5 +39,65 @@ describe('validatePromotedDeployment', () => {
     ['malformed deployment id', { id: '6204988438' }, 'invalid Vercel deployment ID'],
   ])('rejects a %s', (_name, patch, message) => {
     expect(() => validatePromotedDeployment({ ...promoted, ...patch })).toThrow(message)
+  })
+})
+
+describe('selectPreviousPurgedCommit', () => {
+  const status = (sha: string, createdAt: string) => ({
+    context: 'cache-purge/dpl_test',
+    created_at: createdAt,
+    description: `${sha}|Purged 3 prefixes, 1 URLs`,
+    state: 'success',
+  })
+
+  it('uses promotion chronology when the current deployment rolls back', () => {
+    const rollbackHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const latestDeployed = 'cccccccccccccccccccccccccccccccccccccccc'
+    const olderDeployed = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPreviousPurgedCommit(
+        [
+          [status(olderDeployed, '2026-08-30T12:00:00Z')],
+          [status(latestDeployed, '2026-09-01T12:00:00Z')],
+        ],
+        rollbackHead,
+      ),
+    ).toBe(latestDeployed)
+  })
+
+  it('skips a prior deployment of the same commit', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const previousHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPreviousPurgedCommit(
+        [
+          [
+            status(currentHead, '2026-09-01T13:00:00Z'),
+            status(previousHead, '2026-09-01T12:00:00Z'),
+          ],
+        ],
+        currentHead,
+      ),
+    ).toBe(previousHead)
+  })
+
+  it('ignores failed and malformed ledger entries', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    expect(
+      selectPreviousPurgedCommit(
+        [
+          [
+            {
+              ...status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '2026-09-01T12:00:00Z'),
+              state: 'failure',
+            },
+            { ...status('not-a-sha', '2026-09-01T13:00:00Z') },
+          ],
+        ],
+        currentHead,
+      ),
+    ).toBeNull()
   })
 })

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -43,115 +43,151 @@ describe('validatePromotedDeployment', () => {
 })
 
 describe('selectPurgeState', () => {
-  const status = (
-    kind: 'cache-promotion' | 'cache-purge',
-    sha: string,
-    runNumber: string,
-    createdAt: string,
-    state = 'success',
-  ) => ({
-    context: `${kind}/dpl_test`,
-    created_at: createdAt,
-    description: `${runNumber}|${sha}|${kind}`,
+  const status = (sha: string, runNumber: string, state = 'success') => ({
+    context: 'cache-purge/dpl_test',
+    description: `${runNumber}|${sha}|Purged`,
     state,
   })
 
-  it('uses promotion chronology when the current deployment rolls back', () => {
-    const rollbackHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const latestDeployed = 'cccccccccccccccccccccccccccccccccccccccc'
-    const olderDeployed = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  const runTitle = ({
+    environment = 'production',
+    projectId = VERCEL_PROJECT_ID,
+    ref = 'main',
+    sha = 'cccccccccccccccccccccccccccccccccccccccc',
+  } = {}) => `cache-purge:${environment}:${projectId}:${ref}:${sha}:dpl_test`
 
-    expect(
-      selectPurgeState(
-        [
-          // The older promotion finishes last. Completion timestamps must not
-          // override the workflow run numbers assigned at event delivery.
-          [
-            status('cache-promotion', olderDeployed, '10', '2026-09-01T13:00:00Z'),
-            status('cache-purge', olderDeployed, '10', '2026-09-01T13:00:00Z'),
-          ],
-          [
-            status('cache-promotion', latestDeployed, '11', '2026-09-01T12:00:00Z'),
-            status('cache-purge', latestDeployed, '11', '2026-09-01T12:00:00Z'),
-          ],
-        ],
-        rollbackHead,
-        '12',
-      ),
-    ).toEqual({ base: latestDeployed, previous: latestDeployed })
+  const run = (
+    runNumber: number,
+    {
+      displayTitle = runTitle(),
+      event = 'repository_dispatch',
+    }: { displayTitle?: string; event?: string } = {},
+  ) => ({
+    display_title: displayTitle,
+    event,
+    run_number: runNumber,
   })
 
-  it('keeps the same-commit predecessor but skips it as a diff baseline', () => {
+  it('selects the latest successful purge checkpoint across status pages', () => {
     const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const previousHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const latestPurged = 'cccccccccccccccccccccccccccccccccccccccc'
+    const olderPurged = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     expect(
       selectPurgeState(
+        [[status(olderPurged, '10')], [status(latestPurged, '11'), status(currentHead, '13')]],
         [
-          [
-            status('cache-promotion', currentHead, '12', '2026-09-01T13:00:00Z'),
-            status('cache-purge', currentHead, '12', '2026-09-01T13:00:00Z'),
-            status('cache-promotion', previousHead, '11', '2026-09-01T12:00:00Z'),
-            status('cache-purge', previousHead, '11', '2026-09-01T12:00:00Z'),
-          ],
-        ],
-        currentHead,
-        '13',
-      ),
-    ).toEqual({ base: previousHead, previous: currentHead })
-  })
-
-  it('retains an unpurged predecessor separately from the last success', () => {
-    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-    const unpurgedHead = 'cccccccccccccccccccccccccccccccccccccccc'
-    const successfulHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-
-    expect(
-      selectPurgeState(
-        [
-          [
-            status('cache-promotion', unpurgedHead, '11', '2026-09-01T13:00:00Z'),
-            status('cache-promotion', successfulHead, '10', '2026-09-01T12:00:00Z'),
-            status('cache-purge', successfulHead, '10', '2026-09-01T12:05:00Z'),
-          ],
+          {
+            workflow_runs: [
+              run(10, { displayTitle: runTitle({ sha: olderPurged }) }),
+              run(11, { displayTitle: runTitle({ sha: latestPurged }) }),
+            ],
+          },
         ],
         currentHead,
         '12',
       ),
-    ).toEqual({ base: successfulHead, previous: unpurgedHead })
+    ).toEqual({ base: latestPurged, unsafe: [] })
   })
 
-  it('ignores future, failed, and malformed ledger entries', () => {
+  it('uses a same-commit purge as the known-good checkpoint', () => {
     const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
     expect(
       selectPurgeState(
+        [[status(currentHead, '11')]],
+        [{ workflow_runs: [run(11, { displayTitle: runTitle({ sha: currentHead }) })] }],
+        currentHead,
+        '12',
+      ),
+    ).toEqual({ base: currentHead, unsafe: [] })
+  })
+
+  it('rejects a lower production promotion before its runner starts', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPurgeState(
+        [[status(checkpoint, '10')]],
         [
-          [
-            status(
-              'cache-purge',
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              '10',
-              '2026-09-01T12:00:00Z',
-              'failure',
-            ),
-            status('cache-promotion', 'not-a-sha', '11', '2026-09-01T13:00:00Z'),
-            status(
-              'cache-promotion',
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              'not-a-run',
-              '2026-09-01T14:00:00Z',
-            ),
-            status(
-              'cache-promotion',
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              '13',
-              '2026-09-01T15:00:00Z',
-            ),
-          ],
+          {
+            workflow_runs: [run(10, { displayTitle: runTitle({ sha: checkpoint }) }), run(11)],
+          },
         ],
         currentHead,
         '12',
       ),
-    ).toEqual({ base: null, previous: null })
+    ).toEqual({ base: checkpoint, unsafe: ['11'] })
+  })
+  it('rejects an uncheckpointed production run but ignores previews and manual runs', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPurgeState(
+        [[status(checkpoint, '10')]],
+        [
+          {
+            workflow_runs: [
+              run(10, { displayTitle: runTitle({ sha: checkpoint }) }),
+              run(11),
+              run(12, { displayTitle: runTitle({ environment: 'preview' }) }),
+              run(13, { event: 'workflow_dispatch' }),
+            ],
+          },
+        ],
+        currentHead,
+        '14',
+      ),
+    ).toEqual({ base: checkpoint, unsafe: ['11'] })
+  })
+
+  it('treats a lower run missing from the API snapshot as unsafe', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPurgeState(
+        [[status(checkpoint, '10')]],
+        [{ workflow_runs: [run(10, { displayTitle: runTitle({ sha: checkpoint }) })] }],
+        currentHead,
+        '12',
+      ),
+    ).toEqual({ base: checkpoint, unsafe: ['11'] })
+  })
+
+  it('rejects a purge marker that does not match its run title', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const checkpoint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    expect(
+      selectPurgeState(
+        [[status(checkpoint, '10')]],
+        [{ workflow_runs: [run(10)] }],
+        currentHead,
+        '11',
+      ),
+    ).toEqual({ base: null, unsafe: [] })
+  })
+
+  it('ignores failed, malformed, and future purge markers', () => {
+    const currentHead = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+    expect(
+      selectPurgeState(
+        [
+          [
+            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '10', 'failure'),
+            status('not-a-sha', '11'),
+            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'not-a-run'),
+            status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '13'),
+          ],
+        ],
+        [{ workflow_runs: [] }],
+        currentHead,
+        '12',
+      ),
+    ).toEqual({ base: null, unsafe: [] })
   })
 })

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { VERCEL_PROJECT_ID, validatePromotedDeployment } from './cache-purge-event.mjs'
+
+const promoted = {
+  environment: 'production',
+  git: {
+    ref: 'main',
+    sha: 'e161206fa9fd03294430019666687e8f8e232201',
+  },
+  id: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa',
+  project: {
+    id: VERCEL_PROJECT_ID,
+    name: 'librechat-ai',
+  },
+  url: 'https://librechat-ai.example.vercel.app',
+}
+
+describe('validatePromotedDeployment', () => {
+  it('returns the trusted routing fields for this project production branch', () => {
+    expect(validatePromotedDeployment(promoted)).toEqual({
+      deploymentId: 'dpl_EnMFpT7NUGsYu5fDXNakPwBfDGSa',
+      head: 'e161206fa9fd03294430019666687e8f8e232201',
+    })
+  })
+
+  it.each([
+    ['preview environment', { environment: 'preview' }, 'not a production deployment'],
+    [
+      'different project',
+      { project: { id: 'prj_other', name: 'other' } },
+      'unexpected Vercel project',
+    ],
+    ['different branch', { git: { ...promoted.git, ref: 'docs' } }, 'not the production branch'],
+    ['malformed SHA', { git: { ref: 'main', sha: 'main' } }, 'invalid Git commit SHA'],
+    ['malformed deployment id', { id: '6204988438' }, 'invalid Vercel deployment ID'],
+  ])('rejects a %s', (_name, patch, message) => {
+    expect(() => validatePromotedDeployment({ ...promoted, ...patch })).toThrow(message)
+  })
+})

--- a/scripts/cache-purge-event.test.ts
+++ b/scripts/cache-purge-event.test.ts
@@ -43,10 +43,10 @@ describe('validatePromotedDeployment', () => {
 })
 
 describe('selectPreviousPurgedCommit', () => {
-  const status = (sha: string, createdAt: string) => ({
+  const status = (sha: string, runNumber: string, createdAt: string) => ({
     context: 'cache-purge/dpl_test',
     created_at: createdAt,
-    description: `${sha}|Purged 3 prefixes, 1 URLs`,
+    description: `${runNumber}|${sha}|Purged 3 prefixes, 1 URLs`,
     state: 'success',
   })
 
@@ -58,8 +58,10 @@ describe('selectPreviousPurgedCommit', () => {
     expect(
       selectPreviousPurgedCommit(
         [
-          [status(olderDeployed, '2026-08-30T12:00:00Z')],
-          [status(latestDeployed, '2026-09-01T12:00:00Z')],
+          // The older promotion finishes last. Completion timestamps must not
+          // override the workflow run numbers assigned at event delivery.
+          [status(olderDeployed, '10', '2026-09-01T13:00:00Z')],
+          [status(latestDeployed, '11', '2026-09-01T12:00:00Z')],
         ],
         rollbackHead,
       ),
@@ -74,8 +76,8 @@ describe('selectPreviousPurgedCommit', () => {
       selectPreviousPurgedCommit(
         [
           [
-            status(currentHead, '2026-09-01T13:00:00Z'),
-            status(previousHead, '2026-09-01T12:00:00Z'),
+            status(currentHead, '12', '2026-09-01T13:00:00Z'),
+            status(previousHead, '11', '2026-09-01T12:00:00Z'),
           ],
         ],
         currentHead,
@@ -90,10 +92,17 @@ describe('selectPreviousPurgedCommit', () => {
         [
           [
             {
-              ...status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '2026-09-01T12:00:00Z'),
+              ...status('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', '10', '2026-09-01T12:00:00Z'),
               state: 'failure',
             },
-            { ...status('not-a-sha', '2026-09-01T13:00:00Z') },
+            { ...status('not-a-sha', '11', '2026-09-01T13:00:00Z') },
+            {
+              ...status(
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                'not-a-run',
+                '2026-09-01T14:00:00Z',
+              ),
+            },
           ],
         ],
         currentHead,

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -597,8 +597,9 @@ export function parseArgs(argv) {
 }
 
 async function main(argv) {
+  const repoRoot = process.cwd()
   const { flags, positional } = parseArgs(argv)
-  const locales = readLocales()
+  const locales = readLocales(repoRoot)
 
   // Read the file list even with --broad: recovery runs pass both, so that the
   // broad page set is topped up with the asset URLs and removed locales that
@@ -621,7 +622,7 @@ async function main(argv) {
   const result = computePurge(files, locales, { forceBroad: flags.has('--broad') })
 
   if (flags.has('--assets')) {
-    const assets = assetFallbackTargets()
+    const assets = assetFallbackTargets(repoRoot)
     result.prefixes = dropCoveredPrefixes([...result.prefixes, ...assets.prefixes])
     result.files = [...new Set([...result.files, ...assets.files])].sort()
   }

--- a/scripts/cache-purge-prefixes.mjs
+++ b/scripts/cache-purge-prefixes.mjs
@@ -61,26 +61,45 @@ function parseLocales(src, label) {
   return locales
 }
 
-export function readLocales(repoRoot = REPO_ROOT, basePath = process.env.BASE_I18N_FILE) {
-  const locales = parseLocales(
-    readFileSync(resolve(repoRoot, 'lib/i18n.ts'), 'utf8'),
-    'lib/i18n.ts',
-  )
-  if (!basePath) return locales
+export function readLocales(
+  repoRoot = REPO_ROOT,
+  basePath = process.env.BASE_I18N_FILE,
+  fallbackPath = process.env.FALLBACK_I18N_FILE,
+) {
+  const deployedPath = resolve(repoRoot, 'lib/i18n.ts')
+  let locales = []
+
+  try {
+    locales = parseLocales(readFileSync(deployedPath, 'utf8'), 'lib/i18n.ts')
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+    process.stderr.write(
+      `::warning::The deployed tree has no lib/i18n.ts; using trusted rollback locale data.\n`,
+    )
+  }
 
   // A locale dropped in this deploy still has cached pages under /<locale>, but
   // the deployed file no longer names it, so `broadPrefixes()` would not purge
-  // them and that language would sit there until the TTL. Union with the file as
-  // it was at the diff base. A base that cannot be read or parsed (the range
-  // predates i18n, say) is not fatal: warn and carry on with what deployed.
-  try {
-    const baseSrc = readFileSync(basePath, 'utf8')
-    if (!baseSrc.trim()) return locales
-    return [...new Set([...locales, ...parseLocales(baseSrc, basePath)])]
-  } catch (error) {
-    process.stderr.write(`::warning::Could not read locales from ${basePath}: ${error.message}\n`)
-    return locales
+  // them and that language would sit there until the TTL. Union with both the
+  // diff base and trusted workflow revision. Old rollback trees can predate the
+  // locale config entirely, in which case those two sources are the only safe
+  // route inventory.
+  for (const localePath of new Set([basePath, fallbackPath].filter(Boolean))) {
+    try {
+      const source = readFileSync(localePath, 'utf8')
+      if (!source.trim()) continue
+      locales = [...new Set([...locales, ...parseLocales(source, localePath)])]
+    } catch (error) {
+      process.stderr.write(
+        `::warning::Could not read locales from ${localePath}: ${error.message}\n`,
+      )
+    }
   }
+
+  if (locales.length === 0) {
+    throw new Error('Could not read locales from the deployed, base, or trusted workflow config')
+  }
+  return locales
 }
 
 /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -189,6 +189,25 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
+   * A rollback checks out an older deployed tree. Keep the workflow revision in
+   * a sibling checkout so its validator and mapping scripts cannot disappear.
+   */
+  it('runs workflow-owned scripts outside the promoted source checkout', () => {
+    expect(workflow).toContain('path: workflow-source')
+    expect(workflow).toContain('path: deployed-source')
+    expect(workflow).toContain('working-directory: deployed-source')
+    expect(workflow).toContain('working-directory: workflow-source')
+
+    const cacheScriptInvocations = workflow.match(/node \S*scripts\/cache-[\w-]+\.mjs/g) ?? []
+    expect(cacheScriptInvocations).toContain('node scripts/cache-purge-event.mjs')
+    expect(
+      cacheScriptInvocations
+        .filter((command) => !command.endsWith('cache-purge-event.mjs'))
+        .every((command) => command.startsWith('node ../workflow-source/')),
+    ).toBe(true)
+  })
+
+  /**
    * Vercel can redeploy the same SHA. Grouping by SHA would let GitHub discard
    * one of those pending purge runs, even though each deployment needs its own
    * marker.
@@ -209,7 +228,9 @@ describe('the workflow feeds the mapper what it needs', () => {
    */
   it('discovers current build assets only for manual recovery', () => {
     expect(workflow).toContain('if [ "$EVENT" = "workflow_dispatch" ]; then')
-    expect(workflow).toContain('node scripts/cache-build-assets.mjs > build-assets.txt')
+    expect(workflow).toContain(
+      'node ../workflow-source/scripts/cache-build-assets.mjs > build-assets.txt',
+    )
     expect(workflow).toContain("if: steps.assets.outputs.count == '0'")
     expect(workflow).not.toContain('if: steps.compute.outputs.count')
   })
@@ -227,7 +248,7 @@ describe('the workflow feeds the mapper what it needs', () => {
       'Build-asset discovery failed; purging the recovery targets without the current build assets.',
     )
     expect(workflow).toContain(
-      'node scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json',
+      'node ../workflow-source/scripts/cache-purge-prefixes.mjs --broad --assets --json > recovery.json',
     )
     expect(workflow).toContain("jq -r '.prefixes[]' recovery.json >> prefixes.txt")
     expect(workflow).toContain("jq -r '.files[]?' recovery.json >> files.txt")
@@ -235,11 +256,13 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
-  it('finds the baseline from the latest successful Vercel deployment marker', () => {
-    expect(workflow).toContain('select(.context | startswith($prefix))')
+  it('finds the baseline from the chronological Vercel purge ledger', () => {
+    expect(workflow).toContain('git rev-list --max-parents=0 HEAD')
+    expect(workflow).toContain('cache-purge-event.mjs baseline')
     expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
+    expect(workflow).toContain('-f description="$SHA|Purged ')
+    expect(workflow).not.toContain('git rev-list --since="$FALLBACK_WINDOW" "${head}^"')
     expect(workflow).not.toContain('deployments?environment=Production')
-    expect(workflow).not.toContain('deployment.creator.login')
   })
 
   /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -301,11 +301,12 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
-  it('finds the baseline from the chronological Vercel purge ledger', () => {
+  it('finds the baseline from the promotion-ordered Vercel purge ledger', () => {
     expect(workflow).toContain('git rev-list --max-parents=0 HEAD')
     expect(workflow).toContain('cache-purge-event.mjs baseline')
     expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
-    expect(workflow).toContain('-f description="$SHA|Purged ')
+    expect(workflow).toContain('RUN_NUMBER: ${{ github.run_number }}')
+    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|Purged ')
     expect(workflow).not.toContain('git rev-list --since="$FALLBACK_WINDOW" "${head}^"')
     expect(workflow).not.toContain('deployments?environment=Production')
   })

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -76,6 +77,33 @@ describe('readLocales', () => {
       rmSync(base, { force: true })
     }
   })
+})
+
+it('reads deployed inputs from the CLI working directory', () => {
+  const deployedRoot = mkdtempSync(join(tmpdir(), 'cache-purge-deployed-'))
+  mkdirSync(join(deployedRoot, 'lib'))
+  mkdirSync(join(deployedRoot, 'public'))
+  writeFileSync(
+    join(deployedRoot, 'lib/i18n.ts'),
+    `export const i18n = { defaultLanguage: 'en', languages: ['en', 'sv'] }`,
+  )
+  writeFileSync(join(deployedRoot, 'public/rollback.txt'), 'deployed asset')
+
+  try {
+    const script = fileURLToPath(new URL('./cache-purge-prefixes.mjs', import.meta.url))
+    const result = spawnSync(process.execPath, [script, '--broad', '--assets', '--json'], {
+      cwd: deployedRoot,
+      encoding: 'utf8',
+    })
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+
+    const purge = JSON.parse(result.stdout)
+    expect(purge.prefixes).toContain('www.librechat.ai/sv')
+    expect(purge.files).toContain('https://www.librechat.ai/rollback.txt')
+  } finally {
+    rmSync(deployedRoot, { recursive: true, force: true })
+  }
 })
 
 describe('parseArgs', () => {
@@ -202,7 +230,7 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(cacheScriptInvocations).toContain('node scripts/cache-purge-event.mjs')
     expect(
       cacheScriptInvocations
-        .filter((command) => !command.endsWith('cache-purge-event.mjs'))
+        .filter((command) => command !== 'node scripts/cache-purge-event.mjs')
         .every((command) => command.startsWith('node ../workflow-source/')),
     ).toBe(true)
   })

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -217,6 +217,23 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
+   * repository_dispatch payload fields are caller-controlled. The checkout may
+   * supply data to trusted mapper code only after its SHA is proven to belong to
+   * the protected production branch.
+   */
+  it('rejects a dispatch SHA outside current main before secrets are exposed', () => {
+    expect(workflow).toContain(
+      'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main',
+    )
+    expect(workflow).toContain('git merge-base --is-ancestor "$HEAD_SHA" origin/main')
+
+    const trustCheck = workflow.indexOf('git merge-base --is-ancestor "$HEAD_SHA" origin/main')
+    const cloudflareSecrets = workflow.indexOf('CF_API_TOKEN:')
+    expect(trustCheck).toBeGreaterThan(0)
+    expect(trustCheck).toBeLessThan(cloudflareSecrets)
+  })
+
+  /**
    * A rollback checks out an older deployed tree. Keep the workflow revision in
    * a sibling checkout so its validator and mapping scripts cannot disappear.
    */

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -173,43 +173,53 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
-   * Vercel attributes a deployment to the human who initiated it, then posts
-   * the ready status as vercel[bot]. Checking deployment.creator made every
-   * automatic purge run skip before it reached a step.
+   * Vercel's enriched promotion event is the alias-ready signal and carries the
+   * exact project, branch, Git SHA, and Vercel deployment id. No GitHub
+   * Deployment creator/status inference is needed.
    */
-  it('identifies Vercel by the deployment-status creator', () => {
-    expect(workflow).toContain("github.event.deployment_status.creator.login == 'vercel[bot]'")
-    expect(workflow).not.toContain("github.event.deployment.creator.login == 'vercel[bot]'")
+  it('accepts only this project production promotion event', () => {
+    expect(workflow).toContain("types: ['vercel.deployment.promoted']")
+    expect(workflow).toContain("github.event.client_payload.environment == 'production'")
+    expect(workflow).toContain(
+      "github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'",
+    )
+    expect(workflow).toContain("github.event.client_payload.git.ref == 'main'")
+    expect(workflow).toContain('node scripts/cache-purge-event.mjs')
+    expect(workflow).not.toContain('deployment_status:')
   })
 
   /**
    * Vercel can redeploy the same SHA. Grouping by SHA would let GitHub discard
    * one of those pending purge runs, even though each deployment needs its own
-   * baseline and marker.
+   * marker.
    */
-  it('keys concurrency by deployment id so same-sha redeployments are distinct', () => {
+  it('keys concurrency by Vercel deployment id so same-sha redeployments are distinct', () => {
     expect(workflow).toContain(
-      'group: cache-purge-${{ github.event.deployment.id || github.run_id }}',
+      'group: cache-purge-${{ github.event.client_payload.id || github.run_id }}',
     )
     expect(workflow).not.toContain(
-      'group: cache-purge-${{ github.event.deployment.sha || github.run_id }}',
+      'group: cache-purge-${{ github.event.client_payload.git.sha || github.run_id }}',
     )
   })
 
-  it('adds current build assets before deciding there is nothing to purge', () => {
+  /**
+   * The static-asset rule now makes every 4xx response BYPASS Cloudflare, so
+   * immutable assets cannot be poisoned. Automatic deployment purges should not
+   * issue 21 cache-busted Vercel page requests just to enumerate those assets.
+   */
+  it('discovers current build assets only for manual recovery', () => {
+    expect(workflow).toContain('if [ "$EVENT" = "workflow_dispatch" ]; then')
     expect(workflow).toContain('node scripts/cache-build-assets.mjs > build-assets.txt')
     expect(workflow).toContain("if: steps.assets.outputs.count == '0'")
     expect(workflow).not.toContain('if: steps.compute.outputs.count')
   })
 
   /**
-   * Discovery retries an in-flight alias swap on its own, so a failure that
-   * survives those retries means the live site is unhealthy, not mid-flip.
-   * Every run, automatic or manual, must still send the broad page/public
-   * targets computed earlier in the job to Cloudflare, and a run that could not
-   * enumerate the current build assets must leave no purge marker behind.
+   * A manual dispatch is the recovery path for an already unhealthy site. Its
+   * broad prefixes and public asset targets remain valid even when live asset
+   * discovery fails.
    */
-  it('degrades instead of aborting when build-asset discovery fails', () => {
+  it('degrades manual recovery instead of aborting when discovery fails', () => {
     expect(workflow).toContain(': > build-assets.txt')
     expect(workflow).toContain('degraded=true')
     expect(workflow).toContain('echo "degraded=$degraded" >> "$GITHUB_OUTPUT"')
@@ -225,10 +235,11 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
-  it('accepts a baseline only when its deployment-specific purge marker exists', () => {
-    expect(workflow).toContain('PURGE_STATUS_CONTEXT/$id')
-    expect(workflow).toContain('select(.context == $context and .state == "success")')
-    expect(workflow).not.toContain('select(.creator.login == $creator)')
+  it('finds the baseline from the latest successful Vercel deployment marker', () => {
+    expect(workflow).toContain('select(.context | startswith($prefix))')
+    expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
+    expect(workflow).not.toContain('deployments?environment=Production')
+    expect(workflow).not.toContain('deployment.creator.login')
   })
 
   /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -228,13 +228,13 @@ describe('the workflow feeds the mapper what it needs', () => {
    * exact project, branch, Git SHA, and Vercel deployment id. No GitHub
    * Deployment creator/status inference is needed.
    */
-  it('accepts only this project production promotion event', () => {
+  it('accepts this project production promotions from any branch', () => {
     expect(workflow).toContain("types: ['vercel.deployment.promoted']")
     expect(workflow).toContain("github.event.client_payload.environment == 'production'")
     expect(workflow).toContain(
       "github.event.client_payload.project.id == 'prj_BM0YCOihInl5lqPJidAzwixJPdtj'",
     )
-    expect(workflow).toContain("github.event.client_payload.git.ref == 'main'")
+    expect(workflow).not.toContain("github.event.client_payload.git.ref == 'main'")
     expect(workflow).toContain('node scripts/cache-purge-event.mjs')
     expect(workflow).not.toContain('deployment_status:')
   })
@@ -254,6 +254,17 @@ describe('the workflow feeds the mapper what it needs', () => {
     const cloudflareSecrets = workflow.indexOf('CF_API_TOKEN:')
     expect(trustCheck).toBeGreaterThan(0)
     expect(trustCheck).toBeLessThan(cloudflareSecrets)
+  })
+
+  it('routes non-main production promotions directly to a full-zone purge', () => {
+    expect(workflow).toContain('PROMOTED_REF: ${{ steps.event.outputs.ref }}')
+    expect(workflow).toContain('if [ "$PROMOTED_REF" != "main" ]; then')
+    expect(workflow).toContain('Non-main production deployment')
+
+    const nonMainRecovery = workflow.indexOf('if [ "$PROMOTED_REF" != "main" ]; then')
+    const cloudflareSecrets = workflow.indexOf('CF_API_TOKEN:')
+    expect(nonMainRecovery).toBeGreaterThan(0)
+    expect(nonMainRecovery).toBeLessThan(cloudflareSecrets)
   })
 
   /**
@@ -289,6 +300,12 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).not.toContain(
       'group: cache-purge-${{ github.event.client_payload.git.sha || github.run_id }}',
     )
+  })
+
+  it('purges every page route when Vercel redeploys the checkpointed SHA', () => {
+    expect(workflow).toContain('&& [ "$base" = "$head" ]; then')
+    expect(workflow).toContain('emit mode pages')
+    expect(workflow).toContain('[ "$MODE" = "pages" ] && broad_flag="--broad"')
   })
 
   /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -301,6 +301,31 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
+  /**
+   * Purge success alone cannot describe production chronology: a failed C
+   * promotion still has to be removed when production rolls back to B.
+   */
+  it('records each trusted promotion before purge planning', () => {
+    expect(workflow).toContain('PROMOTION_STATUS_CONTEXT: cache-promotion')
+    expect(workflow).toContain('-f context="$PROMOTION_STATUS_CONTEXT/$DEPLOYMENT_ID"')
+    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|Promoted"')
+
+    const promotionMarker = workflow.indexOf('- name: Record promoted deployment')
+    const rangeResolution = workflow.indexOf('- name: Resolve diff range')
+    const purge = workflow.indexOf('- name: Purge')
+    expect(promotionMarker).toBeGreaterThan(0)
+    expect(promotionMarker).toBeLessThan(rangeResolution)
+    expect(rangeResolution).toBeLessThan(purge)
+  })
+
+  it('broadens an unpurged non-forward transition from the prior promotion', () => {
+    expect(workflow).toContain('CURRENT_RUN_NUMBER: ${{ github.run_number }}')
+    expect(workflow).toContain('PROMOTION_STATUS_CONTEXT: ${{ env.PROMOTION_STATUS_CONTEXT }}')
+    expect(workflow).toContain('git merge-base --is-ancestor "$previous" "$head"')
+    expect(workflow).toContain('emit base "$previous"')
+    expect(workflow).toContain('Previous promotion was not purged and is not an ancestor')
+  })
+
   it('finds the baseline from the promotion-ordered Vercel purge ledger', () => {
     expect(workflow).toContain('git rev-list --max-parents=0 HEAD')
     expect(workflow).toContain('cache-purge-event.mjs baseline')

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -240,31 +240,21 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
-   * repository_dispatch payload fields are caller-controlled. The checkout may
-   * supply data to trusted mapper code only after its SHA is proven to belong to
-   * the protected production branch.
+   * Automatic invalidation is independent of the promoted tree. Git metadata
+   * may be absent for CLI or deleted-branch deployments, so only manual
+   * recovery checks out a source tree for diff mapping.
    */
-  it('rejects a dispatch SHA outside current main before secrets are exposed', () => {
-    expect(workflow).toContain(
-      'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main',
-    )
-    expect(workflow).toContain('git merge-base --is-ancestor "$HEAD_SHA" origin/main')
+  it('validates automatic promotions before any optional source checkout', () => {
+    expect(workflow).toContain('- name: Prepare automatic purge workspace')
+    expect(workflow).toContain('- name: Check out manual source')
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'")
+    expect(workflow).toContain('ref: ${{ github.sha }}')
+    expect(workflow).not.toContain('ref: ${{ github.event.client_payload.git.sha || github.sha }}')
 
-    const trustCheck = workflow.indexOf('git merge-base --is-ancestor "$HEAD_SHA" origin/main')
-    const cloudflareSecrets = workflow.indexOf('CF_API_TOKEN:')
-    expect(trustCheck).toBeGreaterThan(0)
-    expect(trustCheck).toBeLessThan(cloudflareSecrets)
-  })
-
-  it('routes non-main production promotions directly to a full-zone purge', () => {
-    expect(workflow).toContain('PROMOTED_REF: ${{ steps.event.outputs.ref }}')
-    expect(workflow).toContain('if [ "$PROMOTED_REF" != "main" ]; then')
-    expect(workflow).toContain('Non-main production deployment')
-
-    const nonMainRecovery = workflow.indexOf('if [ "$PROMOTED_REF" != "main" ]; then')
-    const cloudflareSecrets = workflow.indexOf('CF_API_TOKEN:')
-    expect(nonMainRecovery).toBeGreaterThan(0)
-    expect(nonMainRecovery).toBeLessThan(cloudflareSecrets)
+    const eventValidation = workflow.indexOf('- name: Validate promoted deployment')
+    const manualCheckout = workflow.indexOf('- name: Check out manual source')
+    expect(eventValidation).toBeGreaterThan(0)
+    expect(eventValidation).toBeLessThan(manualCheckout)
   })
 
   /**
@@ -302,10 +292,10 @@ describe('the workflow feeds the mapper what it needs', () => {
     )
   })
 
-  it('purges every page route when Vercel redeploys the checkpointed SHA', () => {
-    expect(workflow).toContain('&& [ "$base" = "$head" ]; then')
-    expect(workflow).toContain('emit mode pages')
-    expect(workflow).toContain('[ "$MODE" = "pages" ] && broad_flag="--broad"')
+  it('purges the full zone for every automatic production promotion', () => {
+    expect(workflow).toContain('if [ "$EVENT" = "repository_dispatch" ]; then')
+    expect(workflow).toContain('Automatic production promotion; purging the full zone.')
+    expect(workflow).toContain('emit mode full')
   })
 
   /**
@@ -340,57 +330,27 @@ describe('the workflow feeds the mapper what it needs', () => {
     expect(workflow).toContain("jq -r '.prefixes[]' recovery.json >> prefixes.txt")
     expect(workflow).toContain("jq -r '.files[]?' recovery.json >> files.txt")
     expect(workflow).not.toContain('if [ "$EVENT" != "workflow_dispatch" ]; then')
-    expect(workflow).toContain("steps.assets.outputs.degraded != 'true'")
   })
 
   /**
-   * A missing promotion payload cannot be recovered from the Actions API. The
-   * workflow may use a successful purge as a selective checkpoint only after
-   * every intervening workflow run is visible and harmless.
+   * Vercel does not provide an authoritative promotion sequence in this event,
+   * and delivery order can differ from alias order. Automatic safety therefore
+   * cannot depend on a cross-run ledger or a Git diff.
    */
-  it('reconciles every lower workflow run before selective planning', () => {
-    expect(workflow).toContain('actions: read')
-    expect(workflow).toContain('run-name: >-')
-    expect(workflow).toContain(
-      "cache-purge:${{ github.event.client_payload.environment || 'manual' }}:${{ github.event.client_payload.project.id || 'manual' }}:${{ github.event.client_payload.git.ref || 'manual' }}:${{ github.event.client_payload.git.sha || github.sha }}:${{ github.event.client_payload.id || github.run_id }}",
-    )
-    expect(workflow).toContain(
-      'gh api --paginate --slurp "repos/$REPO/actions/workflows/cache-purge.yml/runs?per_page=100"',
-    )
-    expect(workflow).toContain('unsafe=$(jq -r \'.unsafe | length\' <<< "$ledger_state")')
-    expect(workflow).toContain('display_title')
-    expect(workflow).toContain('emit mode full')
-    expect(workflow).not.toContain('sleep 10')
+  it('keeps automatic purges stateless', () => {
+    expect(workflow).not.toContain('run-name:')
+    expect(workflow).not.toContain('actions: read')
+    expect(workflow).not.toContain('statuses: write')
+    expect(workflow).not.toContain('PURGE_STATUS_CONTEXT')
+    expect(workflow).not.toContain('gh api')
+    expect(workflow).not.toContain('cache-purge-event.mjs baseline')
+    expect(workflow).not.toContain('- name: Record the purge')
   })
 
-  it('uses successful purges as the only production checkpoints', () => {
-    expect(workflow).not.toContain('PROMOTION_STATUS_CONTEXT')
-    expect(workflow).not.toContain('- name: Record promoted deployment')
-    expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
-    expect(workflow).toContain('RUN_NUMBER: ${{ github.run_number }}')
-    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|')
-    expect(workflow).toContain(
-      "if: ${{ !inputs.dry_run && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}",
-    )
-  })
-
-  it('falls back to a full-zone purge when promotion chronology is unresolved', () => {
+  it('uses Cloudflare full-zone invalidation for automatic recovery', () => {
     expect(workflow).toContain('if [ "$MODE" = "full" ]; then')
     expect(workflow).toContain('payload=\'{"purge_everything":true}\'')
     expect(workflow).toContain('purge_call purge_everything /dev/null')
-  })
-
-  it('finds the baseline from the promotion-ordered Vercel purge ledger', () => {
-    expect(workflow).toContain('git rev-list --max-parents=0 HEAD')
-    expect(workflow).toContain('cache-purge-event.mjs baseline')
-    expect(workflow).not.toContain('git rev-list --since="$FALLBACK_WINDOW" "${head}^"')
-    expect(workflow).not.toContain('deployments?environment=Production')
-  })
-
-  it('paginates the root-commit status ledger', () => {
-    expect(workflow).toContain(
-      'gh api --paginate --slurp "repos/$REPO/commits/$ledger_sha/statuses?per_page=100"',
-    )
   })
 
   /**

--- a/scripts/cache-purge-prefixes.test.ts
+++ b/scripts/cache-purge-prefixes.test.ts
@@ -77,6 +77,29 @@ describe('readLocales', () => {
       rmSync(base, { force: true })
     }
   })
+
+  it('unions base and trusted fallback locales when the deployed config predates i18n', () => {
+    const deployedRoot = mkdtempSync(join(tmpdir(), 'cache-purge-old-deploy-'))
+    const base = join(tmpdir(), `purge-base-old-i18n-${process.pid}.ts`)
+    const fallback = join(tmpdir(), `purge-fallback-i18n-${process.pid}.ts`)
+    mkdirSync(join(deployedRoot, 'lib'))
+    writeFileSync(
+      base,
+      `export const i18n = { defaultLanguage: 'en', languages: ['en', 'zh', 'sv'] }`,
+    )
+    writeFileSync(
+      fallback,
+      `export const i18n = { defaultLanguage: 'en', languages: ['en', 'zh', 'fr'] }`,
+    )
+
+    try {
+      expect(readLocales(deployedRoot, base, fallback)).toEqual(['zh', 'sv', 'fr'])
+    } finally {
+      rmSync(deployedRoot, { recursive: true, force: true })
+      rmSync(base, { force: true })
+      rmSync(fallback, { force: true })
+    }
+  })
 })
 
 it('reads deployed inputs from the CLI working directory', () => {
@@ -250,6 +273,8 @@ describe('the workflow feeds the mapper what it needs', () => {
         .filter((command) => command !== 'node scripts/cache-purge-event.mjs')
         .every((command) => command.startsWith('node ../workflow-source/')),
     ).toBe(true)
+
+    expect(workflow).toContain('FALLBACK_I18N_FILE: ../workflow-source/lib/i18n.ts')
   })
 
   /**
@@ -302,38 +327,53 @@ describe('the workflow feeds the mapper what it needs', () => {
   })
 
   /**
-   * Purge success alone cannot describe production chronology: a failed C
-   * promotion still has to be removed when production rolls back to B.
+   * A missing promotion payload cannot be recovered from the Actions API. The
+   * workflow may use a successful purge as a selective checkpoint only after
+   * every intervening workflow run is visible and harmless.
    */
-  it('records each trusted promotion before purge planning', () => {
-    expect(workflow).toContain('PROMOTION_STATUS_CONTEXT: cache-promotion')
-    expect(workflow).toContain('-f context="$PROMOTION_STATUS_CONTEXT/$DEPLOYMENT_ID"')
-    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|Promoted"')
-
-    const promotionMarker = workflow.indexOf('- name: Record promoted deployment')
-    const rangeResolution = workflow.indexOf('- name: Resolve diff range')
-    const purge = workflow.indexOf('- name: Purge')
-    expect(promotionMarker).toBeGreaterThan(0)
-    expect(promotionMarker).toBeLessThan(rangeResolution)
-    expect(rangeResolution).toBeLessThan(purge)
+  it('reconciles every lower workflow run before selective planning', () => {
+    expect(workflow).toContain('actions: read')
+    expect(workflow).toContain('run-name: >-')
+    expect(workflow).toContain(
+      "cache-purge:${{ github.event.client_payload.environment || 'manual' }}:${{ github.event.client_payload.project.id || 'manual' }}:${{ github.event.client_payload.git.ref || 'manual' }}:${{ github.event.client_payload.git.sha || github.sha }}:${{ github.event.client_payload.id || github.run_id }}",
+    )
+    expect(workflow).toContain(
+      'gh api --paginate --slurp "repos/$REPO/actions/workflows/cache-purge.yml/runs?per_page=100"',
+    )
+    expect(workflow).toContain('unsafe=$(jq -r \'.unsafe | length\' <<< "$ledger_state")')
+    expect(workflow).toContain('display_title')
+    expect(workflow).toContain('emit mode full')
+    expect(workflow).not.toContain('sleep 10')
   })
 
-  it('broadens an unpurged non-forward transition from the prior promotion', () => {
-    expect(workflow).toContain('CURRENT_RUN_NUMBER: ${{ github.run_number }}')
-    expect(workflow).toContain('PROMOTION_STATUS_CONTEXT: ${{ env.PROMOTION_STATUS_CONTEXT }}')
-    expect(workflow).toContain('git merge-base --is-ancestor "$previous" "$head"')
-    expect(workflow).toContain('emit base "$previous"')
-    expect(workflow).toContain('Previous promotion was not purged and is not an ancestor')
+  it('uses successful purges as the only production checkpoints', () => {
+    expect(workflow).not.toContain('PROMOTION_STATUS_CONTEXT')
+    expect(workflow).not.toContain('- name: Record promoted deployment')
+    expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
+    expect(workflow).toContain('RUN_NUMBER: ${{ github.run_number }}')
+    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|')
+    expect(workflow).toContain(
+      "if: ${{ !inputs.dry_run && steps.assets.outputs.degraded != 'true' && github.event_name == 'repository_dispatch' }}",
+    )
+  })
+
+  it('falls back to a full-zone purge when promotion chronology is unresolved', () => {
+    expect(workflow).toContain('if [ "$MODE" = "full" ]; then')
+    expect(workflow).toContain('payload=\'{"purge_everything":true}\'')
+    expect(workflow).toContain('purge_call purge_everything /dev/null')
   })
 
   it('finds the baseline from the promotion-ordered Vercel purge ledger', () => {
     expect(workflow).toContain('git rev-list --max-parents=0 HEAD')
     expect(workflow).toContain('cache-purge-event.mjs baseline')
-    expect(workflow).toContain('PURGE_STATUS_CONTEXT/$DEPLOYMENT_ID')
-    expect(workflow).toContain('RUN_NUMBER: ${{ github.run_number }}')
-    expect(workflow).toContain('-f description="$RUN_NUMBER|$SHA|Purged ')
     expect(workflow).not.toContain('git rev-list --since="$FALLBACK_WINDOW" "${head}^"')
     expect(workflow).not.toContain('deployments?environment=Production')
+  })
+
+  it('paginates the root-commit status ledger', () => {
+    expect(workflow).toContain(
+      'gh api --paginate --slurp "repos/$REPO/commits/$ledger_sha/statuses?per_page=100"',
+    )
   })
 
   /**


### PR DESCRIPTION
## Summary

- Migrate automatic cache purges from GitHub `deployment_status` inference to Vercel's enriched `vercel.deployment.promoted` event.
- Validate the production environment, exact Vercel project, and deployment ID from the trusted workflow checkout before Cloudflare credentials are reachable. Git metadata is optional.
- Perform a full-zone Cloudflare purge for every valid production promotion. This remains correct when Vercel sends events out of order or when CLI, fork, or deleted-branch promotions have no reachable Git checkout.
- Isolate duplicate delivery with per-deployment concurrency while allowing distinct production promotions to invalidate the currently live origin independently.
- Keep selective range and broad purge planning for manual recovery, including live build-asset discovery and rollback support for trees that predate `lib/i18n.ts`.
- Accept the deliberate automatic-path tradeoff: production promotions evict the static cache instead of risking stale or poisoned responses behind a selective state machine without authoritative promotion ordering.

Depends on #744.

## Change Type

- [x] Bug fix

## Testing

- `pnpm test scripts/cache-purge-event.test.ts scripts/cache-purge-prefixes.test.ts`: 123 tests across 2 files.
- `pnpm test`: 403 tests across 34 files.
- `pnpm typecheck`
- `pnpm exec eslint scripts/cache-build-assets.mjs scripts/cache-build-assets.test.ts scripts/cache-purge-event.mjs scripts/cache-purge-event.test.ts scripts/cache-purge-prefixes.mjs scripts/cache-purge-prefixes.test.ts`
- `pnpm exec prettier --check .github/workflows/cache-purge.yml scripts/cache-build-assets.mjs scripts/cache-build-assets.test.ts scripts/cache-purge-event.mjs scripts/cache-purge-event.test.ts scripts/cache-purge-prefixes.mjs scripts/cache-purge-prefixes.test.ts`
- Parsed `.github/workflows/cache-purge.yml` with PyYAML and checked all 9 embedded `run` blocks with `bash -n`.
- Executed the automatic `Resolve diff range` shell in an empty, non-Git workspace; it emitted `mode=full` without reading Git metadata.

## Checklist

- [x] Tests cover production and preview payloads, missing Git metadata, non-main promotions, wrong projects, and malformed deployment IDs.
- [x] Every valid automatic production promotion emits a full-zone purge plan without a deployed-source checkout.
- [x] Manual recovery retains precise diff mapping and live build-asset discovery.
- [x] No new credentials or scheduled cache invalidations are required.