### PR TITLE
🧭 docs: Document defaultDeferLoading Agents Setting

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/agents.mdx
@@ -18,6 +18,9 @@ endpoints:
     maxToolCallArgBytesByTool:
       create_file: 131072
     disableBuilder: false
+    # (optional) When true, MCP tools newly added to an agent in the Agent Builder start with Defer Loading enabled.
+    # Requires the "deferred_tools" capability; users can still opt out per tool. Defaults to false.
+    # defaultDeferLoading: false
     # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
     # Opt-in capabilities: "programmatic_tools", "stateful_code_sessions", "run_in_background", and "tool_intents".
     # capabilities: ["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "memory", "ask_user_question", "tools", "chain", "ocr"]
@@ -304,6 +307,29 @@ capabilities:
 ```
 
 **Note:** This field is optional. If omitted, the default behavior is to include all the capabilities listed in the default.
+
+## defaultDeferLoading
+
+<OptionTable
+  options={[
+    [
+      'defaultDeferLoading',
+      'Boolean',
+      'When set to `true`, MCP tools newly added to an agent in the Agent Builder start with Defer Loading enabled.',
+      'Applies only when the `deferred_tools` capability is enabled. Tools with saved per-tool options and existing agents are unaffected, and users can still opt out per tool.',
+    ],
+  ]}
+/>
+
+**Default:** `false`
+
+**Example:**
+
+```yaml filename="endpoints / agents / defaultDeferLoading"
+defaultDeferLoading: true
+```
+
+**Note:** This field is optional. If omitted, newly added MCP tools start with Defer Loading off, matching the previous behavior.
 
 ## statefulCodeSessions
 

--- a/content/docs/features/agents.mdx
+++ b/content/docs/features/agents.mdx
@@ -188,6 +188,8 @@ This is especially useful when an agent has access to many MCP servers with doze
 
 **Note:** The `deferred_tools` capability is enabled by default. It can be toggled via the [`librechat.yaml` agents configuration](/docs/configuration/librechat_yaml/object_structure/agents#capabilities).
 
+**Defaulting Defer Loading on:** Administrators can set [`defaultDeferLoading: true`](/docs/configuration/librechat_yaml/object_structure/agents#defaultdeferloading) so MCP tools newly added to an agent start with Defer Loading already enabled. The setting requires the `deferred_tools` capability, users can still opt out per tool, and existing agents keep their saved choices.
+
 ### Activity Groups
 
 Activity groups collapse each contiguous block of Agent reasoning and tool calls under a generated one-line header, making long runs easier to scan. Administrators enable them with `activityLabel` and can use a faster model, another configured endpoint, a custom prompt, and per-run limits. Header generation is a separate model call whose tokens and cost are recorded. See [Agent Activity Groups](/docs/configuration/librechat_yaml/object_structure/shared_endpoint_settings#agent-activity-groups).


### PR DESCRIPTION
## Summary

Documents the new opt-in `endpoints.agents.defaultDeferLoading` setting introduced by LibreChat PR danny-avila/LibreChat#15713 (implements danny-avila/LibreChat#14004): when enabled alongside the `deferred_tools` capability, MCP tools newly added to an agent in the Agent Builder start with **Defer Loading** ON. Users can still opt out per tool, and existing agents / saved per-tool choices are unaffected.

## Changes

- **`content/docs/features/agents.mdx`** (Deferred Tools section): adds a note explaining the admin default and linking to the config reference.
- **`content/docs/configuration/librechat_yaml/object_structure/agents.mdx`**:
  - New `## defaultDeferLoading` reference section (OptionTable, default `false`, example, notes) following the existing per-key format.
  - Commented `# defaultDeferLoading: false` entry in the example yaml block, placed above `capabilities` to mirror the main repo's `librechat.example.yaml`.

English source only — translated pages can follow via the usual translation pipeline.

## Note for maintainers

This documents an unreleased setting; the companion feature PR (danny-avila/LibreChat#15713) should merge first or alongside.