### PR TITLE
docs(auth): add OpenID Connect token placeholders and OPENID_EXPOSE_SUB_COOKIE documentation

### DIFF
--- a/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
@@ -127,6 +127,9 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 
 # Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
 # OPENID_MAX_LOGOUT_URL_LENGTH=2000
+
+# Cross-origin OAuth Callback Support (optional, independent of OPENID_REUSE_TOKENS)
+# OPENID_EXPOSE_SUB_COOKIE=true
 ```
 
 ## Additional Configuration Options
@@ -141,6 +144,7 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 - `GRAPH_API_SCOPES`: Space-separated Microsoft Graph scopes requested when resolving `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` in a YAML-defined MCP server. Defaults to `https://graph.microsoft.com/.default`; this is separate from the `OPENID_GRAPH_SCOPES` used for people and group search.
 - `OPENID_USE_END_SESSION_ENDPOINT`: Enables use of the end session endpoint for logout
 - `OPENID_MAX_LOGOUT_URL_LENGTH`: Maximum URL length before using `logout_hint` instead of `id_token_hint` to prevent URI too long errors (default: 2000)
+- `OPENID_EXPOSE_SUB_COOKIE`: Exposes a JWT-signed cookie containing the OpenID `sub` claim with `sameSite=lax`. This enables cross-origin OAuth callback flows (e.g., AWS Bedrock AgentCore 3LO). Can be used independently of `OPENID_REUSE_TOKENS`.
 
 ## Security Considerations
 

--- a/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
+++ b/content/docs/configuration/authentication/OAuth2-OIDC/token-reuse.mdx
@@ -130,6 +130,8 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 
 # Cross-origin OAuth Callback Support (optional, independent of OPENID_REUSE_TOKENS)
 # OPENID_EXPOSE_SUB_COOKIE=true
+# Optional dedicated signing key for openid_sub cookie (defaults to JWT_REFRESH_SECRET)
+# OPENID_SUB_SECRET=
 ```
 
 ## Additional Configuration Options
@@ -144,7 +146,8 @@ OPENID_USE_END_SESSION_ENDPOINT=true
 - `GRAPH_API_SCOPES`: Space-separated Microsoft Graph scopes requested when resolving `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` in a YAML-defined MCP server. Defaults to `https://graph.microsoft.com/.default`; this is separate from the `OPENID_GRAPH_SCOPES` used for people and group search.
 - `OPENID_USE_END_SESSION_ENDPOINT`: Enables use of the end session endpoint for logout
 - `OPENID_MAX_LOGOUT_URL_LENGTH`: Maximum URL length before using `logout_hint` instead of `id_token_hint` to prevent URI too long errors (default: 2000)
-- `OPENID_EXPOSE_SUB_COOKIE`: Exposes a JWT-signed cookie containing the OpenID `sub` claim with `sameSite=lax`. This enables cross-origin OAuth callback flows (e.g., AWS Bedrock AgentCore 3LO). Can be used independently of `OPENID_REUSE_TOKENS`.
+- `OPENID_EXPOSE_SUB_COOKIE`: Exposes a JWT-signed cookie (`openid_sub`) containing the OpenID `sub` claim with `sameSite=lax`. This enables cross-origin OAuth callback flows (e.g., AWS Bedrock AgentCore 3LO). Can be used independently of `OPENID_REUSE_TOKENS`. The token payload includes `typ: "openid_sub"` and is session-bound via `refreshTokenHash`.
+- `OPENID_SUB_SECRET`: Optional dedicated signing key for the `openid_sub` cookie. If unset, defaults to `JWT_REFRESH_SECRET`. Recommended when external callback consumers (e.g., AWS Lambda) need to verify the token without access to `JWT_REFRESH_SECRET`.
 
 ## Security Considerations
 

--- a/content/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/custom_endpoint.mdx
@@ -827,6 +827,33 @@ headers:
   X-Message-ID: '{{LIBRECHAT_BODY_MESSAGEID}}'
 ```
 
+**Available OpenID Token Placeholders:**
+
+These placeholders are available when using OpenID Connect authentication. They extract values from the OpenID tokens stored in the user's session.
+
+| Placeholder | Description |
+| --- | --- |
+| `{{LIBRECHAT_OPENID_TOKEN}}` | OpenID access token (generic alias for ACCESS_TOKEN) |
+| `{{LIBRECHAT_OPENID_ACCESS_TOKEN}}` | OpenID access token |
+| `{{LIBRECHAT_OPENID_ID_TOKEN}}` | OpenID ID token |
+| `{{LIBRECHAT_OPENID_USER_ID}}` | User ID from OpenID claims (sub claim or openidId) |
+| `{{LIBRECHAT_OPENID_USER_EMAIL}}` | User email from OpenID claims |
+| `{{LIBRECHAT_OPENID_USER_NAME}}` | User name from OpenID claims |
+| `{{LIBRECHAT_OPENID_EXPIRES_AT}}` | Token expiration timestamp (Unix epoch seconds) |
+
+<Callout type="info" title="OpenID Token Availability">
+These placeholders require OpenID Connect authentication to be configured. The token values are extracted from the `federatedTokens` or `openidTokens` properties on the user object, which are populated during the OpenID authentication flow.
+</Callout>
+
+**Example using OpenID token placeholders:**
+
+```yaml filename="endpoints / custom / headers with OpenID tokens"
+headers:
+  Authorization: "Bearer {{LIBRECHAT_OPENID_ACCESS_TOKEN}}"
+  X-ID-Token: "{{LIBRECHAT_OPENID_ID_TOKEN}}"
+  X-User-Sub: "{{LIBRECHAT_OPENID_USER_ID}}"
+```
+
 ## directEndpoint
 
 **Key:**


### PR DESCRIPTION
## Summary

Supersedes #483.
Documents OpenID Connect authentication features in LibreChat:
- Documents `OPENID_EXPOSE_SUB_COOKIE` environment variable for cross-origin OAuth callback flows (e.g. AWS Bedrock AgentCore 3LO) in `token-reuse.mdx` (accompanies [danny-avila/LibreChat#15607](https://github.com/danny-avila/LibreChat/pull/15607)).
- Adds the reference table and practical usage example for the seven `{{LIBRECHAT_OPENID_*}}` token placeholders in `custom_endpoint.mdx` (merged in [danny-avila/LibreChat#9931](https://github.com/danny-avila/LibreChat/pull/9931)).

## Changes

### token-reuse.mdx
- Added `OPENID_EXPOSE_SUB_COOKIE` environment variable to the `.env` example block.
- Added `OPENID_EXPOSE_SUB_COOKIE` description to "Additional Configuration Options".

### custom_endpoint.mdx
- Added "Available OpenID Token Placeholders" reference table:
  - `{{LIBRECHAT_OPENID_TOKEN}}` - OpenID access token (generic alias)
  - `{{LIBRECHAT_OPENID_ACCESS_TOKEN}}` - OpenID access token
  - `{{LIBRECHAT_OPENID_ID_TOKEN}}` - OpenID ID token
  - `{{LIBRECHAT_OPENID_USER_ID}}` - User ID from OpenID claims
  - `{{LIBRECHAT_OPENID_USER_EMAIL}}` - User email from OpenID claims
  - `{{LIBRECHAT_OPENID_USER_NAME}}` - User name from OpenID claims
  - `{{LIBRECHAT_OPENID_EXPIRES_AT}}` - Token expiration timestamp
- Added callout explaining token availability requirements.
- Added YAML example showing OpenID tokens used in custom headers.

## Checklist

- [x] Rebased against latest `main`
- [x] Prettier formatting verified