### PR TITLE
🏷️ docs: Document Conversation Tag Migration

### DIFF
--- a/content/docs/local/conversation_tag_migration.mdx
+++ b/content/docs/local/conversation_tag_migration.mdx
@@ -16,6 +16,8 @@ Browser mutations identify tags explicitly by ID. Existing name-based routes res
 
 Imports carry portable names and resolve them within the importing user's tenant. Source `tagIds` are ignored. JSON exports include names and omit database IDs.
 
+If an import fails after creating catalog entries, those entries remain as empty bookmarks. Import compensation removes its conversations and messages but does not delete shared catalog identities: another request may already be using them. Retrying the import reuses the entries. Unneeded bookmarks can be deleted explicitly.
+
 ## Controlled cutover
 
 Do not run old and new application writers concurrently. This is a coordinated upgrade, not a rolling migration with mixed-version writes.

--- a/content/docs/local/conversation_tag_migration.mdx
+++ b/content/docs/local/conversation_tag_migration.mdx
@@ -1,0 +1,47 @@
+---
+title: Conversation Tag Migration
+icon: Tags
+description: Upgrade conversation bookmarks to stable tag identities with a coordinated migration
+---
+
+<Callout type="warning" title="Coordinated upgrade required">
+This guide applies to the release introducing stable conversation tag IDs. Stop all old application writers before applying the migration. Do not use a rolling deployment with mixed old and new writers.
+</Callout>
+
+Conversation membership uses `tagIds`, which reference existing `ConversationTag._id` values. The catalog's `tag` field is a mutable label. Renaming a tag does not rewrite conversations, change their activity timestamps, or reserve old names. A deleted ID is never reused, including when another tag takes its former name.
+
+Browser mutations identify tags explicitly by ID. Existing name-based routes resolve the current name once when handling a request; an old name is not an alias for a renamed tag. Public conversation reads project names from the owned catalog. Counts derive from distinct committed membership. Missing or foreign IDs are omitted from that projection, and deletion and membership writes clean up deleted references.
+
+Imports carry portable names and resolve them within the importing user's tenant. Source `tagIds` are ignored. JSON exports include names and omit database IDs.
+
+## Controlled cutover
+
+Do not run old and new application writers concurrently. This is a coordinated upgrade, not a rolling migration with mixed-version writes.
+
+1. Back up MongoDB. Stop every API server, worker, import process, and other conversation writer.
+2. Build this version's packages using the locked dependencies.
+3. With the normal `MONGO_URI` configured, validate the complete dataset:
+
+   ```sh
+   npm run migrate:conversation-tags -- --dry-run
+   ```
+
+4. Resolve any reported malformed owner/tenant/name, duplicate catalog identity, incomplete legacy rename, or invalid existing ID references before proceeding. Validation runs before any writes; the migration does not guess how to repair ambiguous data.
+5. Apply the migration while writers remain stopped:
+
+   ```sh
+   npm run migrate:conversation-tags -- --apply
+   ```
+
+6. Run the dry-run again. `updated` and `createdTags` should both be zero. Application startup rejects nonempty legacy memberships that have not been converted.
+7. Start only the upgraded application servers and workers. If search is enabled, allow the existing index-sync process to populate the `conversation_tags` index. The search key must permit this index as well as conversations and messages. Rebuild search indexes before making a rollback available.
+
+The migration preserves existing catalog IDs, descriptions and ordering. It creates owner/tenant-local catalog entries for names that exist only on conversations, deduplicates memberships, and preserves conversation timestamps and history. Writes are batched and retries reuse completed work. Do not resume legacy writers between migration retries.
+
+## Search
+
+The existing Meilisearch service indexes catalog labels separately, with `_id` as its primary key. Conversation search combines title/message results with MongoDB membership matching the returned tag IDs. MongoDB revalidates catalog ownership and existence, so a stale search hit cannot revive a deleted tag or join a newly created tag with the same name. Indexing remains asynchronous; allow index sync to finish after cutover or search-service downtime.
+
+## Rollback
+
+Before upgraded writers have run, the original `tags` arrays are still available for restoring the previous application version from the backup. After upgraded writers have changed membership or labels, those legacy arrays are stale. Stop all writers and restore the pre-upgrade backup, or explicitly regenerate legacy names from the current catalog and `tagIds` before using an old binary. Simply deploying an old binary after new writes loses tag changes. Rebuild the old version's search indexes as part of rollback.

--- a/content/docs/local/conversation_tag_migration.mdx
+++ b/content/docs/local/conversation_tag_migration.mdx
@@ -18,6 +18,8 @@ Imports carry portable names and resolve them within the importing user's tenant
 
 If an import fails after creating catalog entries, those entries remain as empty bookmarks. Import compensation removes its conversations and messages but does not delete shared catalog identities: another request may already be using them. Retrying the import reuses the entries. Unneeded bookmarks can be deleted explicitly.
 
+Create-and-attach requests return 404 when the target conversation is missing or no longer accessible. The catalog entry may remain even though attachment failed; retrying reuses its identity. Failed membership updates do not roll back shared catalog entries.
+
 ## Controlled cutover
 
 Do not run old and new application writers concurrently. This is a coordinated upgrade, not a rolling migration with mixed-version writes.
@@ -30,7 +32,7 @@ Do not run old and new application writers concurrently. This is a coordinated u
    npm run migrate:conversation-tags -- --dry-run
    ```
 
-4. Resolve any reported malformed owner/tenant/name, duplicate catalog identity, incomplete legacy rename, or invalid existing ID references before proceeding. Validation runs before any writes; the migration does not guess how to repair ambiguous data.
+4. Resolve any reported malformed owner/tenant/name, missing or invalid catalog position, duplicate catalog identity, incomplete legacy rename, or invalid existing ID references before proceeding. Every catalog entry needs a persisted non-negative integer position. Validation runs before any writes; the migration does not guess how to repair ambiguous data or assign missing ordering metadata.
 5. Apply the migration while writers remain stopped:
 
    ```sh
@@ -45,6 +47,8 @@ The migration preserves existing catalog IDs, descriptions and ordering. It crea
 ## Search
 
 The existing Meilisearch service indexes catalog labels separately, with `_id` as its primary key. Conversation search combines title/message results with MongoDB membership matching the returned tag IDs. MongoDB revalidates catalog ownership and existence, so a stale search hit cannot revive a deleted tag or join a newly created tag with the same name. Indexing remains asynchronous; allow index sync to finish after cutover or search-service downtime.
+
+When startup index sync is enabled, it audits the complete tag index in paced batches to recover deletions interrupted by a process crash or search outage. This background work does not gate server readiness, but its total cost grows with the catalog size on every rollout. Progress flags on surviving MongoDB rows cannot detect deleted rows left in the search index. The audit uses the existing `MEILI_SYNC_BATCH_SIZE` and `MEILI_SYNC_DELAY_MS` settings; defaults are 100 documents and 100 milliseconds between batches.
 
 ## Rollback
 

--- a/content/docs/local/conversation_tag_migration.mdx
+++ b/content/docs/local/conversation_tag_migration.mdx
@@ -5,7 +5,9 @@ description: Upgrade conversation bookmarks to stable tag identities with a coor
 ---
 
 <Callout type="warning" title="Coordinated upgrade required">
-This guide applies to the release introducing stable conversation tag IDs. Stop all old application writers before applying the migration. Do not use a rolling deployment with mixed old and new writers.
+  This guide applies to the release introducing stable conversation tag IDs. Stop all old
+  application writers before applying the migration. Do not use a rolling deployment with mixed old
+  and new writers.
 </Callout>
 
 Conversation membership uses `tagIds`, which reference existing `ConversationTag._id` values. The catalog's `tag` field is a mutable label. Renaming a tag does not rewrite conversations, change their activity timestamps, or reserve old names. A deleted ID is never reused, including when another tag takes its former name.
@@ -33,7 +35,7 @@ Do not run old and new application writers concurrently. This is a coordinated u
    npm run migrate:conversation-tags -- --apply
    ```
 
-6. Run the dry-run again. `updated` and `createdTags` should both be zero. Application startup rejects nonempty legacy memberships that have not been converted.
+6. Run the dry-run again. `updated` and `createdTags` should both be zero. The apply command records completion only after membership writes and required indexes succeed. Application startup checks this completion marker; every existing database without it must run the migration, including databases with no tagged conversations. A fresh database with no conversations or tag catalog entries initializes automatically.
 7. Start only the upgraded application servers and workers. If search is enabled, allow the existing index-sync process to populate the `conversation_tags` index. The search key must permit this index as well as conversations and messages. Rebuild search indexes before making a rollback available.
 
 The migration preserves existing catalog IDs, descriptions and ordering. It creates owner/tenant-local catalog entries for names that exist only on conversations, deduplicates memberships, and preserves conversation timestamps and history. Writes are batched and retries reuse completed work. Do not resume legacy writers between migration retries.
@@ -44,4 +46,4 @@ The existing Meilisearch service indexes catalog labels separately, with `_id` a
 
 ## Rollback
 
-Before upgraded writers have run, the original `tags` arrays are still available for restoring the previous application version from the backup. After upgraded writers have changed membership or labels, those legacy arrays are stale. Stop all writers and restore the pre-upgrade backup, or explicitly regenerate legacy names from the current catalog and `tagIds` before using an old binary. Simply deploying an old binary after new writes loses tag changes. Rebuild the old version's search indexes as part of rollback.
+Stop all writers and restore the complete pre-upgrade MongoDB backup before starting the previous application version. This restores the original memberships and removes the migration-completion marker. Changes made after the backup will be lost. There is no reverse-migration script; legacy `tags` arrays become stale once upgraded writers change memberships or labels, so deploying an old binary against the upgraded database is not supported. Rebuild the old version's search indexes as part of rollback.

--- a/content/docs/local/meta.json
+++ b/content/docs/local/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Local Installation",
   "icon": "Monitor",
-  "pages": ["docker", "npm", "helm_chart"]
+  "pages": ["docker", "npm", "helm_chart", "conversation_tag_migration"]
 }


### PR DESCRIPTION
## Summary

Document the coordinated upgrade required by the stable conversation tag IDs in danny-avila/LibreChat#15748. The guide covers stopping writers, dry-run validation, applying and retrying the migration, search-index permissions, and rollback after new writes. Add the guide to the English local-install navigation.

This is a draft companion to the implementation PR; it should publish with the release containing that migration.

## Change Type

- [x] Documentation update

## Testing

- Checked commands and cutover steps against the implementation and migration tests in danny-avila/LibreChat#15748.
- JSON navigation parses; scoped formatting and `git diff --check` pass.
- Full documentation build has not been run locally.

## Checklist

- [x] I have performed a self-review of my changes.
- [x] The content uses public project behavior and links.
- [x] The migration and rollback requirements are explicit.
