### PR TITLE
🧭 docs: Reconcile Contradictory Custom Endpoint and MCP Guidance

### DIFF
--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -15,13 +15,13 @@ LLMs are limited to their built-in capabilities. With MCP, LibreChat breaks down
 - **Connecting to any tool or service** that provides an MCP server
 - **Standardizing integrations** so you don't need to edit LibreChat's code for each tool
 - **Supporting multi-user environments** with proper authentication and isolation
-- **Providing a growing ecosystem** of dynamic, ready-to-use integrations
+- **Adding and updating servers at runtime** from the MCP Settings panel, without editing a config file or restarting
 
 ## How MCP Works in LibreChat
 
 LibreChat provides two ways to use MCP servers, either in the chat area or with agents.
 
-You can configure MCP servers manually in your `librechat.yaml` file or by using [smithery.ai](https://smithery.ai) to find and install MCP servers into `librechat.yaml` ([see example below](#basic-configuration)). Any time you add or edit an MCP server, you will need to restart LibreChat to initialize the connections.
+You can configure MCP servers manually in your `librechat.yaml` file or by using [smithery.ai](https://smithery.ai) to find and install MCP servers into `librechat.yaml` ([see example below](#basic-configuration)). Any time you add or edit a server in `librechat.yaml`, you will need to restart LibreChat to initialize the connections. Servers added through the [MCP Settings panel](#adding-mcp-servers-in-the-ui) are initialized as soon as they are saved and need no restart.
 
 ### OAuth Callback URL
 

--- a/content/docs/features/mcp.mdx
+++ b/content/docs/features/mcp.mdx
@@ -21,7 +21,7 @@ LLMs are limited to their built-in capabilities. With MCP, LibreChat breaks down
 
 LibreChat provides two ways to use MCP servers, either in the chat area or with agents.
 
-You can configure MCP servers manually in your `librechat.yaml` file or by using [smithery.ai](https://smithery.ai) to find and install MCP servers into `librechat.yaml` ([see example below](#basic-configuration)). Any time you add or edit a server in `librechat.yaml`, you will need to restart LibreChat to initialize the connections. Servers added through the [MCP Settings panel](#adding-mcp-servers-in-the-ui) are initialized as soon as they are saved and need no restart.
+You can configure MCP servers manually in your `librechat.yaml` file or by using [smithery.ai](https://smithery.ai) to find and install MCP servers into `librechat.yaml` ([see example below](#basic-configuration)). Any time you add or edit a server in `librechat.yaml`, you will need to restart LibreChat to initialize the connections. Servers added through the [MCP Settings panel](#adding-mcp-servers-in-the-ui) take effect without a restart. A panel-created server that uses OAuth is registered on save but starts out disconnected: [authenticate it](#step-3-check-connection-status-and-authenticate) once to connect it.
 
 ### OAuth Callback URL
 

--- a/content/docs/quick_start/custom_endpoints.mdx
+++ b/content/docs/quick_start/custom_endpoints.mdx
@@ -99,21 +99,28 @@ Use `provider: "anthropic"` only for endpoints that speak the native Anthropic M
 
 When configuring API keys in custom endpoints, you have three options:
 
-1. **Environment variable** (recommended): `apiKey: "${OPENROUTER_KEY}"` -- reads from `.env`
-2. **User provided**: `apiKey: "user_provided"` -- users enter their own key in the UI
-3. **Direct value** (not recommended): `apiKey: "sk-your-actual-key"` -- stored in plain text
+1. **Environment variable** (recommended): `apiKey: '${OPENROUTER_KEY}'` reads one shared key from `.env`. This is the only option that needs Step 3.
+2. **User provided**: `apiKey: 'user_provided'` asks each user for their own key in the LibreChat UI instead of reading one from `.env`. No `.env` entry is involved, so Step 3 does not apply. LibreChat stores each user's key encrypted and prompts for it the first time they select the endpoint.
+3. **Direct value** (not recommended): `apiKey: 'sk-your-actual-key'` hardcodes the key in `librechat.yaml` in plain text.
+
+`baseURL` accepts `user_provided` in the same way, which lets each user point the endpoint at their own gateway.
+
+The example above deliberately mixes styles: OpenRouter and the Anthropic-compatible gateway use option 1, while Ollama passes the literal string `'ollama'` because a local Ollama server ignores the key entirely.
 
 </Callout>
 
 ## Step 3. Set Environment Variables
 
-Add the API keys referenced in your `librechat.yaml` to the `.env` file:
+This step applies only to endpoints written with the `${VARIABLE_NAME}` form. If every endpoint you added uses `user_provided`, skip to [Step 4](#step-4-restart-and-verify).
+
+Add each variable your `librechat.yaml` references to `.env`. The example above references two:
 
 ```bash filename=".env"
 OPENROUTER_KEY=your_openrouter_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
 ```
 
-Each `${VARIABLE_NAME}` in librechat.yaml must have a matching entry in `.env`.
+Every `${VARIABLE_NAME}` in `librechat.yaml` needs a matching entry. A missing one does not drop the endpoint: it still appears in the selector, and the problem only surfaces as `Missing API Key for <endpoint>` once someone sends a message through it.
 
 ## Step 4. Restart and Verify
 

--- a/content/docs/quick_start/custom_endpoints.mdx
+++ b/content/docs/quick_start/custom_endpoints.mdx
@@ -120,7 +120,7 @@ OPENROUTER_KEY=your_openrouter_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 ```
 
-Every `${VARIABLE_NAME}` in `librechat.yaml` needs a matching entry. A missing one does not drop the endpoint: it still appears in the selector, and the problem only surfaces as `Missing API Key for <endpoint>` once someone sends a message through it.
+Every `${VARIABLE_NAME}` in `librechat.yaml` needs a matching entry. A missing one does not drop the endpoint: it still appears in the selector, and the problem only surfaces once someone sends a message through it. An unresolved `apiKey` fails with `Missing API Key for <endpoint>`, and an unresolved `baseURL` with `Missing Base URL for <endpoint>`.
 
 ## Step 4. Restart and Verify
 

--- a/content/docs/quick_start/custom_endpoints.mdx
+++ b/content/docs/quick_start/custom_endpoints.mdx
@@ -99,8 +99,8 @@ Use `provider: "anthropic"` only for endpoints that speak the native Anthropic M
 
 When configuring API keys in custom endpoints, you have three options:
 
-1. **Environment variable** (recommended): `apiKey: '${OPENROUTER_KEY}'` reads one shared key from `.env`. This is the only option that needs Step 3.
-2. **User provided**: `apiKey: 'user_provided'` asks each user for their own key in the LibreChat UI instead of reading one from `.env`. No `.env` entry is involved, so Step 3 does not apply. LibreChat stores each user's key encrypted and prompts for it the first time they select the endpoint.
+1. **Environment variable** (recommended): `apiKey: '${OPENROUTER_KEY}'` reads one shared key from `.env`, so the key needs a matching entry in [Step 3](#step-3-set-environment-variables).
+2. **User provided**: `apiKey: 'user_provided'` asks each user for their own key in the LibreChat UI instead of reading one from `.env`. No `.env` entry is needed for the key itself. LibreChat stores each user's key encrypted and prompts for it the first time they select the endpoint.
 3. **Direct value** (not recommended): `apiKey: 'sk-your-actual-key'` hardcodes the key in `librechat.yaml` in plain text.
 
 `baseURL` accepts `user_provided` in the same way, which lets each user point the endpoint at their own gateway.
@@ -111,7 +111,7 @@ The example above deliberately mixes styles: OpenRouter and the Anthropic-compat
 
 ## Step 3. Set Environment Variables
 
-This step applies only to endpoints written with the `${VARIABLE_NAME}` form. If every endpoint you added uses `user_provided`, skip to [Step 4](#step-4-restart-and-verify).
+This step covers every `${VARIABLE_NAME}` reference in your `librechat.yaml`, whether it sits in `apiKey`, `baseURL`, or a `headers` value. If nothing you added uses that form, skip to [Step 4](#step-4-restart-and-verify).
 
 Add each variable your `librechat.yaml` references to `.env`. The example above references two:
 
@@ -120,7 +120,7 @@ OPENROUTER_KEY=your_openrouter_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 ```
 
-Every `${VARIABLE_NAME}` in `librechat.yaml` needs a matching entry. A missing one does not drop the endpoint: it still appears in the selector, and the problem only surfaces once someone sends a message through it. An unresolved `apiKey` fails with `Missing API Key for <endpoint>`, and an unresolved `baseURL` with `Missing Base URL for <endpoint>`.
+Every `${VARIABLE_NAME}` in `librechat.yaml` needs a matching entry. A missing one does not drop the endpoint: it still appears in the selector, and the problem only surfaces once someone sends a message through it. An unresolved `apiKey` fails with `Missing API Key for <endpoint>`, and an unresolved `baseURL` with `Missing Base URL for <endpoint>`. An unresolved `headers` value behaves differently: it is sent upstream as the literal text `${VARIABLE_NAME}`, so the failure comes back from the provider rather than from LibreChat.
 
 ## Step 4. Restart and Verify
 


### PR DESCRIPTION
## Summary

Two docs pages told readers something the code does not do. Both came in through Discord feedback and both were verified against `origin/dev` of the app before editing.

**`/docs/quick_start/custom_endpoints`** listed `apiKey: 'user_provided'` as one of three options and then walked every reader into "Step 3. Set Environment Variables" as an unconditional step. A reader who chose `user_provided` was being told to do the exact thing that option exists to avoid. Step 3 is now scoped to the `${VARIABLE_NAME}` form, and each option in the callout says whether it needs an `.env` entry.

Verified in `packages/api/src/endpoints/custom/initialize.ts`: when `apiKey` is `user_provided`, LibreChat reads the key from the per-user `Key` record via `getUserKeyValues` and never consults `process.env`. Two smaller corrections came out of the same reading: the `.env` sample omitted `ANTHROPIC_API_KEY` even though the example config above it references that variable, and an unresolved `${VAR}` does not drop the endpoint (it stays in the selector and throws `Missing API Key for <endpoint>` only when a message is sent).

**`/docs/features/mcp`** opened with "Providing a growing ecosystem of dynamic, ready-to-use integrations". It is contentless, and it is not accurate: LibreChat ships no MCP registry, marketplace or curated catalog. Users always bring their own server config, and Smithery is an external site rather than a bundled catalog. It is replaced with runtime server management, which the page already documents at length and which is backed by `createMCPServerController` and `MCPServersRegistry.addServer`.

That replacement exposed a contradiction already on the page: the intro said a restart is needed "any time you add or edit an MCP server", while the UI section below says servers can be added "without editing any configuration files or restarting the server". Both are half right, so the intro sentence is now scoped to `librechat.yaml`. YAML servers load at boot and have no file watcher; servers saved through the MCP Settings panel are inspected and stored in the DB tier during the request.

Only English sources are touched. The `.de.mdx` page the reporters were reading is bot output from `translate_docs.yml`, which retranslates the changed blocks on merge to `main`.

## Change Type

- [x] Documentation update

## Feedback addressed

- `1545680589888421981` and `/docs/quick_start/custom_endpoints`
  - Page presented `user_provided` as an option, then required an `.env` variable for the API key, which is the opposite of what that option does.
  - Scoped Step 3 to `${VAR}` endpoints, stated per option whether `.env` is involved, completed the `.env` sample, and documented the real missing-variable failure mode.
  - Classification: FIXED

- `1545681058937307189` and `/de/docs/features/mcp`
  - "Providing a growing ecosystem of dynamic, ready-to-use integrations" is marketing rather than documentation.
  - Replaced with a concrete, source-verified capability, and scoped the contradictory restart sentence it sat above.
  - Classification: FIXED

- `1545680954620780568` and `/de/docs/features/mcp`
  - Same reporter, sent 25 seconds earlier, containing only the quoted sentence with no complaint attached.
  - Resolved by the same change.
  - Classification: DUPLICATE of `1545681058937307189`

## Validation

- `pnpm lint` passed, exit 0
- `pnpm typecheck` passed
- `pnpm test` passed, 392 tests across 33 files
- `pnpm prettier --check` on both changed files passed
- `pnpm build` passed with `NODE_OPTIONS=--max-old-space-size=8192`
- Verified in the built HTML that both pages render the new text, that `id="step-4-restart-and-verify"` and `id="adding-mcp-servers-in-the-ui"` exist as real heading targets for the two new links, and that `<endpoint>` escapes as text rather than being parsed as a tag

At Node's default heap size `pnpm build` exits 134 with a V8 out-of-memory error on this machine. That reproduces identically on the base commit `c2458735` with these changes absent, so it is a local memory limit rather than a regression from this PR.

## Not changed

- `1545723846936629279` and `1545793533032796341`, both positive ratings on `/docs` with no report attached. Investigated and classified NON-ACTIONABLE, no repository change.
- No translated `*.de.mdx` files were hand-edited. `translate_docs.yml` treats them as generated output and explicitly excludes them from its own triggers.
- The wider claim in the first report that the page is "AI-generated nonsense" did not hold up. The instructions were individually correct; the defect was that Step 3 was presented unconditionally, which is what this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtKgYeptrzc2kctgcyR8Mf
