### PR TITLE
docs: document cohereApiUrl/COHERE_API_URL for web search reranker

### DIFF
--- a/content/docs/configuration/dotenv.mdx
+++ b/content/docs/configuration/dotenv.mdx
@@ -926,6 +926,12 @@ For detailed configuration and customization options, see: [Web Search Configura
       'API key for Cohere reranker service. Get your key from https://dashboard.cohere.com/welcome/login',
       '# COHERE_API_KEY=',
     ],
+    [
+      'COHERE_API_URL',
+      'string',
+      'Custom Cohere-compatible reranker API URL (optional). Only needed for a custom endpoint, e.g. a self-hosted LiteLLM proxy. Defaults to https://api.cohere.com/v2/rerank.',
+      '# COHERE_API_URL=',
+    ],
   ]}
 />
 

--- a/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/web_search.mdx
@@ -56,6 +56,7 @@ webSearch:
   jinaApiKey: "${JINA_API_KEY}"
   jinaApiUrl: "${JINA_API_URL}"
   cohereApiKey: "${COHERE_API_KEY}"
+  cohereApiUrl: "${COHERE_API_URL}"
   rerankerType: "jina" # Options: "jina", "cohere", "none"
 
   # General Settings
@@ -604,6 +605,16 @@ webSearch:
 />
 
 **Note:** Get your API key from [Cohere Dashboard](https://dashboard.cohere.com/welcome/login)
+
+### cohereApiUrl
+
+<OptionTable
+  options={[
+    ['cohereApiUrl', 'String', 'Environment variable name for a custom Cohere-compatible reranker endpoint. If not set in .env, defaults to https://api.cohere.com/v2/rerank.', '${COHERE_API_URL}'],
+  ]}
+/>
+
+**Note:** This is optional and only needed if you're using a custom Cohere-compatible endpoint, e.g. a self-hosted LiteLLM proxy.
 
 ### rerankerType
 

--- a/content/docs/features/web_search.mdx
+++ b/content/docs/features/web_search.mdx
@@ -41,6 +41,8 @@ To get started with web search, configure a search provider and scraper. Most pr
    JINA_API_URL=your_jina_api_url
    # or
    COHERE_API_KEY=your_cohere_api_key
+   # Optional: Custom Cohere-compatible API URL (e.g. a self-hosted LiteLLM proxy)
+   COHERE_API_URL=your_cohere_api_url
    ```
 
    Using Keenable without an environment key still requires provider selection in `librechat.yaml`:
@@ -224,9 +226,11 @@ webSearch:
   jinaApiKey: "${CUSTOM_JINA_API_KEY}"
   jinaApiUrl: "${CUSTOM_JINA_API_URL}"
   cohereApiKey: "${CUSTOM_COHERE_API_KEY}"
+  cohereApiUrl: "${CUSTOM_COHERE_API_URL}"
   # jinaApiKey: "jn-123..."                 # ❌ Wrong: Never put actual API keys here
   # jinaApiUrl: "https://..."               # ❌ Wrong: Never put actual URLs here
   # cohereApiKey: "ch-123..."               # ❌ Wrong: Never put actual API keys here
+  # cohereApiUrl: "https://..."             # ❌ Wrong: Never put actual URLs here
 
   # General Settings
   safeSearch: 1 # Options: 0 (OFF), 1 (MODERATE - default), 2 (STRICT)


### PR DESCRIPTION
## Summary
Documents the new `cohereApiUrl` config field / `COHERE_API_URL` env var for the web search reranker, mirroring the existing `jinaApiUrl`/`JINA_API_URL` documentation:
- `content/docs/configuration/librechat_yaml/object_structure/web_search.mdx` — YAML example + property reference table
- `content/docs/features/web_search.mdx` — env var setup + YAML example
- `content/docs/configuration/dotenv.mdx` — env var reference table

This documents the feature added in danny-avila/LibreChat#15518 and danny-avila/agents#498, which lets the Cohere reranker point at a Cohere-compatible endpoint (e.g. a self-hosted LiteLLM proxy) instead of `api.cohere.com`.

English-only change, per this repo's localization convention (other languages are handled by translation automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)