### PR TITLE
🏞️ docs: Tighten v0.8.8-rc2 Highlights

### DIFF
--- a/content/changelog/v0.8.8-rc2.mdx
+++ b/content/changelog/v0.8.8-rc2.mdx
@@ -11,23 +11,22 @@ Operator-facing YAML, environment, default, and migration changes are collected 
 
 ### 🏞️ Highlights
 
-- Interrupt Agent runs before visible output, steer or queue follow-ups, and recover tool-limited turns
-- Optional generated activity groups, live phase cards, and reasoning labels
-- Unified Agent Builder with standalone Skill authoring, background tools, intent labels, and Programmatic Tool Calling
-- Durable Agent Events, actor mailboxes, receipts, human pauses, and background completion wakeups
-- Saved Agent teams, deeper Subagent history, stable event panels, live controls, and automatic parent continuation
-- Experimental Agent Plugins and highly experimental Code environments with guarded file and command permissions
+- Interrupt, steer, or queue Agent runs, with HITL approvals, questions, and tool-limit recovery
+- Experimental Scheduled Chats with cron, weekly schedules, time zones, and Project destinations
+- New models: GPT-5.6; Claude Fable 5.1, Opus 5, and Sonnet 5; Gemini 3.8, 3.7, and 3.6 Flash; and Gemini 3.5 Flash-Lite
+- Live activity, phase, reasoning, and tool-intent labels
+- Unified Agent Builder with Skill authoring, background tools, and Programmatic Tool Calling
+- Durable Agent Events, primarily in beta, with mailboxes, receipts, human pauses, and background wakeups
+- Saved Agent teams, primarily in beta, with deeper Subagent history, live controls, and automatic continuation
+- Agent Plugins, primarily in beta, plus highly experimental Code environments with guarded permissions
 - Agent memory isolation and categorized Context Usage with optional cost
-- Redesigned Projects, full-message chat search, searchable settings, shortcuts, pinning, and mobile navigation
-- Experimental Scheduled Chats with cron, time zones, weekly cadence, and project destinations
+- UI polish across Projects, full-message search, settings, shortcuts, pinning, and mobile navigation
 - Stable shared links, personal copies, editable long pastes, and attachment-only turns
 - Fullscreen artifacts, Mermaid export, PowerPoint templates, and original file downloads
-- Keenable keyless web search plus expanded SearXNG and Tavily controls
-- Default security headers, opt-in nonce CSP, authenticated local images, Code Interpreter JWTs, and stronger SAML/OIDC flows
-- In-app Langfuse connections, tenant fanout, export telemetry, and authorized session links
-- Auditable source-aware content filtering, tenant Insights, and encrypted admin configuration
-- GPT-5.6, Claude Fable 5.1, Opus 5 and Sonnet 5, Gemini 3.8/3.7/3.6 Flash, and Gemini 3.5 Flash-Lite
-- Adaptive streaming, automatic generation protocol v2, Redis failover recovery, and live MCP catalog refresh
+- Keyless web search with expanded SearXNG and Tavily controls
+- Stronger security and admin controls across headers, local images, Code Interpreter, SAML/OIDC, content filtering, and encrypted configuration
+- In-app Langfuse connections, tenant fanout, export controls, and authorized session links
+- Adaptive streaming, generation protocol v2, Redis failover recovery, and live MCP catalog refresh
 
 ---
 


### PR DESCRIPTION
## Summary

I revised the v0.8.8-rc2 highlights to make them shorter, easier to scan, and better prioritized.

- Move Scheduled Chats and new model support near the top.
- Consolidate HITL approvals, questions, interrupt, steer, queue, and tool-limit recovery.
- Group live activity, phase, reasoning, and tool-intent labels.
- Clarify the beta or experimental status of Durable Agent Events, saved Agent teams, Agent Plugins, and Code environments.
- Summarize UI polish while naming Projects, search, settings, shortcuts, pinning, and mobile navigation.
- Preserve the exhaustive categorized release notes, attribution, and configuration changelog unchanged.

## Change Type

- [x] Documentation update

## Testing

- Ran `pnpm run typecheck`.
- Ran `pnpm run lint`.
- Ran `pnpm run lint:prettier`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js 24.16.0
- pnpm 9.15.9

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
