### PR TITLE
🗄️ docs: Explain Per-User Storage Quotas

### DIFF
--- a/content/docs/configuration/librechat_yaml/object_structure/config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/config.mdx
@@ -563,6 +563,12 @@ see: [Web Search Object Structure](/docs/configuration/librechat_yaml/object_str
       '',
     ],
     [
+      'storageLimit',
+      'Number',
+      'The maximum stored File and authored SkillFile usage per user (in MB). Omit to disable storage-quota enforcement.',
+      '',
+    ],
+    [
       'serverFileSizeLimit',
       'Number',
       'The maximum file size (in MB) that the server will accept. Applies globally across all endpoints unless overridden by endpoint-specific settings.',

--- a/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
+++ b/content/docs/configuration/librechat_yaml/object_structure/file_config.mdx
@@ -7,9 +7,10 @@ icon: FileCode
 
 The `fileConfig` object allows you to configure file handling settings for the application, including size limits and MIME type restrictions. This section provides a detailed breakdown of the `fileConfig` object structure.
 
-There are 8 main fields under `fileConfig`:
+There are 9 main fields under `fileConfig`:
 
   - `endpoints`
+  - `storageLimit`
   - `serverFileSizeLimit`
   - `avatarSizeLimit`
   - `imageGeneration`
@@ -43,6 +44,7 @@ There are 8 main fields under `fileConfig`:
 
 ```yaml filename="fileConfig"
 fileConfig:
+  storageLimit: 1024
   endpoints:
     assistants:
       fileLimit: 5
@@ -83,6 +85,27 @@ fileConfig:
 
 <Callout type="info" title="MIME pattern syntax">
   LibreChat evaluates administrator-configured `supportedMimeTypes` patterns on the server with an RE2-compatible, linear-time regular expression engine. Backreferences and lookaround are not supported. Invalid patterns are logged and skipped; if every pattern in a configured list is invalid, that list fails closed and rejects every file instead of becoming unrestricted.
+</Callout>
+
+## storageLimit
+
+<OptionTable
+  options={[
+    ['storageLimit', 'Number', 'The maximum stored file usage per user, specified in megabytes (MB).', 'Counts persisted File rows and SkillFile rows authored by the user. Omit this field to disable storage-quota enforcement.'],
+  ]}
+/>
+
+```yaml filename="fileConfig / storageLimit"
+fileConfig:
+  storageLimit: 1024
+```
+
+The limit applies to uploads, generated images, code-execution outputs, skill-file uploads and imports, agent skill authoring, and GitHub skill synchronization. Replacement writes charge only the increase over the file they replace. Expired or otherwise excluded rows remain counted until they are deleted, preventing retained storage from becoming invisible to the quota.
+
+When a write would exceed the limit, LibreChat rejects it with HTTP `413` and tells the user their current usage and configured limit. Any request-owned blob or provider upload created before the check is cleaned up. Lowering the limit below a user's existing usage blocks new storage writes until enough files are deleted or the limit is raised.
+
+<Callout type="warning" title="Concurrency behavior">
+  The quota is a soft storage guard, not a billing-grade transaction boundary. Separate uploads for the same user can pass concurrently before either database row is visible, so brief overage is possible under parallel requests. Writes within one request are reserved against the same request-scoped ledger.
 </Callout>
 
 ## serverFileSizeLimit


### PR DESCRIPTION
## Summary

I documented the new per-user `fileConfig.storageLimit` setting and its operational behavior.

- Add `storageLimit` to the File Config field list, example, and root configuration reference.
- Explain which File and authored SkillFile writes count toward the quota.
- Describe replacement accounting, HTTP 413 responses, cleanup, and lowered-limit behavior.
- Call out the soft concurrency boundary so operators do not treat the setting as billing-grade accounting.

Depends on the stacked LibreChat storage-quota implementation ending with the enforcement PR.

## Testing

- `npx --yes prettier --check content/docs/configuration/librechat_yaml/object_structure/config.mdx content/docs/configuration/librechat_yaml/object_structure/file_config.mdx`

## Checklist

- [x] I reviewed the rendered MDX structure and existing documentation conventions.
- [x] I documented user-visible and operator-visible behavior.
- [x] Formatting checks pass.
