### PR TITLE
🩹 fix: Correct Node Version and Install Command on the Local Install Hub

### DIFF
--- a/components/LocalInstallHub.tsx
+++ b/components/LocalInstallHub.tsx
@@ -102,14 +102,15 @@ const methods: {
     time: '~20 min',
     difficulty: 'Intermediate',
     prereqs: [
-      { label: 'Node.js v20.19+', href: 'https://nodejs.org/en/download' },
+      { label: 'Node.js v24.16.0', href: 'https://nodejs.org/en/download' },
       { label: 'Git', href: 'https://git-scm.com/downloads' },
       { label: 'MongoDB', href: '/docs/configuration/mongodb/mongodb_atlas' },
     ],
     commands: [
       'git clone https://github.com/danny-avila/LibreChat.git',
-      'cd LibreChat && npm ci',
+      'cd LibreChat',
       'cp .env.example .env  # edit MONGO_URI',
+      'npm run reinstall',
       'npm run backend',
     ],
     included: [],


### PR DESCRIPTION
## Summary

The npm card on `/docs/local` carried two incorrect facts about installing LibreChat without Docker. Both are corrected against LibreChat's own source on `origin/dev`.

**Node version.** The card advertised `Node.js v20.19+`. LibreChat pins `24.16.0` in `.nvmrc` and builds on `node:24.16.0-alpine` in its `Dockerfile`, and every localized `/docs/local/npm` guide already states `v24.16.0`. The hub card was the only place in this repository still claiming `v20.19+`, so it contradicted the very guide it links to.

**Install command.** The card listed `cd LibreChat && npm ci` followed by `npm run backend`. LibreChat has no root `postinstall`, so `npm ci` installs workspace dependencies without building `packages/data-provider`, `packages/data-schemas`, `packages/api`, `packages/client`, or the client bundle. `npm run backend` cannot start from that state. The canonical step is `npm run reinstall` (`node config/update.js -l -g`), which runs `npm ci` and then `npm run frontend`, exactly what the full guide instructs.

Both values live in the component's structural data, which is explicitly untranslated ("Brand titles, prereq labels, commands and bundled service names stay as written"). No locale dictionary or MDX translation is affected.

## Feedback addressed

- `1545085630760095786` - `/docs/local`
  - Reported that installing without Docker should be possible because Docker is heavy on low-end machines, and asked for a lighter Python-based server.
  - Investigation found the non-Docker path already exists and is documented at `/docs/local/npm`, but the card that surfaces it on `/docs/local` stated the wrong Node version and an install command that cannot produce a runnable app. A reader on a low-end machine following that card would install Node 20 and then fail to start the backend.
  - Corrected the card's Node version to `v24.16.0` and its command list to the `npm run reinstall` flow so it matches the guide it links to.
  - Classification: FIXED

## Validation

- `pnpm install --frozen-lockfile` - passed, lockfile unchanged
- `pnpm run lint` - passed
- `pnpm run lint:prettier` - passed
- `pnpm run typecheck` - passed
- `pnpm test` - passed (33 files, 391 tests)
- `pnpm build` - passed, and the prerendered `/docs/local` output was checked directly: one occurrence of `Node.js v24.16.0`, zero of `v20.19`, `npm run reinstall` present, `npm ci` gone

Note: the first `pnpm build` on this base aborted with a V8 `heap out of memory` error. It is a local heap-size artifact, not a code failure. The same build passed before the rebase and passes here with `NODE_OPTIONS=--max-old-space-size=8192`.

## Not changed

- The request for "a light version based on a python server" was not acted on. LibreChat is a Node.js and TypeScript application (`api/server/index.js`, npm workspaces, a Node base image), so reimplementing the server in Python is an upstream product-architecture decision and is out of scope for the documentation site. No repository change here could serve it.
- The non-Docker installation path itself was already available and documented, so nothing was added for it beyond correcting the card.
- `/docs/local/npm` states npm `v11.16.0` while LibreChat's `packageManager` field pins `npm@11.13.0`. The docs read as a minimum for the npm 11 line rather than an exact pin, so this was left alone as an unverified discrepancy rather than changed speculatively.
