### PR TITLE
🎞️ docs: Video/Audio Opt-In for Custom Endpoints via `supportedMimeTypes`

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -399,3 +399,20 @@ assistants:
 ```
 
 LibreChat normalizes common MIME aliases before applying these patterns. In particular, `application/x-shellscript` (reported by Chrome on Linux) and `text/x-shellscript` (reported by libmagic) become `application/x-sh`. A custom allowlist that accepts shell scripts should therefore permit the canonical `application/x-sh` type. Rejected uploads return the reported unsupported type to the client instead of a generic server error.
+
+### Video and audio for custom endpoints
+
+For a **custom endpoint** (an entry under `endpoints.custom`), `supportedMimeTypes` also decides which attachment types the `Upload to Provider` option sends to the model. By default only images and PDFs are attached. If the endpoint's server accepts video or audio input in the OpenAI chat format (for example a vLLM or LiteLLM deployment serving a multimodal model), list those types explicitly and LibreChat will both allow them in the file picker and send them as `video_url` / `input_audio` message parts:
+
+```yaml filename="fileConfig / endpoints / {custom_endpoint_name} / supportedMimeTypes"
+fileConfig:
+  endpoints:
+    MyGateway:
+      supportedMimeTypes:
+        - "image/.*"
+        - "application/pdf"
+        - "video/.*"
+        - "audio/.*"
+```
+
+This is opt-in on purpose: not every OpenAI-compatible server accepts media, and sending it to one that does not will fail the request. The inherited default list does not enable it, only an explicit `supportedMimeTypes` entry for that endpoint does. See [Upload Files to Provider](/docs/features/ocr#5-upload-files-to-provider-direct).

--- a/content/docs/features/ocr.mdx
+++ b/content/docs/features/ocr.mdx
@@ -176,6 +176,8 @@ allowing the provider to use their own native OCR implementations to parse files
 
 Currently all five of the aforementioned providers offer support for images and PDFs, with Google also including support for audio and video files when used in conjunction with compatible multimodal models. AWS Bedrock additionally supports CSV, DOC, DOCX, XLS, XLSX, HTML, TXT, and Markdown documents.
 
+**Custom endpoints** (OpenAI-compatible servers configured under `endpoints.custom`, such as vLLM, LiteLLM, or OpenRouter) also receive images and PDFs. OpenRouter additionally receives video and audio. For other custom endpoints, video and audio are off by default because not every server accepts them; an admin can opt an endpoint in by listing `video/.*` and/or `audio/.*` in that endpoint's `supportedMimeTypes` under `fileConfig`. See [supportedMimeTypes for custom endpoints](/docs/configuration/librechat_yaml/object_structure/file_config#video-and-audio-for-custom-endpoints).
+
 <Callout type="note" title="Azure OpenAI PDF Upload Caveat" emoji='✏️'>
 For **Azure OpenAI** endpoints, the Upload to Provider option for PDF files is only available when using the Responses API. Azure OpenAI's Chat Completions API supports images but does not support PDF file attachments.
 


### PR DESCRIPTION
Companion to danny-avila/LibreChat#15709 (fixes danny-avila/LibreChat#15708).

Custom OpenAI-compatible endpoints can opt into receiving video and audio attachments through **Upload to Provider** by listing `video/.*` / `audio/.*` in the endpoint's `fileConfig.endpoints.<name>.supportedMimeTypes`. Off by default, since not every gateway accepts media.

Changes:
- `file_config.mdx`: new **Video and audio for custom endpoints** subsection under the endpoint-level `supportedMimeTypes` with a YAML example and the opt-in rationale.
- `ocr.mdx` (Upload Files to Provider): a paragraph on what custom endpoints receive by default and how to opt in, cross-linked to the reference page.

Should land together with or after the code PR.