### PR TITLE
🖥️ docs: Clarify That LibreChat Has No Desktop Installer on the Local Install Hub

### DIFF
--- a/content/docs/local/index.mdx
+++ b/content/docs/local/index.mdx
@@ -1,7 +1,13 @@
 ---
 title: Local Installation
 icon: Monitor
-description: How to install LibreChat locally
+description: Install LibreChat yourself with Docker, npm, or a Helm chart. It is a self-hosted web app, not a desktop installer.
 ---
+
+<Callout type="info" title="Is there a Windows or macOS app?">
+
+No. LibreChat is a self-hosted web application, so there is no `.exe`, `.dmg`, or AppImage to download: you install it yourself using one of the methods below, then use it in your browser. Docker and npm run it on your own machine on Windows, macOS, or Linux and serve it at [http://localhost:3080](http://localhost:3080); on Windows, [Docker Desktop](/docs/local/docker) is the simplest starting point. The Helm chart deploys to a Kubernetes cluster instead, and is reached through your cluster's networking.
+
+</Callout>
 
 <LocalInstallHub />


### PR DESCRIPTION
## Summary

A reader on `/de/docs/local` submitted "Ich wollte eine Windows app" ("I wanted a Windows app"). The Local Installation hub renders three install cards (`<LocalInstallHub />`) and no prose, so nothing on the page tells a reader that LibreChat is a self-hosted web application rather than something you download and run natively.

`/docs` already carries this clarification, added in #600 in response to the same class of report. The install hub is a separate entry point that readers reach directly from search results and from the sidebar, so that note never reaches them. The same complaint arriving again, one level down, is evidence that a single placement is not enough.

This adds a short callout on `/docs/local` that answers the question directly and routes Windows readers to Docker Desktop, and widens the page description so the expectation is also set in the search-result snippet that brings people to the page.

Only the English source is changed. `.github/workflows/translate_docs.yml` regenerates the 13 locale copies on push to `main`, so `/de/docs/local` picks the callout up from that run.

### Facts verified before writing

Checked against the application source at `danny-avila/LibreChat@origin/dev`, not assumed:

- No Electron, Tauri, NW.js, or Neutralino packaging exists in the repo, so "no native installer" is accurate rather than merely current-sounding.
- `PORT=3080` and `DOMAIN_CLIENT=http://localhost:3080` in `.env.example`, and `docker-compose.yml` publishes `${PORT}:${PORT}`, so the `http://localhost:3080` the callout gives is the real default.
- Windows is a supported host for both methods the callout names: `content/docs/local/docker.mdx` documents Docker Desktop plus a Windows `copy` note, and `content/docs/local/npm.mdx` carries a Windows note of its own.
- The `localhost:3080` promise is scoped to Docker and npm. `content/docs/local/helm_chart.mdx` never mentions that URL, and a Helm install targets a Kubernetes cluster reached through cluster networking, so the callout says so rather than implying a local address for all three cards.

### Review

Reviewed with `codex review --base main` at `xhigh` reasoning effort. The first pass raised one P2: the original wording said "you run it on your own machine using one of the methods below, then open it in your browser at `http://localhost:3080`", which reads as a promise for the Helm card too. Verified against `content/docs/local/helm_chart.mdx` (no `localhost`, no access section at all), so the finding was correct and the sentence is now scoped to Docker and npm with a separate clause for Helm. A second pass on the amended diff returned no findings.

## Change Type

- [x] Documentation

## Feedback addressed

- `1546161795104768073` (`/de/docs/local`)
  - Reader expected a downloadable Windows application and found only Docker, npm, and Helm install cards, with nothing on the page explaining that LibreChat is a web app you host yourself.
  - Added a callout answering the question directly, pointing Windows readers at Docker Desktop, and naming the browser URL the app runs on. Broadened the page description so the same expectation is set before the click.
  - Classification: FIXED

## Validation

Run locally on Node 24.16.0 (the repo requires `>=22.0.0 <25`):

- `pnpm lint`: passed (zero warnings)
- `pnpm lint:prettier`: passed
- `pnpm typecheck`: passed
- `pnpm test`: passed (313 tests, 22 files)
- `pnpm build`: passed, including `postbuild` and sitemap generation

Verified in the build output rather than assumed: the callout is present in the prerendered `/docs/local` HTML with the correct info styling, and it is picked up into the English search index and `llms-full.txt`. The `/de/docs/local` page still builds cleanly and continues to serve the current German copy until the translation workflow runs.

The default V8 heap is not enough for a full build of this site in the automation environment; the first attempt died with an OOM during webpack compilation and the run above used `--max-old-space-size=12288`. That is an environment limit, unrelated to this change.

## Not changed

- `1546050296445276172` (`/docs`): rating "good", no message and no additional embed fields. A bare positive rating with no request in it. Classification: NON-ACTIONABLE.
- Locale copies of `content/docs/local/index.mdx` were deliberately left alone. English is the source of truth and the translation workflow owns the generated files.
- Issue #748 (`/docs/local/npm` Windows troubleshooting) and issue #747 (the docs never explain what LibreChat is) are adjacent but distinct, and neither is closed by this change. #748 needs a real Windows reproduction; #747 is a broader editorial gap about the product introduction.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqsVMs6sqXvDj8KvRut897
